### PR TITLE
Support CPU-only tests #4 and without cuDNN tests.

### DIFF
--- a/tests/attr.py
+++ b/tests/attr.py
@@ -1,0 +1,15 @@
+def attr(*args, **kwargs):
+    """Decorator that adds attributes.
+
+    """
+    def wrap(x):
+        for k in args:
+            setattr(x, k, True)
+        for k, v in kwargs.items():
+            setattr(x, k, v)
+        return x
+    return wrap
+
+gpu = attr('gpu')
+cudnn = attr('gpu', 'cudnn')
+

--- a/tests/attr.py
+++ b/tests/attr.py
@@ -10,6 +10,5 @@ def attr(*args, **kwargs):
         return x
     return wrap
 
-gpu = attr('gpu')
+gpu   = attr('gpu')
 cudnn = attr('gpu', 'cudnn')
-

--- a/tests/functions_tests/test_accuracy.py
+++ b/tests/functions_tests/test_accuracy.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_cpu, to_gpu
 from chainer.gradient_check import assert_allclose
 from chainer.functions import accuracy
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_accuracy.py
+++ b/tests/functions_tests/test_accuracy.py
@@ -4,8 +4,9 @@ from chainer import cuda, Variable
 from chainer.cuda import to_cpu, to_gpu
 from chainer.gradient_check import assert_allclose
 from chainer.functions import accuracy
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestAccuracy(TestCase):
     def setUp(self):
