### PR TITLE
fix cannot call clip_grads() at multi_gpu

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -4,7 +4,8 @@ import cuda
 
 def _sqnorm(x):
     if isinstance(x, cuda.GPUArray):
-        return float(cuda.gpuarray.dot(x, x).get())
+        with cuda.using_device(x):
+            return float(cuda.gpuarray.dot(x, x).get())
     x = x.ravel()
     return float(x.dot(x))
 
@@ -154,7 +155,8 @@ class Optimizer(object):
         if norm > maxnorm:
             ratio = maxnorm / norm
             for _, g, _ in self.tuples:
-                g *= ratio
+                with cuda.using_device(g):
+                    g *= ratio
 
     def weight_decay(self, decay):
         """Applies weight decay (a.k.a. L2 or Tikonov regularization) of given


### PR DESCRIPTION
When multi gpu FunctionSet is set in optimizer, I fail in optimzer#clip_grads()
```python
from chainer import FunctionSet, cuda
from chainer.optimizers import SGD
import chainer.functions as F

cuda.init(0)
model = FunctionSet(l1=F.Linear(4, 4).to_gpu(0), l2=F.Linear(4, 4).to_gpu(1))
optimizer = SGD()
optimizer.setup(model.collect_parameters())
optimizer.clip_grads(5)
#=>raise LogicError: cuMemcpyDtoH failed: an illegal memory access was encountered
```