### PR TITLE
Update scikits.cuda version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimum requirements:
 Requirements to enable CUDA:
 - CUDA 6.5+
 - PyCUDA
-- scikits.cuda (pip install 'scikits.cuda>=0.5.0b1,!=0.042')
+- scikits.cuda (pip install 'scikits.cuda>=0.5.0b2,!=0.042')
 - Mako (depending through PyCUDA)
 
 Recommended:

--- a/cuda_deps/setup.py
+++ b/cuda_deps/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'chainer',
         'pycuda>=2014.1',
-        'scikits.cuda>=0.5.0b1,!=0.042',
+        'scikits.cuda>=0.5.0b2,!=0.042',
         'Mako',
         'six>=1.9.0',
     ],


### PR DESCRIPTION
We require scikits.cuda 0.5.0b2 to support Py3. It seems some of recent updates also depend on scikits.cuda 0.5.0b2 (e.g. #116).