@@ -29,5 +30,6 @@ class TestAccuracy(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.check_forward(to_gpu(self.x), to_gpu(self.t))

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 import chainer.functions as F
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestBinaryOp(TestCase):
     def setUp(self):
@@ -13,6 +14,7 @@ class TestBinaryOp(TestCase):
         self.x2 = numpy.random.uniform(.5, 1, (3, 2)).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
 
+    @attr.gpu
     def check_forward(self, op, x1_data, x2_data):
         x1 = Variable(x1_data)
         x2 = Variable(x2_data)
@@ -30,15 +32,22 @@ class TestBinaryOp(TestCase):
     def test_div_forward_cpu(self): self.forward_cpu(lambda x, y: x / y)
     def test_pow_forward_cpu(self): self.forward_cpu(lambda x, y: x ** y)
 
+    @attr.gpu
     def forward_gpu(self, op):
         self.check_forward(op, to_gpu(self.x1), to_gpu(self.x2))
 
+    @attr.gpu
     def test_add_forward_gpu(self): self.forward_gpu(lambda x, y: x + y)
+    @attr.gpu
     def test_sub_forward_gpu(self): self.forward_gpu(lambda x, y: x - y)
+    @attr.gpu
     def test_mul_forward_gpu(self): self.forward_gpu(lambda x, y: x * y)
+    @attr.gpu
     def test_div_forward_gpu(self): self.forward_gpu(lambda x, y: x / y)
+    @attr.gpu
     def test_pow_forward_gpu(self): self.forward_gpu(lambda x, y: x ** y)
 
+    @attr.gpu
     def test_add_constant_allocation(self):
         x = 0
         y = Variable(cuda.ones((1,)))
@@ -68,13 +77,19 @@ class TestBinaryOp(TestCase):
     def test_div_backward_cpu(self): self.backward_cpu(lambda x, y: x / y)
     def test_pow_backward_cpu(self): self.backward_cpu(lambda x, y: x ** y, atol=1e-4)
 
+    @attr.gpu
     def backward_gpu(self, op, atol=1e-5):
         self.check_backward(op, to_gpu(self.x1), to_gpu(self.x2), to_gpu(self.gy), atol)
 
+    @attr.gpu
     def test_add_backward_gpu(self): self.backward_gpu(lambda x, y: x + y)
+    @attr.gpu
     def test_sub_backward_gpu(self): self.backward_gpu(lambda x, y: x - y)
+    @attr.gpu
     def test_mul_backward_gpu(self): self.backward_gpu(lambda x, y: x * y)
+    @attr.gpu
     def test_div_backward_gpu(self): self.backward_gpu(lambda x, y: x / y)
+    @attr.gpu
     def test_pow_backward_gpu(self): self.backward_gpu(lambda x, y: x ** y, atol=1e-4)
 
 
@@ -103,18 +118,29 @@ class TestVariableConstantOp(TestCase):
     def test_pow_forward_cpu(self):  self.forward_cpu(lambda x, y: x ** y)
     def test_rpow_forward_cpu(self): self.forward_cpu(lambda x, y: y ** x)
 
+    @attr.gpu
     def forward_gpu(self, op):
         self.check_forward(op, to_gpu(self.x))
 
+    @attr.gpu
     def test_add_forward_gpu(self):  self.forward_gpu(lambda x, y: x + y)
+    @attr.gpu
     def test_radd_forward_gpu(self): self.forward_gpu(lambda x, y: y + x)
+    @attr.gpu
     def test_sub_forward_gpu(self):  self.forward_gpu(lambda x, y: x - y)
+    @attr.gpu
     def test_rsub_forward_gpu(self): self.forward_gpu(lambda x, y: y - x)
+    @attr.gpu
     def test_mul_forward_gpu(self):  self.forward_gpu(lambda x, y: x * y)
+    @attr.gpu
     def test_rmul_forward_gpu(self): self.forward_gpu(lambda x, y: y * x)
+    @attr.gpu
     def test_div_forward_gpu(self):  self.forward_gpu(lambda x, y: x / y)
+    @attr.gpu
     def test_rdiv_forward_gpu(self): self.forward_gpu(lambda x, y: y / x)
+    @attr.gpu
     def test_pow_forward_gpu(self):  self.forward_gpu(lambda x, y: x ** y)
+    @attr.gpu
     def test_rpow_forward_gpu(self): self.forward_gpu(lambda x, y: y ** x)
 
     def check_backward(self, op, x_data, y_grad):
@@ -143,18 +169,29 @@ class TestVariableConstantOp(TestCase):
     def test_pow_backward_cpu(self):  self.backward_cpu(lambda x, y: x ** y)
     def test_rpow_backward_cpu(self): self.backward_cpu(lambda x, y: y ** x)
 
+    @attr.gpu
     def backward_gpu(self, op):
         self.check_backward(op, to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_add_backward_gpu(self):  self.backward_gpu(lambda x, y: x + y)
+    @attr.gpu
     def test_radd_backward_gpu(self): self.backward_gpu(lambda x, y: y + x)
+    @attr.gpu
     def test_sub_backward_gpu(self):  self.backward_gpu(lambda x, y: x - y)
+    @attr.gpu
     def test_rsub_backward_gpu(self): self.backward_gpu(lambda x, y: y - x)
+    @attr.gpu
     def test_mul_backward_gpu(self):  self.backward_gpu(lambda x, y: x * y)
+    @attr.gpu
     def test_rmul_backward_gpu(self): self.backward_gpu(lambda x, y: y * x)
+    @attr.gpu
     def test_div_backward_gpu(self):  self.backward_gpu(lambda x, y: x / y)
+    @attr.gpu
     def test_rdiv_backward_gpu(self): self.backward_gpu(lambda x, y: y / x)
+    @attr.gpu
     def test_pow_backward_gpu(self):  self.backward_gpu(lambda x, y: x ** y)
+    @attr.gpu
     def test_rpow_backward_gpu(self): self.backward_gpu(lambda x, y: y ** x)
 
 
@@ -174,10 +211,13 @@ class TestUnaryFunctions(TestCase):
     def test_exp_forward_cpu(self): self.forward_cpu(F.exp, numpy.exp)
     def test_log_forward_cpu(self): self.forward_cpu(F.log, numpy.log)
 
+    @attr.gpu
     def forward_gpu(self, op, op_np):
         self.check_forward(op, op_np, to_gpu(self.x))
 
+    @attr.gpu
     def test_exp_forward_gpu(self): self.forward_gpu(F.exp, numpy.exp)
+    @attr.gpu
     def test_log_forward_gpu(self): self.forward_gpu(F.log, numpy.log)
 
     def check_backward(self, op, x_data, y_grad):
@@ -198,8 +238,11 @@ class TestUnaryFunctions(TestCase):
     def test_exp_backward_cpu(self): self.backward_cpu(F.exp)
     def test_log_backward_cpu(self): self.backward_cpu(F.log)
 
+    @attr.gpu
     def backward_gpu(self, op):
         self.check_backward(op, to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_exp_backward_gpu(self): self.backward_gpu(F.exp)
+    @attr.gpu
     def test_log_backward_gpu(self): self.backward_gpu(F.log)

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 import chainer.functions as F
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_batch_normalization.py
+++ b/tests/functions_tests/test_batch_normalization.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import BatchNormalization
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_batch_normalization.py
+++ b/tests/functions_tests/test_batch_normalization.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import BatchNormalization
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 # fully-connected usage
 class TestBatchNormalization(TestCase):
@@ -39,6 +40,7 @@ class TestBatchNormalization(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(to_gpu(self.x))
@@ -60,6 +62,7 @@ class TestBatchNormalization(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))

--- a/tests/functions_tests/test_concat.py
+++ b/tests/functions_tests/test_concat.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu, GPUArray
 from chainer.gradient_check import assert_allclose
 from chainer.functions import concat
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class Concat(TestCase):
     def setUp(self):
@@ -26,10 +27,12 @@ class Concat(TestCase):
     def test_forward_cpu_1(self):
         self.check_forward(self.xs1, self.y1, axis=0)
 
+    @attr.gpu
     def test_forward_gpu_0(self):
         self.check_forward(
             [to_gpu(x.copy()) for x in self.xs0], to_gpu(self.y0), axis=1)
 
+    @attr.gpu
     def test_forward_gpu_1(self):
         self.check_forward(
             [to_gpu(x.copy()) for x in self.xs1], to_gpu(self.y1), axis=0)
@@ -49,8 +52,10 @@ class Concat(TestCase):
     def test_backward_cpu_1(self):
         self.check_backward(self.xs1, axis=0)
 
+    @attr.gpu
     def test_backward_gpu_0(self):
         self.check_backward([to_gpu(x.copy()) for x in self.xs0], axis=1)
 
+    @attr.gpu
     def test_backward_gpu_1(self):
         self.check_backward([to_gpu(x.copy()) for x in self.xs1], axis=0)

--- a/tests/functions_tests/test_concat.py
+++ b/tests/functions_tests/test_concat.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu, GPUArray
 from chainer.gradient_check import assert_allclose
 from chainer.functions import concat
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_convolution_2d.py
+++ b/tests/functions_tests/test_convolution_2d.py
@@ -7,6 +7,7 @@ from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import Convolution2D
 from chainer.utils import conv
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_convolution_2d.py
+++ b/tests/functions_tests/test_convolution_2d.py
@@ -6,8 +6,10 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import Convolution2D
 from chainer.utils import conv
+from .. import attr
+if cuda.available:
+    cuda.init()
 
-cuda.init()
 
 class TestConvolution2D(TestCase):
     def setUp(self, use_cudnn=True):
@@ -20,11 +22,13 @@ class TestConvolution2D(TestCase):
         self.x  = numpy.random.uniform(-1, 1, (2, 3, 4, 3)).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, (2, 2, 2, 2)).astype(numpy.float32)
 
+    @attr.gpu
     def test_im2col_consistency(self):
         col_cpu = conv.im2col_cpu(self.x, 3, 3, 2, 2, 1, 1)
         col_gpu = conv.im2col_gpu(to_gpu(self.x), 3, 3, 2, 2, 1, 1)
         assert_allclose(col_cpu, col_gpu.get(), atol=0, rtol=0)
 
+    @attr.gpu
     def test_col2im_consistency(self):
         col = conv.im2col_cpu(self.x, 3, 3, 2, 2, 1, 1)
         h, w = self.x.shape[2:]
@@ -32,6 +36,7 @@ class TestConvolution2D(TestCase):
         im_gpu = conv.col2im_gpu(to_gpu(col), 2, 2, 1, 1, h, w)
         assert_allclose(im_cpu, im_gpu.get())
 
+    @attr.cudnn
     def test_forward_consistency(self):
         x_cpu = Variable(self.x)
         y_cpu = self.func(x_cpu)
@@ -44,6 +49,7 @@ class TestConvolution2D(TestCase):
             print i, numpy.abs(y_cpu.data[i] - y_gpu.data[i].get()).max()
         assert_allclose(y_cpu.data, y_gpu.data.get())
 
+    @attr.gpu
     def test_forward_consistency_im2col(self):
         self.func.use_cudnn = False
         self.test_forward_consistency()
@@ -65,10 +71,12 @@ class TestConvolution2D(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_backward_gpu_im2col(self):
         self.func.use_cudnn = False
         self.test_backward_gpu()
@@ -93,6 +101,7 @@ class TestConvolution2D(TestCase):
     def test_pickling_cpu(self):
         self.check_pickling(self.x)
 
+    @attr.gpu
     def test_pickling_gpu(self):
         self.func.to_gpu()
         self.check_pickling(to_gpu(self.x))

--- a/tests/functions_tests/test_embed_id.py
+++ b/tests/functions_tests/test_embed_id.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import EmbedID
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_embed_id.py
+++ b/tests/functions_tests/test_embed_id.py
@@ -4,8 +4,10 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import EmbedID
+from .. import attr
+if cuda.available:
+    cuda.init()
 
-cuda.init()
 
 class TestEmbedID(TestCase):
     def setUp(self):
@@ -16,6 +18,7 @@ class TestEmbedID(TestCase):
         self.x  = numpy.array([0, 1, 0], dtype=numpy.int32)
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
 
+    @attr.gpu
     def to_gpu(self):
         self.func.W  = to_gpu(self.func.W)
         self.func.gW = to_gpu(self.func.gW)
@@ -33,6 +36,7 @@ class TestEmbedID(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.to_gpu()
         self.check_forward(to_gpu(self.x))
@@ -51,6 +55,7 @@ class TestEmbedID(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.to_gpu()
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))

--- a/tests/functions_tests/test_hierarchical_softmax.py
+++ b/tests/functions_tests/test_hierarchical_softmax.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import numpy
 
 from chainer import Variable
-from chainer.cuda import to_cpu, to_gpu, GPUArray
+from chainer.cuda import to_cpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import BinaryHierarchicalSoftmax, create_huffman_tree
 

--- a/tests/functions_tests/test_leaky_relu.py
+++ b/tests/functions_tests/test_leaky_relu.py
@@ -4,8 +4,9 @@ import numpy
 from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import leaky_relu
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestLeakyReLU(TestCase):
     def setUp(self):
@@ -29,6 +30,7 @@ class TestLeakyReLU(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -47,5 +49,6 @@ class TestLeakyReLU(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_leaky_relu.py
+++ b/tests/functions_tests/test_leaky_relu.py
@@ -5,6 +5,7 @@ from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import leaky_relu
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_linear.py
+++ b/tests/functions_tests/test_linear.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import Linear
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_linear.py
+++ b/tests/functions_tests/test_linear.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import Linear
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestLinear(TestCase):
     def setUp(self):
@@ -33,6 +34,7 @@ class TestLinear(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(to_gpu(self.x))
@@ -54,6 +56,7 @@ class TestLinear(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))

--- a/tests/functions_tests/test_local_response_normalization.py
+++ b/tests/functions_tests/test_local_response_normalization.py
@@ -4,6 +4,7 @@ from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import local_response_normalization
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_local_response_normalization.py
+++ b/tests/functions_tests/test_local_response_normalization.py
@@ -3,8 +3,9 @@ import numpy
 from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import local_response_normalization
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestLocalResponseNormalization(TestCase):
     def setUp(self):
@@ -30,6 +31,7 @@ class TestLocalResponseNormalization(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -48,5 +50,6 @@ class TestLocalResponseNormalization(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_lstm.py
+++ b/tests/functions_tests/test_lstm.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import lstm
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_lstm.py
+++ b/tests/functions_tests/test_lstm.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import lstm
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 def _sigmoid(x):
     return 1 / (1 + numpy.exp(-x))
@@ -48,9 +49,11 @@ class TestLSTM(TestCase):
         self.flat()
         self.test_forward_cpu()
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.check_forward(to_gpu(self.c_prev), to_gpu(self.x))
 
+    @attr.gpu
     def test_flat_forward_gpu(self):
         self.flat()
         self.test_forward_gpu()
@@ -91,26 +94,32 @@ class TestLSTM(TestCase):
         self.flat()
         self.test_no_gh_backward_cpu()
 
+    @attr.gpu
     def test_full_backward_gpu(self):
         self.check_backward(
             to_gpu(self.c_prev), to_gpu(self.x), to_gpu(self.gc), to_gpu(self.gh))
 
+    @attr.gpu
     def test_flat_full_backward_gpu(self):
         self.flat()
         self.test_full_backward_gpu()
 
+    @attr.gpu
     def test_no_gc_backward_gpu(self):
         self.check_backward(
             to_gpu(self.c_prev), to_gpu(self.x), None, to_gpu(self.gh))
 
+    @attr.gpu
     def test_flat_no_gc_backward_gpu(self):
         self.flat()
         self.test_no_gc_backward_gpu()
 
+    @attr.gpu
     def test_no_gh_backward_gpu(self):
         self.check_backward(
             to_gpu(self.c_prev), to_gpu(self.x), to_gpu(self.gc), None)
 
+    @attr.gpu
     def test_flat_no_gh_backward_gpu(self):
         self.flat()
         self.test_no_gh_backward_gpu()

--- a/tests/functions_tests/test_mean_squared_error.py
+++ b/tests/functions_tests/test_mean_squared_error.py
@@ -4,8 +4,10 @@ from chainer import cuda, Variable
 from chainer.cuda import to_cpu, to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import mean_squared_error
+from .. import attr
+if cuda.available:
+    cuda.init()
 
-cuda.init()
 
 class TestMeanSquaredError(TestCase):
     def setUp(self):
@@ -29,6 +31,7 @@ class TestMeanSquaredError(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x0, self.x1)
 
+    @attr.gpu
     def test_forwrad_gpu(self):
         self.check_forward(to_gpu(self.x0), to_gpu(self.x1))
 
@@ -48,5 +51,6 @@ class TestMeanSquaredError(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x0, self.x1)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x0), to_gpu(self.x1))

--- a/tests/functions_tests/test_mean_squared_error.py
+++ b/tests/functions_tests/test_mean_squared_error.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_cpu, to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import mean_squared_error
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_parameter.py
+++ b/tests/functions_tests/test_parameter.py
@@ -4,6 +4,7 @@ from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import Parameter
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_parameter.py
+++ b/tests/functions_tests/test_parameter.py
@@ -3,8 +3,9 @@ import numpy
 from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import Parameter
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestParameter(TestCase):
     def setUp(self):
@@ -15,6 +16,7 @@ class TestParameter(TestCase):
     def tearDown(self):
         del self.func
 
+    @attr.gpu
     def to_gpu(self):
         self.func.to_gpu()
 
@@ -25,6 +27,7 @@ class TestParameter(TestCase):
     def test_forward_cpu(self):
         self.check_forward()
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.to_gpu()
         self.check_forward()
@@ -39,6 +42,7 @@ class TestParameter(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.gW)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.to_gpu()
         self.check_backward(cuda.to_gpu(self.gW))

--- a/tests/functions_tests/test_pooling_2d.py
+++ b/tests/functions_tests/test_pooling_2d.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_cpu, to_gpu, GPUArray
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import average_pooling_2d, max_pooling_2d
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestMaxPooling2D(TestCase):
     cover_all = False
@@ -41,9 +42,11 @@ class TestMaxPooling2D(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.cudnn
     def test_forward_gpu(self):
         self.check_forward(to_gpu(self.x))
 
+    @attr.gpu
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(to_gpu(self.x), False)
 
@@ -63,9 +66,11 @@ class TestMaxPooling2D(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy), False)
 
@@ -100,9 +105,11 @@ class TestAveragePooling2D(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.cudnn
     def test_forward_gpu(self):
         self.check_forward(to_gpu(self.x))
 
+    @attr.gpu
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(to_gpu(self.x), False)
 
@@ -121,8 +128,10 @@ class TestAveragePooling2D(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy), False)

--- a/tests/functions_tests/test_pooling_2d.py
+++ b/tests/functions_tests/test_pooling_2d.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_cpu, to_gpu, GPUArray
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import average_pooling_2d, max_pooling_2d
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_prelu.py
+++ b/tests/functions_tests/test_prelu.py
@@ -3,8 +3,9 @@ import numpy
 from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import PReLU
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestPReLUSingle(TestCase):
     def setUp(self):
@@ -34,6 +35,7 @@ class TestPReLUSingle(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -54,6 +56,7 @@ class TestPReLUSingle(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_prelu.py
+++ b/tests/functions_tests/test_prelu.py
@@ -4,6 +4,7 @@ from chainer import cuda, Variable
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import PReLU
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_relu.py
+++ b/tests/functions_tests/test_relu.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import relu
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_relu.py
+++ b/tests/functions_tests/test_relu.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import relu
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestReLU(TestCase):
     def setUp(self):
@@ -29,8 +30,10 @@ class TestReLU(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_backward_cpu_no_cudnn(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy), False)

--- a/tests/functions_tests/test_reshape.py
+++ b/tests/functions_tests/test_reshape.py
@@ -2,8 +2,9 @@ from unittest import TestCase
 import numpy
 from chainer import cuda, Variable
 from chainer.functions import reshape
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestReshape(TestCase):
     def setUp(self):
@@ -19,6 +20,7 @@ class TestReshape(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 

--- a/tests/functions_tests/test_reshape.py
+++ b/tests/functions_tests/test_reshape.py
@@ -3,6 +3,7 @@ import numpy
 from chainer import cuda, Variable
 from chainer.functions import reshape
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_sigmoid.py
+++ b/tests/functions_tests/test_sigmoid.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import sigmoid
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_sigmoid.py
+++ b/tests/functions_tests/test_sigmoid.py
@@ -4,14 +4,16 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import sigmoid
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestSigmoid(TestCase):
     def setUp(self):
         self.x  = numpy.random.uniform(-.5, .5, (3, 2)).astype(numpy.float32)
         self.gy = numpy.random.uniform(-.1, .1, (3, 2)).astype(numpy.float32)
 
+    @attr.cudnn
     def test_forward_gpu(self, use_cudnn=True):
         x = Variable(to_gpu(self.x))
         y = sigmoid(x, use_cudnn=use_cudnn)
@@ -19,6 +21,7 @@ class TestSigmoid(TestCase):
 
         assert_allclose(y_expect.data, y.data)
 
+    @attr.gpu
     def test_forward_gpu_no_cudnn(self):
         self.test_forward_gpu(False)
 
@@ -37,8 +40,10 @@ class TestSigmoid(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy), False)

--- a/tests/functions_tests/test_softmax.py
+++ b/tests/functions_tests/test_softmax.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import softmax
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_softmax.py
+++ b/tests/functions_tests/test_softmax.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import softmax
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestSoftmax(TestCase):
     def setUp(self):
@@ -25,9 +26,11 @@ class TestSoftmax(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.cudnn
     def test_forward_gpu(self):
         self.check_forward(to_gpu(self.x))
 
+    @attr.gpu
     def test_forwrad_gpu_no_cudnn(self):
         self.check_forward(to_gpu(self.x), False)
 
@@ -46,8 +49,10 @@ class TestSoftmax(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy), False)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -5,8 +5,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_cpu, to_gpu, GPUArray
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import softmax_cross_entropy
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestSoftmaxCrossEntropy(TestCase):
     def setUp(self):
@@ -31,9 +32,11 @@ class TestSoftmaxCrossEntropy(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
+    @attr.cudnn
     def test_forward_gpu(self):
         self.check_forward(to_gpu(self.x), to_gpu(self.t))
 
+    @attr.gpu
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(to_gpu(self.x), to_gpu(self.t), False)
 
@@ -53,8 +56,10 @@ class TestSoftmaxCrossEntropy(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.t))
 
+    @attr.gpu
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.t), False)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -6,6 +6,7 @@ from chainer.cuda import to_cpu, to_gpu, GPUArray
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import softmax_cross_entropy
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_sum.py
+++ b/tests/functions_tests/test_sum.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import sum
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_sum.py
+++ b/tests/functions_tests/test_sum.py
@@ -4,8 +4,9 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import sum
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestSum(TestCase):
     def setUp(self):
@@ -21,6 +22,7 @@ class TestSum(TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    @attr.gpu
     def test_forward_gpu(self):
         self.check_forward(to_gpu(self.x))
 
@@ -36,5 +38,6 @@ class TestSum(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.gpu
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))

--- a/tests/functions_tests/test_tanh.py
+++ b/tests/functions_tests/test_tanh.py
@@ -4,20 +4,23 @@ from chainer      import cuda, Variable
 from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import tanh
-
-cuda.init()
+from .. import attr
+if cuda.available:
+    cuda.init()
 
 class TestSigmoid(TestCase):
     def setUp(self):
         self.x  = numpy.random.uniform(-.5, .5, (3, 2)).astype(numpy.float32)
         self.gy = numpy.random.uniform(-.1, .1, (3, 2)).astype(numpy.float32)
 
+    @attr.cudnn
     def test_forward_gpu(self, use_cudnn=True):
         x = Variable(to_gpu(self.x))
         y = tanh(x, use_cudnn=use_cudnn)
         y_expect = tanh(Variable(self.x))
         assert_allclose(y_expect.data, y.data)
 
+    @attr.gpu
     def test_forward_gpu_no_cudnn(self):
         self.test_forward_gpu(False)
 
@@ -35,8 +38,10 @@ class TestSigmoid(TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
+    @attr.cudnn
     def test_backward_gpu(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy))
 
+    @attr.gpu
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(to_gpu(self.x), to_gpu(self.gy), False)

--- a/tests/functions_tests/test_tanh.py
+++ b/tests/functions_tests/test_tanh.py
@@ -5,6 +5,7 @@ from chainer.cuda import to_gpu
 from chainer.gradient_check import assert_allclose, numerical_grad
 from chainer.functions import tanh
 from .. import attr
+
 if cuda.available:
     cuda.init()
 

--- a/tests/test_function_set.py
+++ b/tests/test_function_set.py
@@ -2,8 +2,10 @@ import cPickle as pickle
 from unittest import TestCase
 from chainer import cuda, FunctionSet
 from chainer.functions import Linear
+from . import attr
 
-cuda.init()
+if cuda.available:
+    cuda.init()
 
 class TestFunctionSet(TestCase):
     def setUp(self):
@@ -23,6 +25,7 @@ class TestFunctionSet(TestCase):
         fs2 = pickle.loads(s)
         self.check_equal_fs(self.fs, fs2)
 
+    @attr.gpu
     def test_pickle_gpu(self):
         self.fs.to_gpu()
         s   = pickle.dumps(self.fs)


### PR DESCRIPTION
This PR supports CPU-only tests and without cuDNN tests.

It uses Attribute selector plugin in nose.
http://nose.readthedocs.org/en/latest/plugins/attrib.html

-  `nosetests -a '!gpu'` : Run CPU-only tests.
-  `nosetests -a '!cudnn'` : Run without cuDNN tests.
