### PR TITLE
Fix argument of AdaDelta.update_on_gpu

### DIFF
--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -26,7 +26,8 @@ class AdaDelta(Optimizer):
         msdx += (1 - self.rho) * dx * dx
         param -= dx
 
-    def update_one_gpu(self, param, grad, ms):
+    def update_one_gpu(self, param, grad, state):
+        msg, msdx = state
         cuda.elementwise(
             '''float* param, const float* grad, float* msg, float* msdx,
                float one_minus_rho, float eps''',


### PR DESCRIPTION
Fourth argument of `AdaDelta.update_on_gpu`  must be `state`, but was `msg`, which is first component of state. This PR fixes it.