### PR TITLE
Fix a bug in sentiment analysis example when using GPU

### DIFF
--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -105,7 +105,11 @@ def traverse(node, train=True, evaluate=None, root=True):
         loss += F.softmax_cross_entropy(y, t)
 
     if evaluate is not None:
-        predict = y.data.argmax(1)
+        if isinstance(y.data, cuda.GPUArray):
+            predict = y.data.get().argmax(1)
+        else:
+            predict = y.data.argmax(1)
+
         if predict[0] == node['label']:
             evaluate['correct_node'] += 1
         evaluate['total_node'] += 1

--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -105,11 +105,7 @@ def traverse(node, train=True, evaluate=None, root=True):
         loss += F.softmax_cross_entropy(y, t)
 
     if evaluate is not None:
-        if isinstance(y.data, cuda.GPUArray):
-            predict = y.data.get().argmax(1)
-        else:
-            predict = y.data.argmax(1)
-
+        predict = cuda.to_cpu(y.data).argmax(1)
         if predict[0] == node['label']:
             evaluate['correct_node'] += 1
         evaluate['total_node'] += 1


### PR DESCRIPTION
When GPU is used, `y.data` is `chainer.cuda.gpuarray.GPUArray`.
So, an error is occurred: `AttributeError: 'GPUArray' object has no attribute 'argmax'`

This modification is somewhat ugly...
Is there more sophisticated way?