### PR TITLE
Simplify the output of Function.label

### DIFF
--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -5,7 +5,7 @@ from chainer import variable
 
 
 class DotNode(object):
-    """Node of computational graph, with utilities for dot language.
+    """Node of the computational graph, with utilities for dot language.
 
     This class represents a node of computational graph,
     with some utilities for dot language.
@@ -41,7 +41,7 @@ class DotNode(object):
         """The text that represents properties of the node.
 
         Returns:
-            string: The text that represents the id and attributes of this node.
+            string: The text that represents the id and attributes of the node.
         """
 
         attributes = ["%s=\"%s\"" % (k, v) for (k, v)

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -184,7 +184,7 @@ class Function(object):
         The default implementation returns its type name.
         Each function should override it to give more information.
         """
-        return str(type(self))
+        return self.__class__.__name__
 
     def _check_data_type_forward(self, in_data):
         in_type = type_check.get_types(in_data, 'in_types', False)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -38,4 +38,4 @@ class TestFunction(unittest.TestCase):
 
     def test_label(self):
         self.assertEqual(chainer.Function().label,
-                         '<class \'chainer.function.Function\'>')
+                         'Function')


### PR DESCRIPTION
This PR changes label of Function nodes computational graphs.
Take `Identity` function for example, this PR change from "<class 'chainer.functions.identity.Identity'>" to 'Identity'

This change simplifies the visualization of computational graphs.

* Example : Inception module(3a) of GoogLeNet

**Before**
![2015-07-04 00 42 40](https://cloud.githubusercontent.com/assets/407052/8501981/dc402fca-21e5-11e5-8f2a-1df3a243dda1.png)

**After**
![2015-07-04 00 41 35](https://cloud.githubusercontent.com/assets/407052/8501978/cf329e9e-21e5-11e5-9cc3-ef4f3c895830.png)