### PR TITLE
Matrix multiplication (or dot product)

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -16,6 +16,7 @@ from chainer.functions import leaky_relu
 from chainer.functions import linear
 from chainer.functions import local_response_normalization
 from chainer.functions import lstm
+from chainer.functions import matmul
 from chainer.functions import mean_squared_error
 from chainer.functions import parameter
 from chainer.functions import pooling_2d
@@ -34,10 +35,12 @@ Copy = copy.Copy
 Dropout = dropout.Dropout
 Identity = identity.Identity
 Reshape = reshape.Reshape
+BatchMatMul = matmul.BatchMatMul
 Exp = basic_math.Exp
 Log = basic_math.Log
 LeakyReLU = leaky_relu.LeakyReLU
 LSTM = lstm.LSTM
+MatMul = matmul.MatMul
 ReLU = relu.ReLU
 Sigmoid = sigmoid.Sigmoid
 Softmax = softmax.Softmax
@@ -71,10 +74,12 @@ identity = identity.identity
 reshape = reshape.reshape
 
 absolute = basic_math.absolute
+batch_matmul = matmul.batch_matmul
 exp = basic_math.exp
 log = basic_math.log
 leaky_relu = leaky_relu.leaky_relu
 lstm = lstm.lstm
+matmul = matmul.matmul
 relu = relu.relu
 sigmoid = sigmoid.sigmoid
 softmax = softmax.softmax

