### PR TITLE
fix: return type of Accuracy#forwad_cpu() norm to array fix#97

### DIFF
--- a/chainer/functions/accuracy.py
+++ b/chainer/functions/accuracy.py
@@ -9,7 +9,7 @@ class Accuracy(function.Function):
         y, t = inputs
         y = y.reshape(y.shape[0], y.size / y.shape[0])  # flatten
         pred = y.argmax(axis=1)
-        return numpy.array((pred == t).mean(dtype=numpy.float32)),
+        return (pred == t).mean(dtype=numpy.float32, keepdims=True),
 
     def forward_gpu(self, inputs):
         x, t = inputs


### PR DESCRIPTION
Sorry, I found bug my PR(#97). I was fixed return type of Accuracy#cpu_forwad() like SoftmaxCrossEntropy#foward_cpu().

But  I fear that the different return type forward_cpu() and forward_gpu()
```
x_c = Variable( numpy.array( [ [0. , 1.], [0., 1.,] ], dtype=numpy.float32 ) )
t_c = Variable( numpy.array( [ 1, 1], dtype=numpy.int32 ) )
x_g = Variable( cuda.to_gpu( numpy.array( [ [0. , 1.], [0., 1.,] ], dtype=numpy.float32 ) ) )
t_g = Variable( cuda.to_gpu( numpy.array( [1, 1], dtype=numpy.int32 ) ) ) 

cpu = F.accuracy(x_c, t_c).data
gpu = cuda.to_gpu( F.accuracy(x_g, t_g).data )
print cpu, gpu #=> [ 1.] 1.0
print cpu.shape, gpu.shape #=> (1,) ()

cpu = F.softmax_cross_entropy(x_c, t_c).data
gpu = cuda.to_gpu( F.softmax_cross_entropy(x_g, t_g).data )
print cpu, gpu #=> [ 0.31326166] 0.313261657953
print cpu.shape, gpu.shape #=> (1,) ()
```