### PR TITLE
Fix return type of chainer.functions.Accuracy#forward_cpp()

### DIFF
--- a/chainer/functions/accuracy.py
+++ b/chainer/functions/accuracy.py
@@ -9,7 +9,7 @@ class Accuracy(function.Function):
         y, t = inputs
         y = y.reshape(y.shape[0], y.size / y.shape[0])  # flatten
         pred = y.argmax(axis=1)
-        return (pred == t).mean(dtype=numpy.float32),
+        return numpy.array((pred == t).mean(dtype=numpy.float32)),
 
     def forward_gpu(self, inputs):
         x, t = inputs


### PR DESCRIPTION
Type of `chainer.functions.accuracy().data` using cpu is numpy.float32.
This will cause different behavior when using CPU or GPU ·

```python
x = Variable( numpy.array( [ [0. , 1.], [0., 1.,] ], dtype=numpy.float32 ) )
t = Variable( numpy.array( [ 1, 1], dtype=numpy.float32 ) )
r = F.accuracy(x, t)
print type(r.data) #=> numpy.float32
r1 = r + r # => ArgumentError: @cuda.py line:224     return drv.Device(arg)

x = Variable( cuda.to_gpu( numpy.array( [ [0. , 1.], [0., 1.,] ], dtype=numpy.float32 ) ) )
t = Variable( cuda.to_gpu( numpy.array( [1, 1], dtype=numpy.int32 ) ) ) 
r =  F.accuracy(x, t)
print type(r.data) #=>  <class 'pycuda.gpuarray.GPUArray'>
r1 = r + r
print r1.data #=> 2.0
```