--- a/chainer/functions/matmul.py
+++ b/chainer/functions/matmul.py
@@ -1,0 +1,205 @@
+import numpy
+import six
+
+from chainer import cuda
+from chainer import function
+
+
+def _mat_ptrs(a):
+    """Create an array of pointers to matrices
+
+    Args:
+        a: batch of matrices in GPU
+    Returns:
+        GPU array of pointers to matrices
+    """
+    return cuda.to_gpu(numpy.arange(
+        a.ptr, a.ptr + a.shape[0] * a.strides[0], a.strides[0],
+        dtype=cuda.cublas.ctypes.c_void_p))
+
+
+def _as_mat(x):
+    return x.reshape((len(x), 1)) if len(x.shape) == 1 else x
+
+
+def _as_batch_mat(x):
+    return x.reshape((x.shape[0], x.shape[1], 1)) if len(x.shape) == 2 else x
+
+
+def _as_trans_op(trans):
+    return 't' if trans else 'n'
+
+
+def _matmul_cpu(a, b, transa=False, transb=False, transout=False):
+    if transout:
+        # (A B)^T = B^T A^T
+        a, b, transa, transb = b, a, not transb, not transa
+    a = _as_mat(a)
+    b = _as_mat(b)
+    if transa:
+        a = a.T
+    if transb:
+        b = b.T
+    return numpy.dot(a, b)
+
+
+def _matmul_gpu(a, b, transa=False, transb=False, transout=False, out=None):
+    if transout:
+        # (A B)^T = B^T A^T
+        a, b, transa, transb = b, a, not transb, not transa
+    a = _as_mat(a)
+    b = _as_mat(b)
+    with cuda.using_cumisc():
+        return cuda.culinalg.dot(a, b,
+                                 transa=_as_trans_op(transa),
+                                 transb=_as_trans_op(transb),
+                                 out=out)
+
+
+def _batch_matmul_gpu(a, b, out, transa=False, transb=False, transout=False):
+    if transout:
+        # (A B)^T = B^T A^T
+        a, b, transa, transb = b, a, not transb, not transa
+    a = _as_batch_mat(a)
+    b = _as_batch_mat(b)
+    alpha = numpy.float32(1.0)
+    beta = numpy.float32(0.0)
+    l, m, k = a.shape
+    if transa:
+        m, k = k, m
+    n = b.shape[1] if transb else b.shape[2]
+    with cuda.using_cumisc():
+        return cuda.cublas.cublasSgemmBatched(
+            cuda.get_cublas_handle(),
+            _as_trans_op(transb),
+            _as_trans_op(transa),
+            n, m, k, alpha,
+            _mat_ptrs(b).gpudata, k if transb else n,
+            _mat_ptrs(a).gpudata, m if transa else k,
+            beta, _mat_ptrs(out).gpudata, n, l)
+
+
+class MatMul(function.Function):
+    def __init__(self, transa=False, transb=False):
+        self.transa = transa
+        self.transb = transb
+
+    def forward_cpu(self, x):
+        assert len(x[0].shape) == len(x[1].shape)
+        return _matmul_cpu(x[0], x[1], transa=self.transa, transb=self.transb),
+
+    def forward_gpu(self, x):
+        assert len(x[0].shape) == len(x[1].shape)
+        return _matmul_gpu(x[0], x[1], transa=self.transa, transb=self.transb),
+
+    def backward_cpu(self, x, gy):
+        gx0 = _matmul_cpu(
+            gy[0], x[1], transb=not self.transb, transout=self.transa
+            ).reshape(x[0].shape)
+        gx1 = _matmul_cpu(
+            x[0], gy[0], transa=not self.transa, transout=self.transb
+            ).reshape(x[1].shape)
+        return gx0, gx1
+
+    def backward_gpu(self, x, gy):
+        with cuda.using_cumisc():
+            gx0 = _matmul_gpu(
+                gy[0], x[1], transb=not self.transb, transout=self.transa
+                ).reshape(x[0].shape)
+            gx1 = _matmul_gpu(
+                x[0], gy[0], transa=not self.transa, transout=self.transb
+                ).reshape(x[1].shape)
+            return gx0, gx1
+
+
+def matmul(a, b, transa=False, transb=False):
+    """Compute matrix multiplication of two arrays.
+
+    Args:
+        a, b: Variables of 2-D or 1-D arrays.
+            A 2-D array with shape (N, M) is considered as a NxM matrix.
+            A 1-D array with shape (N,) is considered as a Nx1 matrix.
+        transa (bool): If true, transpose a.
+        transb (bool): If true, transpose b.
+
+    Returns:
+        ~chainer.Variable: Matrix multiplication as a 2-D array
+    """
+    return MatMul(transa=transa, transb=transb)(a, b)
+
+
+class BatchMatMul(function.Function):
+    def __init__(self, transa=False, transb=False):
+        self.transa = transa
+        self.transb = transb
+
+    def _output_shape(self, a, b):
+        batch_size = a.shape[0]
+        a_mat_shape = _as_mat(a[0]).shape
+        b_mat_shape = _as_mat(b[0]).shape
+        m = a_mat_shape[1] if self.transa else a_mat_shape[0]
+        n = b_mat_shape[0] if self.transb else b_mat_shape[1]
+        return (batch_size, m, n)
+
+    def forward_cpu(self, x):
+        a, b = x
+        assert a.shape[0] == b.shape[0]
+        batch_size = a.shape[0]
+        shape = self._output_shape(a, b)
+        ret = numpy.empty(shape)
+        for i in six.moves.range(batch_size):
+            ret[i] = _matmul_cpu(
+                a[i], b[i], transa=self.transa, transb=self.transb)
+        return ret,
+
+    def backward_cpu(self, x, gy):
+        a, b = x
+        batch_size = a.shape[0]
+        ga = numpy.empty(a.shape)
+        gb = numpy.empty(b.shape)
+        for i in six.moves.range(batch_size):
+            ga[i] = _matmul_cpu(gy[0][i], b[i],
+                                transb=not self.transb, transout=self.transa
+                                ).reshape(a[0].shape)
+            gb[i] = _matmul_cpu(a[i], gy[0][i],
+                                transa=not self.transa, transout=self.transb
+                                ).reshape(b[0].shape)
+        return ga, gb
+
+    def forward_gpu(self, x):
+        a, b = x
+        assert a.shape[0] == b.shape[0]
+        shape = self._output_shape(a, b)
+        ret = cuda.empty(shape)
+        _batch_matmul_gpu(a, b,
+                          transa=self.transa, transb=self.transb, out=ret)
+        return ret,
+
+    def backward_gpu(self, x, gy):
+        a, b = x
+        batch_size = a.shape[0]
+        ga = cuda.empty((batch_size,) + _as_mat(a[0]).shape)
+        gb = cuda.empty((batch_size,) + _as_mat(b[0]).shape)
+        _batch_matmul_gpu(gy[0], b,
+                          transb=not self.transb, transout=self.transa, out=ga)
+        _batch_matmul_gpu(a, gy[0],
+                          transa=not self.transa, transout=self.transb, out=gb)
+        ga = ga.reshape(a.shape)
+        gb = gb.reshape(b.shape)
+        return ga, gb
+
+
+def batch_matmul(a, b, transa=False, transb=False):
+    """Compute matrix multiplication of two arrays in a batch manner.
+
+    Args:
+        a, b: Variables of 3-D or 2-D arrays.
+            A 3-D array of shape (B, N, M) is considered as B NxM matrices.
+            A 2-D array of shape (B, N,) is considered as B Nx1 matrices.
+        transa (bool): If true, transpose each matrix in a.
+        transb (bool): If true, transpose each matrix in b.
+
+    Returns:
+        ~chainer.Variable: Batch of matrix multiplications as a 3-D array.
+    """
+    return BatchMatMul(transa=transa, transb=transb)(a, b)

