### PR TITLE
Fix max_pooling_2d on CPU with large window size (fix #120)

### DIFF
--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -86,7 +86,7 @@ class MaxPooling2D(Pooling2D):
         col = col.reshape(n, c, kh * kw, out_h, out_w)
 
         # We select maximum twice, since the implementation using numpy.choose
-        # hits its bug when kh * kw >= 30.
+        # hits its bug when kh * kw >= 32.
         self.indexes = col.argmax(axis=2)
         y = col.max(axis=2)
         return y,

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -83,10 +83,12 @@ class MaxPooling2D(Pooling2D):
             x[0], self.kh, self.kw, self.sy, self.sx, self.ph, self.pw,
             pval=-float('inf'), cover_all=self.cover_all)
         n, c, kh, kw, out_h, out_w = col.shape
-        col = numpy.rollaxis(col.reshape(n, c, kh * kw, out_h, out_w), 2)
+        col = col.reshape(n, c, kh * kw, out_h, out_w)
 
-        self.indexes = col.argmax(axis=0)
-        y = self.indexes.choose(col)
+        # We select maximum twice, since the implementation using numpy.choose
+        # hits its bug when kh * kw >= 30.
+        self.indexes = col.argmax(axis=2)
+        y = col.max(axis=2)
         return y,
 
     def forward_gpu(self, x):

--- a/tests/functions_tests/test_pooling_2d.py
+++ b/tests/functions_tests/test_pooling_2d.py
@@ -56,6 +56,11 @@ class TestMaxPooling2D(unittest.TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
+    def test_forward_cpu_wide(self):  # see #120
+        x_data = numpy.random.rand(2, 3, 15, 15).astype(numpy.float32)
+        x = chainer.Variable(x_data)
+        functions.max_pooling_2d(x, 6, stride=6, pad=0)
+
     @attr.cudnn
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))


### PR DESCRIPTION
This PR fixes #120. The bug seems to be caused by the bug (or specification?) of numpy.choose https://github.com/numpy/numpy/issues/3259. I used this function to get maximum elements using indices given by argmax. It seems that numpy.choose does not accept an array with the first axis of length more than 30, which makes the max_pooling_2d not work on the window size more than 30 (e.g. if kh = kw = 6, then the window size is kh * kw = 36, which exceeds this threshold).

In order to avoid this bug, I changed the forward implementation to directly call numpy.max instead of numpy.choose. It makes the code a bit redundant, though it runs correctly with large windows.