### PR TITLE
Fix type check

### DIFF
--- a/chainer/functions/embed_id.py
+++ b/chainer/functions/embed_id.py
@@ -53,6 +53,8 @@ class EmbedID(function.Function):
         type_check.expect(
             y_type.dtype == numpy.float32,
             y_type.ndim == 2,
+        )
+        type_check.expect(
             y_type.shape[0] == x_type.shape[0],
             y_type.shape[1] == type_check.IntVariable(self.W.shape[1],
                                                       'W.shape[1]'),

--- a/chainer/functions/linear.py
+++ b/chainer/functions/linear.py
@@ -78,10 +78,11 @@ class Linear(function.Function):
 
         type_check.expect(
             x_type.dtype == numpy.float32,
-            x_type.ndim == 2,
-            x_type.shape[1] == type_check.IntVariable(self.W.shape[1],
-                                                      'W.shape[1]'),
+            x_type.ndim >= 2,
         )
+        type_check.expect(
+            numpy.prod(x_type.shape[1:]) == type_check.IntVariable(
+                self.W.shape[1], 'W.shape[1]'))
 
     def check_type_backward(self, in_types, out_types):
         type_check.expect(
@@ -94,6 +95,8 @@ class Linear(function.Function):
         type_check.expect(
             y_type.dtype == numpy.float32,
             y_type.ndim == 2,
+        )
+        type_check.expect(
             y_type.shape[0] == x_type.shape[0],
             y_type.shape[1] == type_check.IntVariable(self.W.shape[0],
                                                       'W.shape[0]'),

--- a/chainer/functions/lstm.py
+++ b/chainer/functions/lstm.py
@@ -58,7 +58,8 @@ class LSTM(function.Function):
             c_type.ndim >= 2,
             x_type.ndim >= 2,
             c_type.ndim == x_type.ndim,
-
+        )
+        type_check.expect(
             x_type.shape[0] == c_type.shape[0],
             x_type.shape[1] == 4 * c_type.shape[1],
         )

--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -35,8 +35,8 @@ class Softmax(function.Function):
         x_type, = in_types
         y_type, = out_types
 
+        type_check.expect(y_type.ndim == 2)
         type_check.expect(
-            y_type.ndim == 2,
             y_type.shape[0] == x_type.shape[0],
             y_type.shape[1] == x_type.shape[1],
         )

--- a/chainer/functions/softmax_cross_entropy.py
+++ b/chainer/functions/softmax_cross_entropy.py
@@ -23,7 +23,8 @@ class SoftmaxCrossEntropy(function.Function):
             x_type.ndim == 2,
             t_type.dtype == numpy.int32,
             t_type.ndim == 1,
-
+        )
+        type_check.expect(
             x_type.shape[0] == t_type.shape[0],
         )
 


### PR DESCRIPTION
I fixed existing type check of functions. It includes following changes:

1. Split type_check.expect calls for ndim checking and shape checking, since, if the ndim is too small, the corresponding shape accessing is failed outside of the type checking utility, which ends up with unfriendly messages.
2. I fixed the type specification of Linear function, which must accept arrays with more than two dimensions. It enables us to directly input to Linear function an array with spatial dimensions.