--- a/chainer/functions/matmul.py
+++ b/chainer/functions/matmul.py
@@ -1,3 +1,4 @@
+import ctypes
 import numpy
 import six
 
@@ -15,7 +16,7 @@ def _mat_ptrs(a):
     """
     return cuda.to_gpu(numpy.arange(
         a.ptr, a.ptr + a.shape[0] * a.strides[0], a.strides[0],
-        dtype=cuda.cublas.ctypes.c_void_p))
+        dtype=ctypes.c_void_p))
 
 
 def _as_mat(x):

--- a/chainer/functions/matmul.py
+++ b/chainer/functions/matmul.py
@@ -1,4 +1,5 @@
 import ctypes
+
 import numpy
 import six
 

--- a/chainer/functions/matmul.py
+++ b/chainer/functions/matmul.py
@@ -7,10 +7,10 @@ from chainer import function
 
 
 def _mat_ptrs(a):
-    """Create an array of pointers to matrices
+    """Creates an array of pointers to matrices
 
     Args:
-        a: batch of matrices in GPU
+        a: A batch of matrices on GPU
     Returns:
         GPU array of pointers to matrices
     """
@@ -112,17 +112,20 @@ class MatMul(function.Function):
 
 
 def matmul(a, b, transa=False, transb=False):
-    """Compute matrix multiplication of two arrays.
+    """Computes the matrix multiplication of two arrays.
 
     Args:
-        a, b: Variables of 2-D or 1-D arrays.
-            A 2-D array with shape (N, M) is considered as a NxM matrix.
-            A 1-D array with shape (N,) is considered as a Nx1 matrix.
+        a (Variable): The left operand of the matrix multiplication.
+            A 1-D array of shape (N,) is considered as an Nx1 matrix.
+            A 2-D array of shape (M, N) is considered as an MxN matrix.
+        b (Variable): The right operand of the matrix multiplication.
+            Its array is treated as a matrix in the same way as ``a``'s array.
         transa (bool): If true, transpose a.
         transb (bool): If true, transpose b.
 
     Returns:
-        ~chainer.Variable: Matrix multiplication as a 2-D array
+        ~chainer.Variable: The result of the matrix multiplication as a 2-D
+            array.
     """
     return MatMul(transa=transa, transb=transb)(a, b)
 
@@ -189,16 +192,19 @@ class BatchMatMul(function.Function):
 
 
 def batch_matmul(a, b, transa=False, transb=False):
-    """Compute matrix multiplication of two arrays in a batch manner.
+    """Computes the batch matrix multiplications of two sets of arrays.
 
     Args:
-        a, b: Variables of 3-D or 2-D arrays.
-            A 3-D array of shape (B, N, M) is considered as B NxM matrices.
+        a (Variable): The left operand of the batch matrix multiplications.
             A 2-D array of shape (B, N,) is considered as B Nx1 matrices.
+            A 3-D array of shape (B, M, N) is considered as B MxN matrices.
+        b (Variable): The right operand of the batch matrix multiplications.
+            Its array is treated as matrices in the same way as ``a``'s array.
         transa (bool): If true, transpose each matrix in a.
         transb (bool): If true, transpose each matrix in b.
 
     Returns:
-        ~chainer.Variable: Batch of matrix multiplications as a 3-D array.
+        ~chainer.Variable: The result of the batch matrix multiplications as a
+            3-D array.
     """
     return BatchMatMul(transa=transa, transb=transb)(a, b)

