### PR TITLE
Added a Dockerfile for quick starter

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,26 @@
+# Dockerfile for running chainer (https://github.com/pfnet/chainer)
+# Usage:
+#   > sudo docker run -t -i kazunori279/chainer
+#   # cd chainer/examples/mnist
+#   # python download_convert.py
+#   # python train_mnist.py
+
+FROM scivm/scientific-python-2.7 
+MAINTAINER kazunori279 "https://github.com/kazunori279" 
+
+# basic setup 
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get upgrade -y --force-yes
+
+# install git
+RUN apt-get install -y --force-yes curl git
+RUN mkdir /git && cd /git && git init
+
+# install chainer
+RUN pip install six chainer
+RUN git clone https://github.com/pfnet/chainer.git
+
+# bash
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
I was able to run the mnist example with this Dockerfile. This fixes #94 and makes it easier for beginners to try out chainer by using Docker image. I've already pushed kazunori279/chainer Docker image to the repo.

Usage:
   > sudo docker run -t -i kazunori279/chainer
   # cd chainer/examples/mnist
   # python download_convert.py
   # python train_mnist.py

TODOs:
- Maybe pfnet can create an official Docker image, such as "pfnet/chainer", so that you can replace "kazunori279/chainer" with it
- Haven't checked with GPU yet. I hope ixixi's options would work
- Need to add a getting started document for this