### PR TITLE
Fix Inception module to consistent with the document

### DIFF
--- a/chainer/functions/inception.py
+++ b/chainer/functions/inception.py
@@ -55,21 +55,14 @@ class Inception(function.Function):
             projp=convolution_2d.Convolution2D(in_channels, proj_pool, 1),
         )
 
-    def forward(self, x):
-        self.x = variable.Variable(x[0])
-        out1 = self.f.conv1(self.x)
-        out3 = self.f.conv3(relu.relu(self.f.proj3(self.x)))
-        out5 = self.f.conv5(relu.relu(self.f.proj5(self.x)))
+    def __call__(self, x):
+        out1 = self.f.conv1(x)
+        out3 = self.f.conv3(relu.relu(self.f.proj3(x)))
+        out5 = self.f.conv5(relu.relu(self.f.proj5(x)))
         pool = self.f.projp(pooling_2d.max_pooling_2d(
-            self.x, 3, stride=1, pad=1))
-        self.y = relu.relu(concat.concat((out1, out3, out5, pool), axis=1))
-
-        return self.y.data,
-
-    def backward(self, x, gy):
-        self.y.grad = gy[0]
-        self.y.backward()
-        return self.x.grad,
+            x, 3, stride=1, pad=1))
+        y = relu.relu(concat.concat((out1, out3, out5, pool), axis=1))
+        return y
 
     def to_gpu(self, device=None):
         return self.f.to_gpu(device)

--- a/chainer/functions/inception.py
+++ b/chainer/functions/inception.py
@@ -4,7 +4,6 @@ from chainer.functions import concat
 from chainer.functions import convolution_2d
 from chainer.functions import pooling_2d
 from chainer.functions import relu
-from chainer import variable
 
 
 class Inception(function.Function):


### PR DESCRIPTION
I fixed the design of Inception module. The document says that it inserts the full computational graph of Inception on top of the input variables, while the previous implementation does not implement as this and hide the computational graph. It caused the volatile flag disabled inside of the Inception module. This change fixes this inconsistency.