--- a/tests/functions_tests/test_matmul.py
+++ b/tests/functions_tests/test_matmul.py
@@ -24,19 +24,12 @@ class _TestMatMul(unittest.TestCase):
             self.assertTrue(hasattr(y.data.gpudata, 'device'))
         gradient_check.assert_allclose(self.forward_answer, y.data)
 
-    def forward_cpu(self):
-        self.check_forward(self.x1, self.x2)
-
     def test_matmul_forward_cpu(self):
-        self.forward_cpu()
-
-    @attr.gpu
-    def forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
+        self.check_forward(self.x1, self.x2)
 
     @attr.gpu
     def test_matmul_forward_gpu(self):
-        self.forward_gpu()
+        self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
     def check_backward(self, x1_data, x2_data, y_grad, atol):
         x1 = chainer.Variable(x1_data)
@@ -52,21 +45,14 @@ class _TestMatMul(unittest.TestCase):
         gradient_check.assert_allclose(gx1, x1.grad, atol=atol)
         gradient_check.assert_allclose(gx2, x2.grad, atol=atol)
 
-    def backward_cpu(self, atol=1e-2):
-        self.check_backward(self.x1, self.x2, self.gy, atol)
-
     def test_matmul_backward_cpu(self):
-        self.backward_cpu()
-
-    @attr.gpu
-    def backward_gpu(self, atol=1e-2):
-        self.check_backward(
-            cuda.to_gpu(self.x1), cuda.to_gpu(self.x2),
-            cuda.to_gpu(self.gy), atol)
+        self.check_backward(self.x1, self.x2, self.gy, atol=1e-2)
 
     @attr.gpu
     def test_matmul_backward_gpu(self):
-        self.backward_gpu()
+        self.check_backward(
+            cuda.to_gpu(self.x1), cuda.to_gpu(self.x2),
+            cuda.to_gpu(self.gy), atol=1e-2)
 
 m = 2
 k = 5

