### PR TITLE
setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ If you want to enable CUDA, first you have to install CUDA and set the environme
 You also have to set binary and library paths by appropriate environment variables like `PATH` and `LD_LIBRARY_PATH`.
 Then install CUDA-related packages by:
 ```
-pip install `chainer-cuda-requirements`
+pip install chainer-cuda-deps
+```
+
+or, from the source:
+```
+python setup_cuda_deps.py install
 ```
 
 ## License

--- a/scripts/chainer-cuda-requirements
+++ b/scripts/chainer-cuda-requirements
@@ -5,4 +5,7 @@ import chainer.requirements
 
 
 if __name__ == '__main__':
+   sys.stderr.write('## This script is deplicated.\n')
+   sys.stderr.write('## Please use `pip install chainer-cuda-deps`\n')
+   sys.stderr.flush()
    sys.stdout.write(chainer.requirements.get_cuda_requirements())

--- a/setup_cuda_deps.py
+++ b/setup_cuda_deps.py
@@ -10,6 +10,7 @@ setup(
     url='http://chainer.org/',
     packages=[],
     install_requires=[
+        'chainer',
         'pycuda>=2014.1',
         'scikits.cuda>=0.5.0b1,!=0.042',
         'Mako',

--- a/setup_cuda_deps.py
+++ b/setup_cuda_deps.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='chainer-cuda-deps',
     version='1.0.0',
-    description='A flexible framework of neural networks',
+    description='Install dependent packages to use Chainer on CUDA',
     author='Seiya Tokui',
     author_email='tokui@preferred.jp',
     url='http://chainer.org/',

--- a/setup_cuda_deps.py
+++ b/setup_cuda_deps.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup(
+    name='chainer-cuda-deps',
+    version='1.0.0',
+    description='A flexible framework of neural networks',
+    author='Seiya Tokui',
+    author_email='tokui@preferred.jp',
+    url='http://chainer.org/',
+    packages=[],
+    install_requires=[
+        'pycuda>=2014.1',
+        'scikits.cuda>=0.5.0b1,!=0.042',
+        'Mako',
+        'six>=1.9.0',
+    ],
+)


### PR DESCRIPTION
I added setup.py script for dependent libraries. Users can install dependent libraries with `setup_cuda_deps.py`. They don't need to use `chainer-cuda-requirements`.

This RP also fixes #40 