### PR TITLE
Add nodes to computational graph

### DIFF
--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -63,7 +63,7 @@ class ComputationalGraph(object):
 
         Args:
             nodes (list): List of nodes. Each node is either
-            :class:`Variable` object or :class:`Function` object.
+                 :class:`Variable` object or :class:`Function` object.
             edges (list): List of edges. Each edge consists of pair of nodes.
         """
         self.nodes = nodes

--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -58,14 +58,15 @@ class ComputationalGraph(object):
       We assume that the computational graph is directed and acyclic.
     """
 
-    def __init__(self, edges):
+    def __init__(self, nodes, edges):
         """Initializes computational graph.
 
         Args:
+            nodes (list): List of nodes. Each node is either
+            :class:`Variable` object or :class:`Function` object.
             edges (list): List of edges. Each edge consists of pair of nodes.
-            Nodes are either :class:`Variable` object or
-            :class:`Function` object.
         """
+        self.nodes = nodes
         self.edges = edges
 
     def _to_dot(self):
@@ -77,6 +78,9 @@ class ComputationalGraph(object):
         """
 
         ret = "digraph graphname{"
+        for node in self.nodes:
+            assert isinstance(node, (variable.Variable, function.Function))
+            ret += DotNode(node).label
         for edge in self.edges:
             head, tail = edge
             assert (isinstance(head, variable.Variable)
@@ -85,8 +89,6 @@ class ComputationalGraph(object):
                     and isinstance(tail, variable.Variable))
             head_node = DotNode(head)
             tail_node = DotNode(tail)
-            ret += head_node.label
-            ret += tail_node.label
             ret += "%s -> %s;" % (head_node.id_, tail_node.id_)
         ret += "}"
         return ret
@@ -105,12 +107,6 @@ class ComputationalGraph(object):
             return self._to_dot()
         else:
             NotImplementedError('Currently, only dot format is supported.')
-
-    def __len__(self):
-        return len(self.edges)
-
-    def __contains__(self, e):
-        return e in self.edges
 
 
 def build_computational_graph(outputs, remove_split=True):
@@ -161,6 +157,7 @@ def build_computational_graph(outputs, remove_split=True):
 
     cands = []
     seen_edges = set()
+    nodes = set()
     push_count = [0]
 
     def add_cand(cand):
@@ -169,6 +166,7 @@ def build_computational_graph(outputs, remove_split=True):
 
     for o in outputs:
         add_cand(o)
+        nodes.add(o)
 
     while cands:
         _, _, cand = heapq.heappop(cands)
@@ -182,6 +180,8 @@ def build_computational_graph(outputs, remove_split=True):
             if creator is not None and (creator, cand) not in seen_edges:
                 add_cand(creator)
                 seen_edges.add((creator, cand))
+                nodes.add(creator)
+                nodes.add(cand)
         elif isinstance(cand, function.Function):
             if remove_split and isinstance(cand, function.Split):
                 next_cand = creator.inputs[0]
@@ -196,4 +196,6 @@ def build_computational_graph(outputs, remove_split=True):
                         input_ = creator.inputs[0]
                     add_cand(input_)
                     seen_edges.add((input_, cand))
-    return ComputationalGraph(seen_edges)
+                    nodes.add(input_)
+                    nodes.add(cand)
+    return ComputationalGraph(list(nodes), list(seen_edges))

--- a/tests/test_computational_graph.py
+++ b/tests/test_computational_graph.py
@@ -182,33 +182,31 @@ class TestGraphBuilder5(unittest.TestCase):
 
     def test_edges(self):
         self.assertEqual(len(self.g1.edges), 4)
-
-        self.assertTrue((self.x, self.x_splitter) in self.g1.edges)
-        self.assertTrue((self.x_splitter, self.x_clone) in self.g1.edges)
-        self.assertTrue((self.x_clone, self.f) in self.g1.edges)
-        self.assertTrue((self.f, self.y) in self.g1.edges)
+        self.assertSetEqual(set(self.g1.edges),
+                            set([(self.x, self.x_splitter),
+                                 (self.x_splitter, self.x_clone),
+                                 (self.x_clone, self.f),
+                                 (self.f, self.y)]))
 
     def test_nodes(self):
         self.assertEqual(len(self.g1.nodes), 5)
-
-        self.assertTrue(self.x in self.g1.nodes)
-        self.assertTrue(self.x_splitter in self.g1.nodes)
-        self.assertTrue(self.x_clone in self.g1.nodes)
-        self.assertTrue(self.f in self.g1.nodes)
-        self.assertTrue(self.y in self.g1.nodes)
+        self.assertSetEqual(set(self.g1.nodes),
+                            set([self.x,
+                                 self.x_splitter,
+                                 self.x_clone,
+                                 self.f,
+                                 self.y]))
 
     def test_edges_remove_split(self):
         self.assertEqual(len(self.g2.edges), 2)
-
-        self.assertTrue((self.x, self.f) in self.g2.edges)
-        self.assertTrue((self.f, self.y) in self.g2.edges)
+        self.assertSetEqual(set(self.g2.edges),
+                            set([(self.x, self.f),
+                                 (self.f, self.y)]))
 
     def test_nodes_remove_split(self):
         self.assertEqual(len(self.g2.nodes), 3)
-
-        self.assertTrue(self.x in self.g2.nodes)
-        self.assertTrue(self.f in self.g2.nodes)
-        self.assertTrue(self.y in self.g2.nodes)
+        self.assertSetEqual(set(self.g2.nodes),
+                            set([self.x, self.f, self.y]))
 
 
 class TestGraphBuilder6(unittest.TestCase):
@@ -228,45 +226,41 @@ class TestGraphBuilder6(unittest.TestCase):
 
     def test_edges(self):
         self.assertEqual(len(self.g1.edges), 7)
-
-        self.assertTrue((self.x1, self.x1_splitter) in self.g1.edges)
-        self.assertTrue((self.x1_splitter, self.x1_clone) in self.g1.edges)
-        self.assertTrue((self.x1_clone, self.f) in self.g1.edges)
-
-        self.assertTrue((self.x2, self.x2_splitter) in self.g1.edges)
-        self.assertTrue((self.x2_splitter, self.x2_clone) in self.g1.edges)
-        self.assertTrue((self.x2_clone, self.f) in self.g1.edges)
-
-        self.assertTrue((self.f, self.y) in self.g1.edges)
+        self.assertSetEqual(set(self.g1.edges),
+                            set([(self.x1, self.x1_splitter),
+                                 (self.x1_splitter, self.x1_clone),
+                                 (self.x1_clone, self.f),
+                                 (self.x2, self.x2_splitter),
+                                 (self.x2_splitter, self.x2_clone),
+                                 (self.x2_clone, self.f),
+                                 (self.f, self.y)]))
 
     def test_nodes(self):
         self.assertEqual(len(self.g1.nodes), 8)
-
-        self.assertTrue(self.x1 in self.g1.nodes)
-        self.assertTrue(self.x1_splitter in self.g1.nodes)
-        self.assertTrue(self.x1_clone in self.g1.nodes)
-
-        self.assertTrue(self.x2 in self.g1.nodes)
-        self.assertTrue(self.x2_splitter in self.g1.nodes)
-        self.assertTrue(self.x2_clone in self.g1.nodes)
-
-        self.assertTrue(self.f in self.g1.nodes)
-        self.assertTrue(self.y in self.g1.nodes)
+        self.assertSetEqual(set(self.g1.nodes),
+                            set([self.x1,
+                                 self.x1_splitter,
+                                 self.x1_clone,
+                                 self.x2,
+                                 self.x2_splitter,
+                                 self.x2_clone,
+                                 self.f,
+                                 self.y]))
 
     def test_edges_remove_split(self):
         self.assertEqual(len(self.g2.edges), 3)
-
-        self.assertTrue((self.x1, self.f) in self.g2.edges)
-        self.assertTrue((self.x2, self.f) in self.g2.edges)
-        self.assertTrue((self.f, self.y) in self.g2.edges)
+        self.assertSetEqual(set(self.g2.edges),
+                            set([(self.x1, self.f),
+                                 (self.x2, self.f),
+                                 (self.f, self.y)]))
 
     def test_nodes_remove_split(self):
-        self.assertEqual(len(self.g2.edges), 3)
-
-        self.assertTrue(self.x1 in self.g2.nodes)
-        self.assertTrue(self.x2 in self.g2.nodes)
-        self.assertTrue(self.f in self.g2.nodes)
-        self.assertTrue(self.y in self.g2.nodes)
+        self.assertEqual(len(self.g2.nodes), 4)
+        self.assertSetEqual(set(self.g2.nodes),
+                            set([self.x1,
+                                 self.x2,
+                                 self.f,
+                                 self.y]))
 
 
 class TestGraphBuilder7(unittest.TestCase):

--- a/tests/test_computational_graph.py
+++ b/tests/test_computational_graph.py
@@ -29,6 +29,12 @@ def mock_function(xs, n_out):
     return MockFunction(len(xs), n_out)(*xs)
 
 
+def _check(self, outputs, remove_split, node_num, edge_num):
+    g = c.build_computational_graph(outputs, remove_split)
+    self.assertEqual(len(g.nodes), node_num)
+    self.assertEqual(len(g.edges), edge_num)
+
+
 class TestGraphBuilder(unittest.TestCase):
     # x-splitter-x'-f-y-splitter-y'-g-z
     def setUp(self):
@@ -38,44 +44,36 @@ class TestGraphBuilder(unittest.TestCase):
 
     # x
     def test_head_variable(self):
-        self.assertEqual(len(c.build_computational_graph((self.x,), False)), 0)
-        self.assertEqual(len(c.build_computational_graph((self.x,),  True)), 0)
+        _check(self, (self.x, ), False, 1, 0)
+        _check(self, (self.x, ), True, 1, 0)
 
     def test_intermediate_variable(self):
         # x-splitter-x'-f-y
-        self.assertEqual(len(c.build_computational_graph((self.y,), False)), 4)
+        _check(self, (self.y, ), False, 5, 4)
         # x-f-y (splitter removed)
-        self.assertEqual(len(c.build_computational_graph((self.y,),  True)), 2)
+        _check(self, (self.y, ), True, 3, 2)
 
     def test_tail_variable(self):
         # x-splitter-x'-f-y-splitter-y'-g-z
-        self.assertEqual(len(c.build_computational_graph((self.z,), False)), 8)
+        _check(self, (self.z, ), False, 9, 8)
         # x-f-y-g-z (splitter removed)
-        self.assertEqual(len(c.build_computational_graph((self.z,),  True)), 4)
+        _check(self, (self.z, ), True, 5, 4)
 
     def test_multiple_outputs(self):
-        edges = c.build_computational_graph((self.x, self.y), False)
-        self.assertEqual(len(edges), 4)
-        edges = c.build_computational_graph((self.x, self.y),  True)
-        self.assertEqual(len(edges), 2)
+        _check(self, (self.x, self.y), False, 5, 4)
+        _check(self, (self.x, self.y), True, 3, 2)
 
     def test_multiple_outputs2(self):
-        edges = c.build_computational_graph((self.x, self.z), False)
-        self.assertEqual(len(edges), 8)
-        edges = c.build_computational_graph((self.x, self.z),  True)
-        self.assertEqual(len(edges), 4)
+        _check(self, (self.x, self.z), False, 9, 8)
+        _check(self, (self.x, self.z), True, 5, 4)
 
     def test_multiple_outputs3(self):
-        edges = c.build_computational_graph((self.y, self.z), False)
-        self.assertEqual(len(edges), 8)
-        edges = c.build_computational_graph((self.y, self.z),  True)
-        self.assertEqual(len(edges), 4)
+        _check(self, (self.y, self.z), False, 9, 8)
+        _check(self, (self.y, self.z), True, 5, 4)
 
     def test_multiple_outputs4(self):
-        edges = c.build_computational_graph((self.x, self.y, self.z), False)
-        self.assertEqual(len(edges), 8)
-        edges = c.build_computational_graph((self.x, self.y, self.z),  True)
-        self.assertEqual(len(edges), 4)
+        _check(self, (self.x, self.y, self.z), False, 9, 8)
+        _check(self, (self.x, self.y, self.z), True, 5, 4)
 
 
 class TestGraphBuilder2(unittest.TestCase):
@@ -93,26 +91,20 @@ class TestGraphBuilder2(unittest.TestCase):
         self.y2 = mock_function((self.x,), 1)
 
     def test_head_node(self):
-        self.assertEqual(len(c.build_computational_graph((self.x,), False)), 0)
-        self.assertEqual(len(c.build_computational_graph((self.x,),  True)), 0)
+        _check(self, (self.x, ), False, 1, 0)
+        _check(self, (self.x, ), True, 1, 0)
 
     def test_tail_node(self):
-        edges = c.build_computational_graph((self.y1,), False)
-        self.assertEqual(len(edges), 4)
-        edges = c.build_computational_graph((self.y1,),  True)
-        self.assertEqual(len(edges), 2)
+        _check(self, (self.y1, ), False, 5, 4)
+        _check(self, (self.y1, ), True, 3, 2)
 
     def test_tail_node2(self):
-        edges = c.build_computational_graph((self.y2,), False)
-        self.assertEqual(len(edges), 4)
-        edges = c.build_computational_graph((self.y2,),  True)
-        self.assertEqual(len(edges), 2)
+        _check(self, (self.y2, ), False, 5, 4)
+        _check(self, (self.y2, ), True, 3, 2)
 
     def test_multiple_tails(self):
-        edges = c.build_computational_graph((self.y1, self.y2), False)
-        self.assertEqual(len(edges), 7)
-        edges = c.build_computational_graph((self.y1, self.y2),  True)
-        self.assertEqual(len(edges), 4)
+        _check(self, (self.y1, self.y2), False, 8, 7)
+        _check(self, (self.y1, self.y2), True, 5, 4)
 
 
 class TestGraphBuilder3(unittest.TestCase):
@@ -129,26 +121,20 @@ class TestGraphBuilder3(unittest.TestCase):
         self.y1, self.y2 = mock_function((self.x,), 2)
 
     def test_head_node(self):
-        self.assertEqual(len(c.build_computational_graph((self.x,), False)), 0)
-        self.assertEqual(len(c.build_computational_graph((self.x,),  True)), 0)
+        _check(self, (self.x, ), False, 1, 0)
+        _check(self, (self.x, ), True, 1, 0)
 
     def test_tail_node(self):
-        edges = c.build_computational_graph((self.y1,), False)
-        self.assertEqual(len(edges), 4)
-        edges = c.build_computational_graph((self.y1,),  True)
-        self.assertEqual(len(edges), 2)
+        _check(self, (self.y1, ), False, 5, 4)
+        _check(self, (self.y1, ), True, 3, 2)
 
     def test_tail_node2(self):
-        edges = c.build_computational_graph((self.y2,), False)
-        self.assertEqual(len(edges), 4)
-        edges = c.build_computational_graph((self.y2,),  True)
-        self.assertEqual(len(edges), 2)
+        _check(self, (self.y2, ), False, 5, 4)
+        _check(self, (self.y2, ), True, 3, 2)
 
     def test_multiple_tails(self):
-        edges = c.build_computational_graph((self.y1, self.y2), False)
-        self.assertEqual(len(edges), 5)
-        edges = c.build_computational_graph((self.y1, self.y2),  True)
-        self.assertEqual(len(edges), 3)
+        _check(self, (self.y1, self.y2), False, 6, 5)
+        _check(self, (self.y1, self.y2), True, 4, 3)
 
 
 class TestGraphBuilder4(unittest.TestCase):
@@ -166,28 +152,20 @@ class TestGraphBuilder4(unittest.TestCase):
         self.y = mock_function((self.x1, self.x2), 1)
 
     def test_head_node1(self):
-        edges = c.build_computational_graph((self.x1,), False)
-        self.assertEqual(len(edges), 0)
-        edges = c.build_computational_graph((self.x1,),  True)
-        self.assertEqual(len(edges), 0)
+        _check(self, (self.x1, ), False, 1, 0)
+        _check(self, (self.x1, ), True, 1, 0)
 
     def test_head_node2(self):
-        edges = c.build_computational_graph((self.x2,), False)
-        self.assertEqual(len(edges), 0)
-        edges = c.build_computational_graph((self.x2,),  True)
-        self.assertEqual(len(edges), 0)
+        _check(self, (self.x2, ), False, 1, 0)
+        _check(self, (self.x2, ), True, 1, 0)
 
     def test_multiple_heads(self):
-        edges = c.build_computational_graph((self.x1, self.x2), False)
-        self.assertEqual(len(edges), 0)
-        edges = c.build_computational_graph((self.x1, self.x2),  True)
-        self.assertEqual(len(edges), 0)
+        _check(self, (self.x1, self.x2), False, 2, 0)
+        _check(self, (self.x1, self.x2), True, 2, 0)
 
     def test_tail_node(self):
-        edges = c.build_computational_graph((self.y,), False)
-        self.assertEqual(len(edges), 7)
-        edges = c.build_computational_graph((self.y,),  True)
-        self.assertEqual(len(edges), 3)
+        _check(self, (self.y, ), False, 8, 7)
+        _check(self, (self.y, ), True, 4, 3)
 
 
 class TestGraphBuilder5(unittest.TestCase):
@@ -199,19 +177,38 @@ class TestGraphBuilder5(unittest.TestCase):
         self.x_clone = self.x_splitter.outputs[0]()
         self.f = self.y.creator
 
-    def test_tail_node(self):
-        edges = c.build_computational_graph((self.y,), False)
-        self.assertEqual(len(edges), 4)
-        self.assertTrue((self.x, self.x_splitter) in edges)
-        self.assertTrue((self.x_splitter, self.x_clone) in edges)
-        self.assertTrue((self.x_clone, self.f) in edges)
-        self.assertTrue((self.f, self.y) in edges)
+        self.g1 = c.build_computational_graph((self.y,), False)
+        self.g2 = c.build_computational_graph((self.y,), True)
 
-    def test_tail_node_remove_edge(self):
-        edges = c.build_computational_graph((self.y,), True)
-        self.assertEqual(len(edges), 2)
-        self.assertTrue((self.x, self.f) in edges)
-        self.assertTrue((self.f, self.y) in edges)
+    def test_edges(self):
+        self.assertEqual(len(self.g1.edges), 4)
+
+        self.assertTrue((self.x, self.x_splitter) in self.g1.edges)
+        self.assertTrue((self.x_splitter, self.x_clone) in self.g1.edges)
+        self.assertTrue((self.x_clone, self.f) in self.g1.edges)
+        self.assertTrue((self.f, self.y) in self.g1.edges)
+
+    def test_nodes(self):
+        self.assertEqual(len(self.g1.nodes), 5)
+
+        self.assertTrue(self.x in self.g1.nodes)
+        self.assertTrue(self.x_splitter in self.g1.nodes)
+        self.assertTrue(self.x_clone in self.g1.nodes)
+        self.assertTrue(self.f in self.g1.nodes)
+        self.assertTrue(self.y in self.g1.nodes)
+
+    def test_edges_remove_split(self):
+        self.assertEqual(len(self.g2.edges), 2)
+
+        self.assertTrue((self.x, self.f) in self.g2.edges)
+        self.assertTrue((self.f, self.y) in self.g2.edges)
+
+    def test_nodes_remove_split(self):
+        self.assertEqual(len(self.g2.nodes), 3)
+
+        self.assertTrue(self.x in self.g2.nodes)
+        self.assertTrue(self.f in self.g2.nodes)
+        self.assertTrue(self.y in self.g2.nodes)
 
 
 class TestGraphBuilder6(unittest.TestCase):
@@ -226,23 +223,50 @@ class TestGraphBuilder6(unittest.TestCase):
         self.x2_clone = self.x2_splitter.outputs[0]()
         self.f = self.y.creator
 
-    def test_tail_node(self):
-        edges = c.build_computational_graph((self.y,), False)
-        self.assertEqual(len(edges), 7)
-        self.assertTrue((self.x1, self.x1_splitter) in edges)
-        self.assertTrue((self.x1_splitter, self.x1_clone) in edges)
-        self.assertTrue((self.x1_clone, self.f) in edges)
-        self.assertTrue((self.x2, self.x2_splitter) in edges)
-        self.assertTrue((self.x2_splitter, self.x2_clone) in edges)
-        self.assertTrue((self.x2_clone, self.f) in edges)
-        self.assertTrue((self.f, self.y) in edges)
+        self.g1 = c.build_computational_graph((self.y,), False)
+        self.g2 = c.build_computational_graph((self.y,), True)
 
-    def test_tail_node_remove_edge(self):
-        edges = c.build_computational_graph((self.y,), True)
-        self.assertEqual(len(edges), 3)
-        self.assertTrue((self.x1, self.f) in edges)
-        self.assertTrue((self.x2, self.f) in edges)
-        self.assertTrue((self.f, self.y) in edges)
+    def test_edges(self):
+        self.assertEqual(len(self.g1.edges), 7)
+
+        self.assertTrue((self.x1, self.x1_splitter) in self.g1.edges)
+        self.assertTrue((self.x1_splitter, self.x1_clone) in self.g1.edges)
+        self.assertTrue((self.x1_clone, self.f) in self.g1.edges)
+
+        self.assertTrue((self.x2, self.x2_splitter) in self.g1.edges)
+        self.assertTrue((self.x2_splitter, self.x2_clone) in self.g1.edges)
+        self.assertTrue((self.x2_clone, self.f) in self.g1.edges)
+
+        self.assertTrue((self.f, self.y) in self.g1.edges)
+
+    def test_nodes(self):
+        self.assertEqual(len(self.g1.nodes), 8)
+
+        self.assertTrue(self.x1 in self.g1.nodes)
+        self.assertTrue(self.x1_splitter in self.g1.nodes)
+        self.assertTrue(self.x1_clone in self.g1.nodes)
+
+        self.assertTrue(self.x2 in self.g1.nodes)
+        self.assertTrue(self.x2_splitter in self.g1.nodes)
+        self.assertTrue(self.x2_clone in self.g1.nodes)
+
+        self.assertTrue(self.f in self.g1.nodes)
+        self.assertTrue(self.y in self.g1.nodes)
+
+    def test_edges_remove_split(self):
+        self.assertEqual(len(self.g2.edges), 3)
+
+        self.assertTrue((self.x1, self.f) in self.g2.edges)
+        self.assertTrue((self.x2, self.f) in self.g2.edges)
+        self.assertTrue((self.f, self.y) in self.g2.edges)
+
+    def test_nodes_remove_split(self):
+        self.assertEqual(len(self.g2.edges), 3)
+
+        self.assertTrue(self.x1 in self.g2.nodes)
+        self.assertTrue(self.x2 in self.g2.nodes)
+        self.assertTrue(self.f in self.g2.nodes)
+        self.assertTrue(self.y in self.g2.nodes)
 
 
 class TestGraphBuilder7(unittest.TestCase):
@@ -253,9 +277,5 @@ class TestGraphBuilder7(unittest.TestCase):
         self.y = 0.3 * (self.x1 + self.x2) + self.x3
 
     def test_tail_node(self):
-        edges = c.build_computational_graph((self.y,), False)
-        self.assertEqual(len(edges), 18)
-
-    def test_tail_node_remove_edge(self):
-        edges = c.build_computational_graph((self.y,), True)
-        self.assertEqual(len(edges), 8)
+        _check(self, (self.y, ), False, 19, 18)
+        _check(self, (self.y, ), True, 9, 8)


### PR DESCRIPTION
Currently, `ComputationalGraph` is essentially a list of edges. So if we run `build_computational_graph` with variables part of which is unchained, the unchained variables are missing from the resulting computational graph. Further, if all of variables are unchained, the graph is empty set and no graph is plotted. This specification is not intuitive. 

This PR adds nodes to computational graph so that such isolated variables are restored.