### PR TITLE
Support lazy evaluation for member access, item access and function call

### DIFF
--- a/chainer/functions/embed_id.py
+++ b/chainer/functions/embed_id.py
@@ -53,8 +53,6 @@ class EmbedID(function.Function):
         type_check.expect(
             y_type.dtype == numpy.float32,
             y_type.ndim == 2,
-        )
-        type_check.expect(
             y_type.shape[0] == x_type.shape[0],
             y_type.shape[1] == type_check.Variable(self.W.shape[1],
                                                    'W.shape[1]'),

--- a/chainer/functions/linear.py
+++ b/chainer/functions/linear.py
@@ -81,8 +81,8 @@ class Linear(function.Function):
             x_type.ndim >= 2,
         )
         type_check.expect(
-            numpy.prod(x_type.shape[1:]) == type_check.Variable(
-                self.W.shape[1], 'W.shape[1]'))
+            (type_check.Variable(numpy.prod, 'prod')(x_type.shape[1:]) ==
+             type_check.Variable(self.W.shape[1], 'W.shape[1]')))
 
     def check_type_backward(self, in_types, out_types):
         type_check.expect(

--- a/chainer/functions/linear.py
+++ b/chainer/functions/linear.py
@@ -79,10 +79,9 @@ class Linear(function.Function):
         type_check.expect(
             x_type.dtype == numpy.float32,
             x_type.ndim >= 2,
-        )
-        type_check.expect(
             (type_check.Variable(numpy.prod, 'prod')(x_type.shape[1:]) ==
-             type_check.Variable(self.W.shape[1], 'W.shape[1]')))
+             type_check.Variable(self.W.shape[1], 'W.shape[1]')),
+        )
 
     def check_type_backward(self, in_types, out_types):
         type_check.expect(
@@ -95,8 +94,6 @@ class Linear(function.Function):
         type_check.expect(
             y_type.dtype == numpy.float32,
             y_type.ndim == 2,
-        )
-        type_check.expect(
             y_type.shape[0] == x_type.shape[0],
             y_type.shape[1] == type_check.Variable(self.W.shape[0],
                                                    'W.shape[0]'),

--- a/chainer/functions/lstm.py
+++ b/chainer/functions/lstm.py
@@ -58,8 +58,7 @@ class LSTM(function.Function):
             c_type.ndim >= 2,
             x_type.ndim >= 2,
             c_type.ndim == x_type.ndim,
-        )
-        type_check.expect(
+
             x_type.shape[0] == c_type.shape[0],
             x_type.shape[1] == 4 * c_type.shape[1],
         )

--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -35,8 +35,9 @@ class Softmax(function.Function):
         x_type, = in_types
         y_type, = out_types
 
-        type_check.expect(y_type.ndim == 2)
         type_check.expect(
+            y_type.ndim == 2,
+
             y_type.shape[0] == x_type.shape[0],
             y_type.shape[1] == x_type.shape[1],
         )

--- a/chainer/functions/softmax_cross_entropy.py
+++ b/chainer/functions/softmax_cross_entropy.py
@@ -23,8 +23,7 @@ class SoftmaxCrossEntropy(function.Function):
             x_type.ndim == 2,
             t_type.dtype == numpy.int32,
             t_type.ndim == 1,
-        )
-        type_check.expect(
+
             x_type.shape[0] == t_type.shape[0],
         )
 

--- a/tests/functions_tests/test_linear.py
+++ b/tests/functions_tests/test_linear.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.utils import type_check
 
 
 if cuda.available:
@@ -77,3 +78,14 @@ class TestLinear(unittest.TestCase):
 class TestLinearWithSpatialDimensions(TestLinear):
 
     in_shape = (3, 2, 2)
+
+
+class TestInvalidLinear(unittest.TestCase):
+
+    def setUp(self):
+        self.func = functions.Linear(3, 2)
+        self.x = numpy.random.uniform(-1, 1, (4, 1, 2)).astype(numpy.float32)
+
+    def test_invalid_size(self):
+        with self.assertRaises(type_check.InvalidType):
+            self.func(chainer.Variable(self.x))


### PR DESCRIPTION
I implemented `GetAttr`, `GetItem`, and `Call` classes which are sub-classes of `Expr`. These classes evluate `__getattr__`, `__getitem__` and `__call__` in `expr`. And old special classes like `Shape` are replaced with combinations of these classes.

For example this code is valid:
```
>>> s = Constant('xyz')
>>> s[1].__len__().eval()
1
```
In this situation, first `Call(GetAttr(GetItem(Constant(...), 1), '__len__'), ())` is created, and then it is evaluated.

fix #131 