### PR TITLE
Loosen accuracy threshold of functionality test of optimizers

### DIFF
--- a/tests/optimizers_tests/test_ada_delta.py
+++ b/tests/optimizers_tests/test_ada_delta.py
@@ -9,8 +9,8 @@ class TestAdaDelta(TestCase):
         self.model = LinearModel(self.optimizer)
 
     def test_linear_model_cpu(self):
-        self.assertGreater(self.model.accuracy(False), 0.75)
+        self.assertGreater(self.model.accuracy(False), 0.7)
 
     @attr.gpu
     def test_linear_model_gpu(self):
-        self.assertGreater(self.model.accuracy(True), 0.75)
+        self.assertGreater(self.model.accuracy(True), 0.7)

--- a/tests/optimizers_tests/test_ada_grad.py
+++ b/tests/optimizers_tests/test_ada_grad.py
@@ -9,8 +9,8 @@ class TestAdaGrad(TestCase):
         self.model = LinearModel(self.optimizer)
 
     def test_linear_model_cpu(self):
-        self.assertGreater(self.model.accuracy(False), 0.8)
+        self.assertGreater(self.model.accuracy(False), 0.7)
 
     @attr.gpu
     def test_linear_model_gpu(self):
-        self.assertGreater(self.model.accuracy(True), 0.8)
+        self.assertGreater(self.model.accuracy(True), 0.7)

--- a/tests/optimizers_tests/test_adam.py
+++ b/tests/optimizers_tests/test_adam.py
@@ -9,8 +9,8 @@ class TestAdam(TestCase):
         self.model = LinearModel(self.optimizer)
 
     def test_linear_model_cpu(self):
-        self.assertGreater(self.model.accuracy(False), 0.8)
+        self.assertGreater(self.model.accuracy(False), 0.7)
 
     @attr.gpu
     def test_linear_model_gpu(self):
-        self.assertGreater(self.model.accuracy(True), 0.8)
+        self.assertGreater(self.model.accuracy(True), 0.7)

--- a/tests/optimizers_tests/test_momentum_sgd.py
+++ b/tests/optimizers_tests/test_momentum_sgd.py
@@ -9,8 +9,8 @@ class TestMomentumSGD(TestCase):
         self.model = LinearModel(self.optimizer)
 
     def test_linear_model_cpu(self):
-        self.assertGreater(self.model.accuracy(False), 0.8)
+        self.assertGreater(self.model.accuracy(False), 0.7)
 
     @attr.gpu
     def test_linear_model_gpu(self):
-        self.assertGreater(self.model.accuracy(True), 0.8)
+        self.assertGreater(self.model.accuracy(True), 0.7)

--- a/tests/optimizers_tests/test_rmsprop.py
+++ b/tests/optimizers_tests/test_rmsprop.py
@@ -9,8 +9,8 @@ class TestRMSprop(TestCase):
         self.model = LinearModel(self.optimizer)
 
     def test_linear_model_cpu(self):
-        self.assertGreater(self.model.accuracy(False), 0.8)
+        self.assertGreater(self.model.accuracy(False), 0.7)
 
     @attr.gpu
     def test_linear_model_gpu(self):
-        self.assertGreater(self.model.accuracy(True), 0.8)
+        self.assertGreater(self.model.accuracy(True), 0.7)

--- a/tests/optimizers_tests/test_sgd.py
+++ b/tests/optimizers_tests/test_sgd.py
@@ -9,9 +9,9 @@ class TestSGD(TestCase):
         self.model = LinearModel(self.optimizer)
 
     def test_linear_model_cpu(self):
-        self.assertGreater(self.model.accuracy(False), 0.8)
+        self.assertGreater(self.model.accuracy(False), 0.7)
 
     @attr.gpu
     def test_linear_model_gpu(self):
-        self.assertGreater(self.model.accuracy(True), 0.8)
+        self.assertGreater(self.model.accuracy(True), 0.7)
 


### PR DESCRIPTION
Because functionality tests of optimizer behave stochastically, CI occasionally fails because of insufficient accuracy. To reduce undesired failure, threshold of accuracy is lessen to 0.7.