### PR TITLE
Remove Int from type_check

### DIFF
--- a/chainer/functions/concat.py
+++ b/chainer/functions/concat.py
@@ -26,7 +26,7 @@ class Concat(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
         type_check.expect(in_types[0].ndim >
-                          type_check.IntVariable(self.axis, 'axis'))
+                          type_check.Variable(self.axis, 'axis'))
 
         ndim = in_types[0].ndim.eval()
         for i in range(1, in_types.size().eval()):

--- a/chainer/functions/embed_id.py
+++ b/chainer/functions/embed_id.py
@@ -54,8 +54,8 @@ class EmbedID(function.Function):
             y_type.dtype == numpy.float32,
             y_type.ndim == 2,
             y_type.shape[0] == x_type.shape[0],
-            y_type.shape[1] == type_check.IntVariable(self.W.shape[1],
-                                                      'W.shape[1]'),
+            y_type.shape[1] == type_check.Variable(self.W.shape[1],
+                                                   'W.shape[1]'),
         )
 
     def forward_cpu(self, x):

--- a/chainer/functions/linear.py
+++ b/chainer/functions/linear.py
@@ -79,8 +79,8 @@ class Linear(function.Function):
         type_check.expect(
             x_type.dtype == numpy.float32,
             x_type.ndim == 2,
-            x_type.shape[1] == type_check.IntVariable(self.W.shape[1],
-                                                      'W.shape[1]'),
+            x_type.shape[1] == type_check.Variable(self.W.shape[1],
+                                                   'W.shape[1]'),
         )
 
     def check_type_backward(self, in_types, out_types):
@@ -95,8 +95,8 @@ class Linear(function.Function):
             y_type.dtype == numpy.float32,
             y_type.ndim == 2,
             y_type.shape[0] == x_type.shape[0],
-            y_type.shape[1] == type_check.IntVariable(self.W.shape[0],
-                                                      'W.shape[0]'),
+            y_type.shape[1] == type_check.Variable(self.W.shape[0],
+                                                   'W.shape[0]'),
         )
 
     def forward_cpu(self, x):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -1,4 +1,5 @@
 import operator
+import sys
 
 import numpy
 
@@ -172,8 +173,14 @@ class Expr(object):
     __rsub__ = _flip(__sub__)
     __mul__ = _make_bin_operator('*', 5, operator.__mul__)
     __rmul__ = _flip(__mul__)
-    __truediv__ = _make_bin_operator('/', 5, operator.__truediv__)
-    __rtruediv__ = _flip(__truediv__)
+
+    if sys.version_info < (3, 0, 0):
+        __div__ = _make_bin_operator('/', 5, operator.__div__)
+        __rdiv__ = _flip(__div__)
+    else:
+        __truediv__ = _make_bin_operator('/', 5, operator.__truediv__)
+        __rtruediv__ = _flip(__truediv__)
+
     __floordiv__ = _make_bin_operator('//', 5, operator.__floordiv__)
     __rfloordiv__ = _flip(__floordiv__)
     __mod__ = _make_bin_operator('%', 5, operator.__mod__)

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -69,13 +69,13 @@ def _get_type(name, index, array, accept_none):
 
 def _make_un_operator(exp, priority, func):
     def f(x):
-        return IntUnaryOperator(priority, x, exp, func)
+        return UnaryOperator(priority, x, exp, func)
     return f
 
 
 def _make_bin_operator(exp, priority, func, right_associative=False):
     def f(x, y):
-        return IntBinaryOperator(priority, x, y, exp, func, right_associative)
+        return BinaryOperator(priority, x, y, exp, func, right_associative)
     return f
 
 
@@ -163,40 +163,40 @@ class Expr(object):
     __gt__ = _make_bool_operator('>', '<=', operator.__gt__)
     __ge__ = _make_bool_operator('>=', '<', operator.__ge__)
 
-
-class Int(object):
-
     # Please refer the Python document to know priority of operators.
     # https://docs.python.org/3.4/reference/expressions.html
 
-    __add__ = _make_bin_operator('+', 4, int.__add__)
+    __add__ = _make_bin_operator('+', 4, operator.__add__)
     __radd__ = _flip(__add__)
-    __sub__ = _make_bin_operator('-', 4, int.__sub__)
+    __sub__ = _make_bin_operator('-', 4, operator.__sub__)
     __rsub__ = _flip(__sub__)
-    __mul__ = _make_bin_operator('*', 5, int.__mul__)
+    __mul__ = _make_bin_operator('*', 5, operator.__mul__)
     __rmul__ = _flip(__mul__)
-    __floordiv__ = _make_bin_operator('//', 5, int.__floordiv__)
+    __truediv__ = _make_bin_operator('/', 5, operator.__truediv__)
+    __rtruediv__ = _flip(__truediv__)
+    __floordiv__ = _make_bin_operator('//', 5, operator.__floordiv__)
     __rfloordiv__ = _flip(__floordiv__)
