### PR TITLE
Fix InceptionBN to execute forward of all functions in the module

### DIFF
--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -5,7 +5,7 @@ from chainer import variable
 
 
 class DotNode(object):
-    """Node of computational graph, with utilities for dot language.
+    """Node of the computational graph, with utilities for dot language.
 
     This class represents a node of computational graph,
     with some utilities for dot language.
@@ -41,7 +41,7 @@ class DotNode(object):
         """The text that represents properties of the node.
 
         Returns:
-            string: The text that represents the id and attributes of this node.
+            string: The text that represents the id and attributes of the node.
         """
 
         attributes = ["%s=\"%s\"" % (k, v) for (k, v)

--- a/chainer/functions/inceptionbn.py
+++ b/chainer/functions/inceptionbn.py
@@ -5,7 +5,6 @@ from chainer.functions import concat
 from chainer.functions import convolution_2d
 from chainer.functions import pooling_2d
 from chainer.functions import relu
-from chainer import variable
 
 
 class InceptionBN(function.Function):

--- a/chainer/functions/inceptionbn.py
+++ b/chainer/functions/inceptionbn.py
@@ -52,39 +52,31 @@ class InceptionBN(function.Function):
         else:
             raise NotImplementedError()
 
-    def forward(self, x):
-        f = self.f
-
-        self.x = variable.Variable(x[0])
+    def __call__(self, x):
         outs = []
 
-        if hasattr(f, 'conv1'):
-            h1 = f.conv1(self.x)
-            h1 = f.conv1n(h1)
+        if hasattr(self.f, 'conv1'):
+            h1 = self.f.conv1(x)
+            h1 = self.f.conv1n(h1)
             h1 = relu.relu(h1)
             outs.append(h1)
 
-        h3 = relu.relu(f.proj3n(f.proj3(self.x)))
-        h3 = relu.relu(f.conv3n(f.conv3(h3)))
+        h3 = relu.relu(self.f.proj3n(self.f.proj3(x)))
+        h3 = relu.relu(self.f.conv3n(self.f.conv3(h3)))
         outs.append(h3)
 
-        h33 = relu.relu(f.proj33n(f.proj33(self.x)))
-        h33 = relu.relu(f.conv33an(f.conv33a(h33)))
-        h33 = relu.relu(f.conv33bn(f.conv33b(h33)))
+        h33 = relu.relu(self.f.proj33n(self.f.proj33(x)))
+        h33 = relu.relu(self.f.conv33an(self.f.conv33a(h33)))
+        h33 = relu.relu(self.f.conv33bn(self.f.conv33b(h33)))
         outs.append(h33)
 
-        p = f.pool(self.x)
-        if hasattr(f, 'poolp'):
-            p = relu.relu(f.poolpn(f.poolp(p)))
+        p = self.f.pool(x)
+        if hasattr(self.f, 'poolp'):
+            p = relu.relu(self.f.poolpn(self.f.poolp(p)))
         outs.append(p)
 
-        self.y = concat.concat(outs, axis=1)
-        return self.y.data,
-
-    def backward(self, x, gy):
-        self.y.grad = gy[0]
-        self.y.backward()
-        return self.x.grad,
+        y = concat.concat(outs, axis=1)
+        return y
 
     def to_gpu(self, device=None):
         super(InceptionBN, self).to_gpu(device)


### PR DESCRIPTION
This PR applies almost same changes as #103 to `InceptionBN` module.
We execute forward operation of all function in `inceptionBN`to enable `volatile` option of all functions in `inceptionBN` module.

Note that `examples/imagenet/train_imagenet.py` does not work unless changes of #124 are applied. So I think we should merge #124 first and merge this PR after confirming that examples run properly.