--- a/tests/functions_tests/test_matmul.py
+++ b/tests/functions_tests/test_matmul.py
@@ -1,0 +1,226 @@
+import unittest
+
+import numpy
+import six
+
+import chainer
+from chainer import cuda
+import chainer.functions as F
+from chainer import gradient_check
+from chainer.testing import attr
+
+
+if cuda.available:
+    cuda.init()
+
+
+class _TestMatMul(unittest.TestCase):
+
+    def check_forward(self, x1_data, x2_data):
+        x1 = chainer.Variable(x1_data)
+        x2 = chainer.Variable(x2_data)
+        y = self.op(x1, x2)
+        if isinstance(y.data, cuda.GPUArray):
+            self.assertTrue(hasattr(y.data.gpudata, 'device'))
+        gradient_check.assert_allclose(self.forward_answer, y.data)
+
+    def forward_cpu(self):
+        self.check_forward(self.x1, self.x2)
+
+    def test_matmul_forward_cpu(self):
+        self.forward_cpu()
+
+    @attr.gpu
+    def forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
+
+    @attr.gpu
+    def test_matmul_forward_gpu(self):
+        self.forward_gpu()
+
+    def check_backward(self, x1_data, x2_data, y_grad, atol):
+        x1 = chainer.Variable(x1_data)
+        x2 = chainer.Variable(x2_data)
+        y = self.op(x1, x2)
+        y.grad = y_grad
+        y.backward()
+
+        func = y.creator
+        f = lambda: func.forward((x1.data, x2.data))
+        gx1, gx2 = gradient_check.numerical_grad(
+            f, (x1.data, x2.data), (y.grad,))
+        gradient_check.assert_allclose(gx1, x1.grad, atol=atol)
+        gradient_check.assert_allclose(gx2, x2.grad, atol=atol)
+
+    def backward_cpu(self, atol=1e-2):
+        self.check_backward(self.x1, self.x2, self.gy, atol)
+
+    def test_matmul_backward_cpu(self):
+        self.backward_cpu()
+
+    @attr.gpu
+    def backward_gpu(self, atol=1e-2):
+        self.check_backward(
+            cuda.to_gpu(self.x1), cuda.to_gpu(self.x2),
+            cuda.to_gpu(self.gy), atol)
+
+    @attr.gpu
+    def test_matmul_backward_gpu(self):
+        self.backward_gpu()
+
+m = 2
+k = 5
+n = 10
+
+
+class TestMatMulMatrixMatrix(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(.5, 1, (m, k)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(.5, 1, (k, n)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.matmul(x, y)
+        self.forward_answer = numpy.dot(self.x1, self.x2)
+
+
+class TestMatMulMatrixTMatrix(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(.5, 1, (k, m)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(.5, 1, (k, n)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.matmul(x, y, transa=True)
+        self.forward_answer = numpy.dot(self.x1.T, self.x2)
+
+
+class TestMatMulMatrixMatrixT(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(.5, 1, (m, k)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(.5, 1, (n, k)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.matmul(x, y, transb=True)
+        self.forward_answer = numpy.dot(self.x1, self.x2.T)
+
+
+class TestMatMulMatrixTMatrixT(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(.5, 1, (k, m)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(.5, 1, (n, k)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.matmul(x, y, transa=True, transb=True)
+        self.forward_answer = numpy.dot(self.x1.T, self.x2.T)
+
+
+class TestMatMulVectorTVector(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(.5, 1, (m,)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(.5, 1, (m,)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (1, 1)).astype(numpy.float32)
+        self.op = lambda x, y: F.matmul(x, y, transa=True)
+        self.forward_answer = numpy.dot(self.x1, self.x2).reshape(1, 1)
+
+
+class TestMatMulVectorVectorT(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(.5, 1, (m,)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(.5, 1, (m,)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (m, m)).astype(numpy.float32)
+        self.op = lambda x, y: F.matmul(x, y, transb=True)
+        self.forward_answer = numpy.dot(
+            self.x1.reshape(m, 1), self.x2.reshape(1, m))
+
+batch_size = 10
+
+
+class TestBatchMatMulMatrixMatrix(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, m, k)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (batch_size, k, n)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x, y)
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i], self.x2[i])
+            for i in six.moves.range(batch_size)])
+
+
+class TestBatchMatMulMatrixTMatrix(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, k, m)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (batch_size, k, n)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x, y, transa=True)
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i].T, self.x2[i])
+            for i in six.moves.range(batch_size)])
+
+
+class TestBatchMatMulMatrixMatrixT(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, m, k)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (batch_size, n, k)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x, y, transb=True)
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i], self.x2[i].T)
+            for i in six.moves.range(batch_size)])
+
+
+class TestBatchMatMulMatrixTMatrixT(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, k, m)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (batch_size, n, k)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x, y, transa=True, transb=True)
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i].T, self.x2[i].T)
+            for i in six.moves.range(batch_size)])
+
+
+class TestBatchMatMulVectorTVector(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, m,)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (batch_size, m,)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, 1, 1)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x, y, transa=True)
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i], self.x2[i])
+            for i in six.moves.range(batch_size)]).reshape(batch_size, 1, 1)
+
+
+class TestBatchMatMulVectorVectorT(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, m,)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (batch_size, m,)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, m, m)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x, y, transb=True)
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i].reshape(m, 1), self.x2[i].reshape(1, m))
+            for i in six.moves.range(batch_size)])


### PR DESCRIPTION
This PR adds two functions named ```matmul``` and ```batch_matmul```, both of which do matrix multiplication of two ```Variable```s representing matrices. They also can be used to compute vector inner products.

```matmul``` accepts two ```Variable```s that are 1-D or 2-D arrays. 1-D arrays are treated as column vectors while 2-D arrays are as matrices. Its output is always a 2-D array representing a matrix.

```batch_matmul``` accepts two ```Variable```s that are 2-D or 3-D arrays. 2-D arrays are treated as batches of column vectors while 3-D arrays are as batches of matrices. Its output is always a 3-D array representing a batch of matrices.

Both accept Boolean options ```transa``` and ```transb``` for transposing corresponding argument matrices.

This PR may solve #8.