-    __mod__ = _make_bin_operator('%', 5, int.__mod__)
+    __mod__ = _make_bin_operator('%', 5, operator.__mod__)
     __rmod__ = _flip(__mod__)
     # Only '**' operator is right-associative
-    __pow__ = _make_bin_operator('**', 7, int.__mod__, right_associative=True)
+    __pow__ = _make_bin_operator('**', 7, operator.__mod__,
+                                 right_associative=True)
 
-    __lshift__ = _make_bin_operator('<<', 3, int.__lshift__)
+    __lshift__ = _make_bin_operator('<<', 3, operator.__lshift__)
     __rlshift__ = _flip(__lshift__)
-    __rshift__ = _make_bin_operator('>>', 3, int.__rshift__)
+    __rshift__ = _make_bin_operator('>>', 3, operator.__rshift__)
     __rrshift__ = _flip(__rshift__)
 
-    __and__ = _make_bin_operator('&', 2, int.__and__)
+    __and__ = _make_bin_operator('&', 2, operator.__and__)
     __rand__ = _flip(__and__)
-    __xor__ = _make_bin_operator('^', 1, int.__xor__)
+    __xor__ = _make_bin_operator('^', 1, operator.__xor__)
     __rxor__ = _flip(__xor__)
-    __or__ = _make_bin_operator('|', 0, int.__or__)
+    __or__ = _make_bin_operator('|', 0, operator.__or__)
     __ror__ = _flip(__or__)
 
-    __neg__ = _make_un_operator('-', 6, int.__neg__)
-    __pos__ = _make_un_operator('+', 6, int.__pos__)
-    __invert__ = _make_un_operator('~', 6, int.__invert__)
+    __neg__ = _make_un_operator('-', 6, operator.__neg__)
+    __pos__ = _make_un_operator('+', 6, operator.__pos__)
+    __invert__ = _make_un_operator('~', 6, operator.__invert__)
 
 
 class Atom(Expr):
@@ -209,32 +209,26 @@ class Atom(Expr):
         return self.value
 
 
-class IntAtom(Atom, Int):
+class Constant(Atom):
 
     def __init__(self, value):
-        Atom.__init__(self, value)
-
-
-class IntConstant(IntAtom):
-
-    def __init__(self, value):
-        super(IntConstant, self).__init__(value)
+        super(Constant, self).__init__(value)
 
     def __str__(self):
         return str(self.value)
 
 
-class IntVariable(IntAtom):
+class Variable(Atom):
 
     def __init__(self, value, name):
-        super(IntVariable, self).__init__(value)
+        super(Variable, self).__init__(value)
         self.name = name
 
     def __str__(self):
         return self.name
 
 
-class Shape(IntAtom):
+class Shape(Atom):
 
     def __init__(self, value, index, name):
         super(Shape, self).__init__(value)
@@ -245,7 +239,7 @@ class Shape(IntAtom):
         return '{0}.shape[{1}]'.format(self.name, self.index)
 
 
-class Member(IntAtom):
+class Member(Atom):
 
     def __init__(self, value, obj, name):
         super(Member, self).__init__(value)
@@ -273,12 +267,6 @@ class UnaryOperator(Expr):
             exp = '(' + exp + ')'
 
         return self.exp + exp
-
-
-class IntUnaryOperator(UnaryOperator, Int):
-
-    def __init__(self, priority, term, exp, func):
-        UnaryOperator.__init__(self, priority, term, exp, func)
 
 
 class BinaryOperator(Expr):
@@ -328,13 +316,6 @@ class BinaryOperator(Expr):
             right = '(' + right + ')'
 
         return '{0} {2} {1}'.format(left, right, self.exp)
-
-
-class IntBinaryOperator(BinaryOperator, Int):
-
-    def __init__(self, priority, lhs, rhs, exp, func, right_associative=False):
-        BinaryOperator.__init__(self, priority, lhs, rhs, exp, func,
-                                right_associative)
 
 
 class Testable(object):

--- a/tests/utils_tests/test_type_check.py
+++ b/tests/utils_tests/test_type_check.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import numpy
@@ -171,6 +172,20 @@ class TestOperators(unittest.TestCase):
                         (-x).priority <
                         (x ** y).priority <
                         x.priority)
+
+
+class TestDivOperator(unittest.TestCase):
+
+    def setUp(self):
+        self.x = T.Variable(1, 'x')
+        self.y = T.Variable(2, 'y')
+
+    def test_div(self):
+        # Behavior of '/' operator for int depends on the version of Python
+        if sys.version_info < (3, 0, 0):
+            self.assertEqual(0, (self.x / self.y).eval())
+        else:
+            self.assertEqual(0.5, (self.x / self.y).eval())
 
 
 class TestGetType(unittest.TestCase):

--- a/tests/utils_tests/test_type_check.py
+++ b/tests/utils_tests/test_type_check.py
@@ -5,10 +5,10 @@ import numpy
 from chainer.utils import type_check as T
 
 
-class TestIntConstant(unittest.TestCase):
+class TestConstant(unittest.TestCase):
 
     def setUp(self):
-        self.x = T.IntConstant(10)
+        self.x = T.Constant(10)
 
     def test_str(self):
         self.assertEqual('10', str(self.x))
@@ -17,10 +17,10 @@ class TestIntConstant(unittest.TestCase):
         self.assertEqual(10, self.x.eval())
 
 
-class TestIntVariable(unittest.TestCase):
+class TestVariable(unittest.TestCase):
 
     def setUp(self):
-        self.x = T.IntVariable(10, 'x')
+        self.x = T.Variable(10, 'x')
 
     def test_str(self):
         self.assertEqual('x', str(self.x))
@@ -56,16 +56,16 @@ class TestMember(unittest.TestCase):
 class TestBinaryOperator(unittest.TestCase):
 
     def setUp(self):
-        x = T.IntVariable(1, 'x')
-        y = T.IntVariable(1, 'y')
+        x = T.Variable(1, 'x')
+        y = T.Variable(1, 'y')
         f = lambda x, y: (x, y)
-        self.op1 = T.IntBinaryOperator(7, x, y, '+', f)
-        self.op2 = T.IntBinaryOperator(8, x, y, '+', f)
-        self.op3 = T.IntBinaryOperator(9, x, y, '+', f)
+        self.op1 = T.BinaryOperator(7, x, y, '+', f)
+        self.op2 = T.BinaryOperator(8, x, y, '+', f)
+        self.op3 = T.BinaryOperator(9, x, y, '+', f)
 
-        self.op4 = T.IntBinaryOperator(7, x, y, '+', f, True)
-        self.op5 = T.IntBinaryOperator(8, x, y, '+', f, True)
-        self.op6 = T.IntBinaryOperator(9, x, y, '+', f, True)
+        self.op4 = T.BinaryOperator(7, x, y, '+', f, True)
+        self.op5 = T.BinaryOperator(8, x, y, '+', f, True)
+        self.op6 = T.BinaryOperator(9, x, y, '+', f, True)
 
     def test_str(self):
         self.assertEqual('x + y', str(self.op1))
@@ -83,10 +83,10 @@ class TestBinaryOperator(unittest.TestCase):
 class TestUnaryOperator(unittest.TestCase):
 
     def setUp(self):
-        x = T.IntVariable(1, 'x')
+        x = T.Variable(1, 'x')
         f = lambda x: (x,)
-        self.op1 = T.IntUnaryOperator(8, x, '-', f)
-        self.op2 = T.IntUnaryOperator(9, x, '-', f)
+        self.op1 = T.UnaryOperator(8, x, '-', f)
+        self.op2 = T.UnaryOperator(9, x, '-', f)
 
     def test_str(self):
         self.assertEqual('-x', str(self.op1))
@@ -99,8 +99,8 @@ class TestUnaryOperator(unittest.TestCase):
 class TestOperators(unittest.TestCase):
 
     def setUp(self):
-        self.x = T.IntVariable(1, 'x')
-        self.y = T.IntVariable(1, 'y')
+        self.x = T.Variable(1, 'x')
+        self.y = T.Variable(1, 'y')
 
     def test_str(self):
         x = self.x
@@ -111,6 +111,8 @@ class TestOperators(unittest.TestCase):
         self.assertEqual('1 - x', str(1 - x))
         self.assertEqual('x * y', str(x * y))
         self.assertEqual('1 * x', str(1 * x))
+        self.assertEqual('x / y', str(x / y))
+        self.assertEqual('1 / x', str(1 / x))
         self.assertEqual('x // y', str(x // y))
         self.assertEqual('1 // x', str(1 // x))
         self.assertEqual('x % y', str(x % y))
@@ -155,6 +157,7 @@ class TestOperators(unittest.TestCase):
         self.assertTrue((x << y).priority == (x >> y).priority)
         self.assertTrue((x + y).priority == (x - y).priority)
         self.assertTrue((x * y).priority ==
+                        (x / y).priority ==
                         (x // y).priority ==
                         (x % y).priority)
         self.assertTrue((-x).priority == (+x).priority == (~x).priority)
@@ -203,9 +206,9 @@ class TestGetType(unittest.TestCase):
 class TestBoolBinaryOperator(unittest.TestCase):
 
     def setUp(self):
-        x = T.IntVariable(1, 'x')
-        y = T.IntVariable(1, 'y')
-        z = T.IntVariable(2, 'z')
+        x = T.Variable(1, 'x')
+        y = T.Variable(1, 'y')
+        z = T.Variable(2, 'z')
         f = lambda x, y: x == y
         self.op1 = T.BoolBinaryOperator(x, y, '==', '!=', f)
         self.op2 = T.BoolBinaryOperator(x, z, '==', '!=', f)


### PR DESCRIPTION
I noticed that we need not restrict only int to check values.
We can check any types of variables including str and float with this patch.

for example:
```
expect(Variable('AAA', x) + 'BBB' == 'AAABBB')
```
works.