### PR TITLE
Add test decorators that make test cases run multiple times

### DIFF
--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -13,15 +13,15 @@ class QuietTestRunner(object):
 
 
 def repeat_with_success_at_least(times, min_success):
-    """Decorator for multiple trial of the test case
+    """Decorator for multiple trial of the test case.
 
-    Decorated test case is launched multiple times.
+    The decorated test case is launched multiple times.
     The case is judged as passed at least specified number of trials.
     If the number of successful trials exceeds `min_success`,
     the remaining trials are skipped.
 
     Args:
-        times(int): The number of trials
+        times(int): The number of trials.
         min_success(int): Threshold that the decorated test
             case is regarded as passed.
 

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -11,11 +11,10 @@ class QuietTestRunner(object):
         return result
 
 
-def success_at_least(times, min_success):
+def repeat_with_success_at_least(times, min_success):
     assert times >= min_success
 
-    def _multiple(f):
-
+    def _repeat_with_success_at_least(f):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
             assert len(args) > 0
@@ -39,5 +38,6 @@ def success_at_least(times, min_success):
     return _repeat_with_success_at_least
 
 
-def all_success(times):
-    return success_at_least(times, times)
+def repeat(times):
+    return repeat_with_success_at_least(times, times)
+

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -33,8 +33,8 @@ def repeat_with_success_at_least(times, min_success):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
             assert len(args) > 0
-            cls = args[0]
-            assert isinstance(cls, unittest.TestCase)
+            instance = args[0]
+            assert isinstance(instance, unittest.TestCase)
             success_counter = 0
             failure_counter = 0
             for _ in six.moves.range(times):
@@ -42,19 +42,20 @@ def repeat_with_success_at_least(times, min_success):
                 suite.addTest(
                     unittest.FunctionTestCase(
                         lambda: f(*args, **kwargs),
-                        setUp=cls.setUp,
-                        tearDown=cls.tearDown))
+                        setUp=instance.setUp,
+                        tearDown=instance.tearDown))
 
                 if QuietTestRunner().run(suite).wasSuccessful():
                     success_counter += 1
-                    if success_counter >= min_success:
-                        cls.assertTrue(True)
-                        return
                 else:
                     failure_counter += 1
-                    if failure_counter > times - min_success:
-                        cls.fail()
-            cls.fail()
+                if success_counter >= min_success:
+                    instance.assertTrue(True)
+                    return
+                if failure_counter > times - min_success:
+                    instance.fail()
+                    return
+            instance.fail()
         return wrapper
     return _repeat_with_success_at_least
 

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -12,6 +12,20 @@ class QuietTestRunner(object):
 
 
 def repeat_with_success_at_least(times, min_success):
+    """Decorator for multiple trial of the test case
+
+    Decorated test case is launched multiple times.
+    The case is judged as passed at least specified number of trials.
+    If the number of successful trials exceeds `min_success`,
+    the remaining trials are skipped.
+
+    Args:
+        times(int): The number of trials
+        min_success(int): Threshold that the decorated test
+            case is regarded as passed.
+
+    """
+
     assert times >= min_success
 
     def _repeat_with_success_at_least(f):
@@ -39,8 +53,26 @@ def repeat_with_success_at_least(times, min_success):
 
 
 def repeat(times):
+    """Decorator that imposes the test to be successful in a row.
+
+    Decorated test case is launched multiple times.
+    The case is regarded as passed only if it is successful
+    specified times in a row.
+
+    Args:
+        times(int): The number of trials.
+    """
     return repeat_with_success_at_least(times, times)
 
 
 def retry(times):
+    """Decorator that imposes the test to be successful at least once.
+
+    Decorated test case is launched multiple times.
+    The case is regarded as passed if it is successful
+    at least once.
+
+    Args:
+        times(int): The number of trials.
+    """
     return repeat_with_success_at_least(times, 1)

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -35,6 +35,7 @@ def repeat_with_success_at_least(times, min_success):
             cls = args[0]
             assert isinstance(cls, unittest.TestCase)
             success_counter = 0
+            failure_counter = 0
             for _ in six.moves.range(times):
                 suite = unittest.TestSuite()
                 suite.addTest(
@@ -42,11 +43,16 @@ def repeat_with_success_at_least(times, min_success):
                         lambda: f(*args, **kwargs),
                         setUp=cls.setUp,
                         tearDown=cls.tearDown))
+
                 if QuietTestRunner().run(suite).wasSuccessful():
                     success_counter += 1
-                if success_counter >= min_success:
-                    cls.assertTrue(True)
-                    return
+                    if success_counter >= min_success:
+                        cls.assertTrue(True)
+                        return
+                else:
+                    failure_counter += 1
+                    if failure_counter > times - min_success:
+                        cls.fail()
             cls.fail()
         return wrapper
     return _repeat_with_success_at_least

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -21,21 +21,8 @@ def success_at_least(times, min_success):
             assert len(args) > 0
             cls = args[0]
             assert isinstance(cls, unittest.TestCase)
-
-            suite = unittest.TestSuite()
-            for _ in six.moves.range(min_success):
-                suite.addTest(
-                    unittest.FunctionTestCase(
-                        lambda: f(*args, **kwargs),
-                        setUp=cls.setUp,
-                        tearDown=cls.tearDown))
-            success_counter = (min_success -
-                               len(QuietTestRunner().run(suite).failures))
-            if success_counter >= min_success:
-                cls.assertTrue(True)
-                return
-
-            for _ in six.moves.range(min_success, times):
+            success_counter = 0
+            for _ in six.moves.range(times):
                 suite = unittest.TestSuite()
                 suite.addTest(
                     unittest.FunctionTestCase(
@@ -47,10 +34,9 @@ def success_at_least(times, min_success):
                 if success_counter >= min_success:
                     cls.assertTrue(True)
                     return
-
             cls.fail()
         return wrapper
-    return _multiple
+    return _repeat_with_success_at_least
 
 
 def all_success(times):

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -20,6 +20,12 @@ def repeat_with_success_at_least(times, min_success):
     If the number of successful trials exceeds `min_success`,
     the remaining trials are skipped.
 
+    .. note::
+        In current implementation, this decorator grasps the
+        failure information of each trial. This specification is not desirable
+        for debugging. We should as much failure information as possible.
+        This problem will be issued.
+
     Args:
         times(int): The number of trials.
         min_success(int): Threshold that the decorated test
@@ -67,6 +73,10 @@ def repeat(times):
     The case is regarded as passed only if it is successful
     specified times in a row.
 
+    .. note::
+        In current implementation, this decorator grasps the
+        failure information of each trial.
+
     Args:
         times(int): The number of trials.
     """
@@ -79,6 +89,10 @@ def retry(times):
     Decorated test case is launched multiple times.
     The case is regarded as passed if it is successful
     at least once.
+
+    .. note::
+        In current implementation, this decorator grasps the
+        failure information of each trial.
 
     Args:
         times(int): The number of trials.

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -41,3 +41,6 @@ def repeat_with_success_at_least(times, min_success):
 def repeat(times):
     return repeat_with_success_at_least(times, times)
 
+
+def retry(times):
+    return repeat_with_success_at_least(times, 1)

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -1,0 +1,57 @@
+import functools
+import unittest
+
+import six
+
+
+class QuietTestRunner(object):
+    def run(self, suite):
+        result = unittest.TestResult()
+        suite(result)
+        return result
+
+
+def success_at_least(times, min_success):
+    assert times >= min_success
+
+    def _multiple(f):
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            assert len(args) > 0
+            cls = args[0]
+            assert isinstance(cls, unittest.TestCase)
+
+            suite = unittest.TestSuite()
+            for _ in six.moves.range(min_success):
+                suite.addTest(
+                    unittest.FunctionTestCase(
+                        lambda: f(*args, **kwargs),
+                        setUp=cls.setUp,
+                        tearDown=cls.tearDown))
+            success_counter = (min_success -
+                               len(QuietTestRunner().run(suite).failures))
+            if success_counter >= min_success:
+                cls.assertTrue(True)
+                return
+
+            for _ in six.moves.range(min_success, times):
+                suite = unittest.TestSuite()
+                suite.addTest(
+                    unittest.FunctionTestCase(
+                        lambda: f(*args, **kwargs),
+                        setUp=cls.setUp,
+                        tearDown=cls.tearDown))
+                if QuietTestRunner().run(suite).wasSuccessful():
+                    success_counter += 1
+                if success_counter >= min_success:
+                    cls.assertTrue(True)
+                    return
+
+            cls.fail()
+        return wrapper
+    return _multiple
+
+
+def all_success(times):
+    return success_at_least(times, times)

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -5,6 +5,7 @@ import six
 
 
 class QuietTestRunner(object):
+
     def run(self, suite):
         result = unittest.TestResult()
         suite(result)

--- a/tests/functions_tests/test_accuracy.py
+++ b/tests/functions_tests/test_accuracy.py
@@ -35,11 +35,11 @@ class TestAccuracy(unittest.TestCase):
         expected = float(count) / self.t.size
         gradient_check.assert_allclose(expected, cuda.to_cpu(y.data))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))

--- a/tests/functions_tests/test_accuracy.py
+++ b/tests/functions_tests/test_accuracy.py
@@ -7,6 +7,7 @@ import chainer
 from chainer import cuda
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -34,9 +35,11 @@ class TestAccuracy(unittest.TestCase):
         expected = float(count) / self.t.size
         gradient_check.assert_allclose(expected, cuda.to_cpu(y.data))
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -7,7 +7,7 @@ from chainer import cuda
 import chainer.functions as F
 from chainer import gradient_check
 from chainer.testing import attr
-
+from chainer.testing import condition
 
 if cuda.available:
     cuda.init()
@@ -32,33 +32,43 @@ class BinaryOpTestBase(object):
     def forward_cpu(self, op):
         self.check_forward(op, self.x1, self.x2)
 
+    @condition.success_at_least(3, 1)
     def test_add_forward_cpu(self):
         self.forward_cpu(lambda x, y: x + y)
 
+    @condition.success_at_least(3, 1)
     def test_sub_forward_cpu(self):
         self.forward_cpu(lambda x, y: x - y)
 
+    @condition.success_at_least(3, 1)
     def test_mul_forward_cpu(self):
         self.forward_cpu(lambda x, y: x * y)
 
+    @condition.success_at_least(3, 1)
     def test_div_forward_cpu(self):
         self.forward_cpu(lambda x, y: x / y)
 
+    @condition.success_at_least(3, 1)
     def test_pow_forward_cpu(self):
         self.forward_cpu(lambda x, y: x ** y)
 
+    @condition.success_at_least(3, 1)
     def test_radd_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__radd__(x))
 
+    @condition.success_at_least(3, 1)
     def test_rsub_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rsub__(x))
 
+    @condition.success_at_least(3, 1)
     def test_rmul_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rmul__(x))
 
+    @condition.success_at_least(3, 1)
     def test_rdiv_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rtruediv__(x))
 
+    @condition.success_at_least(3, 1)
     def test_rpow_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rpow__(x))
 
@@ -66,42 +76,52 @@ class BinaryOpTestBase(object):
         self.check_forward(op, cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_add_forward_gpu(self):
         self.forward_gpu(lambda x, y: x + y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_sub_forward_gpu(self):
         self.forward_gpu(lambda x, y: x - y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_mul_forward_gpu(self):
         self.forward_gpu(lambda x, y: x * y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_div_forward_gpu(self):
         self.forward_gpu(lambda x, y: x / y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_pow_forward_gpu(self):
         self.forward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_radd_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__radd__(x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rsub_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rsub__(x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rmul_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rmul__(x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rdiv_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rtruediv__(x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rpow_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rpow__(x))
 
@@ -130,18 +150,23 @@ class BinaryOpTestBase(object):
     def backward_cpu(self, op, atol=1e-5):
         self.check_backward(op, self.x1, self.x2, self.gy, atol)
 
+    @condition.success_at_least(3, 1)
     def test_add_backward_cpu(self):
         self.backward_cpu(lambda x, y: x + y)
 
+    @condition.success_at_least(3, 1)
     def test_sub_backward_cpu(self):
         self.backward_cpu(lambda x, y: x - y)
 
+    @condition.success_at_least(3, 1)
     def test_mul_backward_cpu(self):
         self.backward_cpu(lambda x, y: x * y)
 
+    @condition.success_at_least(3, 1)
     def test_div_backward_cpu(self):
         self.backward_cpu(lambda x, y: x / y)
 
+    @condition.success_at_least(3, 1)
     def test_pow_backward_cpu(self):
         self.backward_cpu(lambda x, y: x ** y, atol=1e-4)
 
@@ -151,22 +176,27 @@ class BinaryOpTestBase(object):
             cuda.to_gpu(self.gy), atol)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_add_backward_gpu(self):
         self.backward_gpu(lambda x, y: x + y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_sub_backward_gpu(self):
         self.backward_gpu(lambda x, y: x - y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_mul_backward_gpu(self):
         self.backward_gpu(lambda x, y: x * y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_div_backward_gpu(self):
         self.backward_gpu(lambda x, y: x / y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_pow_backward_gpu(self):
         self.backward_gpu(lambda x, y: x ** y, atol=1e-4)
 
@@ -206,33 +236,43 @@ class VariableConstantOpTestBase(object):
     def forward_cpu(self, op):
         self.check_forward(op, self.x)
 
+    @condition.success_at_least(3, 1)
     def test_add_forward_cpu(self):
         self.forward_cpu(lambda x, y: x + y)
 
+    @condition.success_at_least(3, 1)
     def test_radd_forward_cpu(self):
         self.forward_cpu(lambda x, y: y + x)
 
+    @condition.success_at_least(3, 1)
     def test_sub_forward_cpu(self):
         self.forward_cpu(lambda x, y: x - y)
 
+    @condition.success_at_least(3, 1)
     def test_rsub_forward_cpu(self):
         self.forward_cpu(lambda x, y: y - x)
 
+    @condition.success_at_least(3, 1)
     def test_mul_forward_cpu(self):
         self.forward_cpu(lambda x, y: x * y)
 
+    @condition.success_at_least(3, 1)
     def test_rmul_forward_cpu(self):
         self.forward_cpu(lambda x, y: y * x)
 
+    @condition.success_at_least(3, 1)
     def test_div_forward_cpu(self):
         self.forward_cpu(lambda x, y: x / y)
 
+    @condition.success_at_least(3, 1)
     def test_rdiv_forward_cpu(self):
         self.forward_cpu(lambda x, y: y / x)
 
+    @condition.success_at_least(3, 1)
     def test_pow_forward_cpu(self):
         self.forward_cpu(lambda x, y: x ** y)
 
+    @condition.success_at_least(3, 1)
     def test_rpow_forward_cpu(self):
         self.forward_cpu(lambda x, y: y ** x)
 
@@ -240,42 +280,52 @@ class VariableConstantOpTestBase(object):
         self.check_forward(op, cuda.to_gpu(self.x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_add_forward_gpu(self):
         self.forward_gpu(lambda x, y: x + y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_radd_forward_gpu(self):
         self.forward_gpu(lambda x, y: y + x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_sub_forward_gpu(self):
         self.forward_gpu(lambda x, y: x - y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rsub_forward_gpu(self):
         self.forward_gpu(lambda x, y: y - x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_mul_forward_gpu(self):
         self.forward_gpu(lambda x, y: x * y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rmul_forward_gpu(self):
         self.forward_gpu(lambda x, y: y * x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_div_forward_gpu(self):
         self.forward_gpu(lambda x, y: x / y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rdiv_forward_gpu(self):
         self.forward_gpu(lambda x, y: y / x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_pow_forward_gpu(self):
         self.forward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rpow_forward_gpu(self):
         self.forward_gpu(lambda x, y: y ** x)
 
@@ -294,33 +344,43 @@ class VariableConstantOpTestBase(object):
     def backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)
 
+    @condition.success_at_least(3, 1)
     def test_add_backward_cpu(self):
         self.backward_cpu(lambda x, y: x + y)
 
+    @condition.success_at_least(3, 1)
     def test_radd_backward_cpu(self):
         self.backward_cpu(lambda x, y: y + x)
 
+    @condition.success_at_least(3, 1)
     def test_sub_backward_cpu(self):
         self.backward_cpu(lambda x, y: x - y)
 
+    @condition.success_at_least(3, 1)
     def test_rsub_backward_cpu(self):
         self.backward_cpu(lambda x, y: y - x)
 
+    @condition.success_at_least(3, 1)
     def test_mul_backward_cpu(self):
         self.backward_cpu(lambda x, y: x * y)
 
+    @condition.success_at_least(3, 1)
     def test_rmul_backward_cpu(self):
         self.backward_cpu(lambda x, y: y * x)
 
+    @condition.success_at_least(3, 1)
     def test_div_backward_cpu(self):
         self.backward_cpu(lambda x, y: x / y)
 
+    @condition.success_at_least(3, 1)
     def test_rdiv_backward_cpu(self):
         self.backward_cpu(lambda x, y: y / x)
 
+    @condition.success_at_least(3, 1)
     def test_pow_backward_cpu(self):
         self.backward_cpu(lambda x, y: x ** y)
 
+    @condition.success_at_least(3, 1)
     def test_rpow_backward_cpu(self):
         self.backward_cpu(lambda x, y: y ** x)
 
@@ -328,42 +388,52 @@ class VariableConstantOpTestBase(object):
         self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_add_backward_gpu(self):
         self.backward_gpu(lambda x, y: x + y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_radd_backward_gpu(self):
         self.backward_gpu(lambda x, y: y + x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_sub_backward_gpu(self):
         self.backward_gpu(lambda x, y: x - y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rsub_backward_gpu(self):
         self.backward_gpu(lambda x, y: y - x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_mul_backward_gpu(self):
         self.backward_gpu(lambda x, y: x * y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rmul_backward_gpu(self):
         self.backward_gpu(lambda x, y: y * x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_div_backward_gpu(self):
         self.backward_gpu(lambda x, y: x / y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rdiv_backward_gpu(self):
         self.backward_gpu(lambda x, y: y / x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_pow_backward_gpu(self):
         self.backward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rpow_backward_gpu(self):
         self.backward_gpu(lambda x, y: y ** x)
 
@@ -410,33 +480,43 @@ class TestVariableConstantArrayOp(unittest.TestCase):
     def forward_cpu(self, op, positive=False):
         self.check_forward(op, self.x, False, positive)
 
+    @condition.success_at_least(3, 1)
     def test_add_forward_cpu(self):
         self.forward_cpu(lambda x, y: x + y)
 
+    @condition.success_at_least(3, 1)
     def test_radd_forward_cpu(self):
         self.forward_cpu(lambda x, y: y + x)
 
+    @condition.success_at_least(3, 1)
     def test_sub_forward_cpu(self):
         self.forward_cpu(lambda x, y: x - y)
 
+    @condition.success_at_least(3, 1)
     def test_rsub_forward_cpu(self):
         self.forward_cpu(lambda x, y: y - x)
 
+    @condition.success_at_least(3, 1)
     def test_mul_forward_cpu(self):
         self.forward_cpu(lambda x, y: x * y)
 
+    @condition.success_at_least(3, 1)
     def test_rmul_forward_cpu(self):
         self.forward_cpu(lambda x, y: y * x)
 
+    @condition.success_at_least(3, 1)
     def test_div_forward_cpu(self):
         self.forward_cpu(lambda x, y: x / y)
 
+    @condition.success_at_least(3, 1)
     def test_rdiv_forward_cpu(self):
         self.forward_cpu(lambda x, y: y / x)
 
+    @condition.success_at_least(3, 1)
     def test_pow_forward_cpu(self):
         self.forward_cpu(lambda x, y: x ** y)
 
+    @condition.success_at_least(3, 1)
     def test_rpow_forward_cpu(self):
         self.forward_cpu(lambda x, y: y ** x, positive=True)
 
@@ -444,42 +524,52 @@ class TestVariableConstantArrayOp(unittest.TestCase):
         self.check_forward(op, cuda.to_gpu(self.x), True, positive)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_add_forward_gpu(self):
         self.forward_gpu(lambda x, y: x + y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_radd_forward_gpu(self):
         self.forward_gpu(lambda x, y: y + x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_sub_forward_gpu(self):
         self.forward_gpu(lambda x, y: x - y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rsub_forward_gpu(self):
         self.forward_gpu(lambda x, y: y - x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_mul_forward_gpu(self):
         self.forward_gpu(lambda x, y: x * y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rmul_forward_gpu(self):
         self.forward_gpu(lambda x, y: y * x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_div_forward_gpu(self):
         self.forward_gpu(lambda x, y: x / y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rdiv_forward_gpu(self):
         self.forward_gpu(lambda x, y: y / x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_pow_forward_gpu(self):
         self.forward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rpow_forward_gpu(self):
         self.forward_gpu(lambda x, y: y ** x, positive=True)
 
@@ -503,33 +593,43 @@ class TestVariableConstantArrayOp(unittest.TestCase):
     def backward_cpu(self, op, positive=False):
         self.check_backward(op, self.x, self.gy, False, positive)
 
+    @condition.success_at_least(3, 1)
     def test_add_backward_cpu(self):
         self.backward_cpu(lambda x, y: x + y)
 
+    @condition.success_at_least(3, 1)
     def test_radd_backward_cpu(self):
         self.backward_cpu(lambda x, y: y + x)
 
+    @condition.success_at_least(3, 1)
     def test_sub_backward_cpu(self):
         self.backward_cpu(lambda x, y: x - y)
 
+    @condition.success_at_least(3, 1)
     def test_rsub_backward_cpu(self):
         self.backward_cpu(lambda x, y: y - x)
 
+    @condition.success_at_least(3, 1)
     def test_mul_backward_cpu(self):
         self.backward_cpu(lambda x, y: x * y)
 
+    @condition.success_at_least(3, 1)
     def test_rmul_backward_cpu(self):
         self.backward_cpu(lambda x, y: y * x)
 
+    @condition.success_at_least(3, 1)
     def test_div_backward_cpu(self):
         self.backward_cpu(lambda x, y: x / y)
 
+    @condition.success_at_least(3, 1)
     def test_rdiv_backward_cpu(self):
         self.backward_cpu(lambda x, y: y / x)
 
+    @condition.success_at_least(3, 1)
     def test_pow_backward_cpu(self):
         self.backward_cpu(lambda x, y: x ** y)
 
+    @condition.success_at_least(3, 1)
     def test_rpow_backward_cpu(self):
         self.backward_cpu(lambda x, y: y ** x, positive=True)
 
@@ -538,38 +638,47 @@ class TestVariableConstantArrayOp(unittest.TestCase):
             op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy), True, positive)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_add_backward_gpu(self):
         self.backward_gpu(lambda x, y: x + y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_radd_backward_gpu(self):
         self.backward_gpu(lambda x, y: y + x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_sub_backward_gpu(self):
         self.backward_gpu(lambda x, y: x - y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_mul_backward_gpu(self):
         self.backward_gpu(lambda x, y: x * y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rmul_backward_gpu(self):
         self.backward_gpu(lambda x, y: y * x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_div_backward_gpu(self):
         self.backward_gpu(lambda x, y: x / y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rdiv_backward_gpu(self):
         self.backward_gpu(lambda x, y: y / x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_pow_backward_gpu(self):
         self.backward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_rpow_backward_gpu(self):
         self.backward_gpu(lambda x, y: y ** x, positive=True)
 
@@ -591,15 +700,19 @@ class UnaryFunctionsTestBase(object):
     def forward_cpu(self, op, op_np):
         self.check_forward(op, op_np, self.x)
 
+    @condition.success_at_least(3, 1)
     def test_neg_forward_cpu(self):
         self.forward_cpu(lambda x: -x, lambda x: -x)
 
+    @condition.success_at_least(3, 1)
     def test_abs_forward_cpu(self):
         self.forward_cpu(lambda x: abs(x), lambda x: abs(x))
 
+    @condition.success_at_least(3, 1)
     def test_exp_forward_cpu(self):
         self.forward_cpu(F.exp, numpy.exp)
 
+    @condition.success_at_least(3, 1)
     def test_log_forward_cpu(self):
         self.forward_cpu(F.log, numpy.log)
 
@@ -607,18 +720,22 @@ class UnaryFunctionsTestBase(object):
         self.check_forward(op, op_np, cuda.to_gpu(self.x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_neg_forward_gpu(self):
         self.forward_gpu(lambda x: -x, lambda x: -x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_abs_forward_gpu(self):
         self.forward_gpu(lambda x: abs(x), lambda x: abs(x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_exp_forward_gpu(self):
         self.forward_gpu(F.exp, numpy.exp)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_log_forward_gpu(self):
         self.forward_gpu(F.log, numpy.log)
 
@@ -637,15 +754,19 @@ class UnaryFunctionsTestBase(object):
     def backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)
 
+    @condition.success_at_least(3, 1)
     def test_neg_backward_cpu(self):
         self.backward_cpu(lambda x: -x)
 
+    @condition.success_at_least(3, 1)
     def test_abs_backward_cpu(self):
         self.backward_cpu(lambda x: abs(x))
 
+    @condition.success_at_least(3, 1)
     def test_exp_backward_cpu(self):
         self.backward_cpu(F.exp)
 
+    @condition.success_at_least(3, 1)
     def test_log_backward_cpu(self):
         self.backward_cpu(F.log)
 
@@ -653,18 +774,22 @@ class UnaryFunctionsTestBase(object):
         self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_neg_backward_gpu(self):
         self.backward_gpu(lambda x: -x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_abs_backward_gpu(self):
         self.backward_gpu(lambda x: abs(x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_exp_backward_gpu(self):
         self.backward_gpu(F.exp)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_log_backward_gpu(self):
         self.backward_gpu(F.log)
 

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -9,6 +9,7 @@ from chainer import gradient_check
 from chainer.testing import attr
 from chainer.testing import condition
 
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -32,43 +32,43 @@ class BinaryOpTestBase(object):
     def forward_cpu(self, op):
         self.check_forward(op, self.x1, self.x2)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_forward_cpu(self):
         self.forward_cpu(lambda x, y: x + y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_forward_cpu(self):
         self.forward_cpu(lambda x, y: x - y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_forward_cpu(self):
         self.forward_cpu(lambda x, y: x * y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_forward_cpu(self):
         self.forward_cpu(lambda x, y: x / y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_forward_cpu(self):
         self.forward_cpu(lambda x, y: x ** y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__radd__(x))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rsub__(x))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rmul__(x))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rtruediv__(x))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_forward_cpu(self):
         self.forward_cpu(lambda x, y: y.__rpow__(x))
 
@@ -76,52 +76,52 @@ class BinaryOpTestBase(object):
         self.check_forward(op, cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_forward_gpu(self):
         self.forward_gpu(lambda x, y: x + y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_forward_gpu(self):
         self.forward_gpu(lambda x, y: x - y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_forward_gpu(self):
         self.forward_gpu(lambda x, y: x * y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_forward_gpu(self):
         self.forward_gpu(lambda x, y: x / y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_forward_gpu(self):
         self.forward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__radd__(x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rsub__(x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rmul__(x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rtruediv__(x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_forward_gpu(self):
         self.forward_gpu(lambda x, y: y.__rpow__(x))
 
@@ -150,23 +150,23 @@ class BinaryOpTestBase(object):
     def backward_cpu(self, op, atol=1e-5):
         self.check_backward(op, self.x1, self.x2, self.gy, atol)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_backward_cpu(self):
         self.backward_cpu(lambda x, y: x + y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_backward_cpu(self):
         self.backward_cpu(lambda x, y: x - y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_backward_cpu(self):
         self.backward_cpu(lambda x, y: x * y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_backward_cpu(self):
         self.backward_cpu(lambda x, y: x / y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_backward_cpu(self):
         self.backward_cpu(lambda x, y: x ** y, atol=1e-4)
 
@@ -176,27 +176,27 @@ class BinaryOpTestBase(object):
             cuda.to_gpu(self.gy), atol)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_backward_gpu(self):
         self.backward_gpu(lambda x, y: x + y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_backward_gpu(self):
         self.backward_gpu(lambda x, y: x - y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_backward_gpu(self):
         self.backward_gpu(lambda x, y: x * y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_backward_gpu(self):
         self.backward_gpu(lambda x, y: x / y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_backward_gpu(self):
         self.backward_gpu(lambda x, y: x ** y, atol=1e-4)
 
@@ -236,43 +236,43 @@ class VariableConstantOpTestBase(object):
     def forward_cpu(self, op):
         self.check_forward(op, self.x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_forward_cpu(self):
         self.forward_cpu(lambda x, y: x + y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_forward_cpu(self):
         self.forward_cpu(lambda x, y: y + x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_forward_cpu(self):
         self.forward_cpu(lambda x, y: x - y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_forward_cpu(self):
         self.forward_cpu(lambda x, y: y - x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_forward_cpu(self):
         self.forward_cpu(lambda x, y: x * y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_forward_cpu(self):
         self.forward_cpu(lambda x, y: y * x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_forward_cpu(self):
         self.forward_cpu(lambda x, y: x / y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_forward_cpu(self):
         self.forward_cpu(lambda x, y: y / x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_forward_cpu(self):
         self.forward_cpu(lambda x, y: x ** y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_forward_cpu(self):
         self.forward_cpu(lambda x, y: y ** x)
 
@@ -280,52 +280,52 @@ class VariableConstantOpTestBase(object):
         self.check_forward(op, cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_forward_gpu(self):
         self.forward_gpu(lambda x, y: x + y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_forward_gpu(self):
         self.forward_gpu(lambda x, y: y + x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_forward_gpu(self):
         self.forward_gpu(lambda x, y: x - y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_forward_gpu(self):
         self.forward_gpu(lambda x, y: y - x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_forward_gpu(self):
         self.forward_gpu(lambda x, y: x * y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_forward_gpu(self):
         self.forward_gpu(lambda x, y: y * x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_forward_gpu(self):
         self.forward_gpu(lambda x, y: x / y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_forward_gpu(self):
         self.forward_gpu(lambda x, y: y / x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_forward_gpu(self):
         self.forward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_forward_gpu(self):
         self.forward_gpu(lambda x, y: y ** x)
 
@@ -344,43 +344,43 @@ class VariableConstantOpTestBase(object):
     def backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_backward_cpu(self):
         self.backward_cpu(lambda x, y: x + y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_backward_cpu(self):
         self.backward_cpu(lambda x, y: y + x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_backward_cpu(self):
         self.backward_cpu(lambda x, y: x - y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_backward_cpu(self):
         self.backward_cpu(lambda x, y: y - x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_backward_cpu(self):
         self.backward_cpu(lambda x, y: x * y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_backward_cpu(self):
         self.backward_cpu(lambda x, y: y * x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_backward_cpu(self):
         self.backward_cpu(lambda x, y: x / y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_backward_cpu(self):
         self.backward_cpu(lambda x, y: y / x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_backward_cpu(self):
         self.backward_cpu(lambda x, y: x ** y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_backward_cpu(self):
         self.backward_cpu(lambda x, y: y ** x)
 
@@ -388,52 +388,52 @@ class VariableConstantOpTestBase(object):
         self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_backward_gpu(self):
         self.backward_gpu(lambda x, y: x + y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_backward_gpu(self):
         self.backward_gpu(lambda x, y: y + x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_backward_gpu(self):
         self.backward_gpu(lambda x, y: x - y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_backward_gpu(self):
         self.backward_gpu(lambda x, y: y - x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_backward_gpu(self):
         self.backward_gpu(lambda x, y: x * y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_backward_gpu(self):
         self.backward_gpu(lambda x, y: y * x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_backward_gpu(self):
         self.backward_gpu(lambda x, y: x / y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_backward_gpu(self):
         self.backward_gpu(lambda x, y: y / x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_backward_gpu(self):
         self.backward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_backward_gpu(self):
         self.backward_gpu(lambda x, y: y ** x)
 
@@ -480,43 +480,43 @@ class TestVariableConstantArrayOp(unittest.TestCase):
     def forward_cpu(self, op, positive=False):
         self.check_forward(op, self.x, False, positive)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_forward_cpu(self):
         self.forward_cpu(lambda x, y: x + y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_forward_cpu(self):
         self.forward_cpu(lambda x, y: y + x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_forward_cpu(self):
         self.forward_cpu(lambda x, y: x - y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_forward_cpu(self):
         self.forward_cpu(lambda x, y: y - x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_forward_cpu(self):
         self.forward_cpu(lambda x, y: x * y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_forward_cpu(self):
         self.forward_cpu(lambda x, y: y * x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_forward_cpu(self):
         self.forward_cpu(lambda x, y: x / y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_forward_cpu(self):
         self.forward_cpu(lambda x, y: y / x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_forward_cpu(self):
         self.forward_cpu(lambda x, y: x ** y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_forward_cpu(self):
         self.forward_cpu(lambda x, y: y ** x, positive=True)
 
@@ -524,52 +524,52 @@ class TestVariableConstantArrayOp(unittest.TestCase):
         self.check_forward(op, cuda.to_gpu(self.x), True, positive)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_forward_gpu(self):
         self.forward_gpu(lambda x, y: x + y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_forward_gpu(self):
         self.forward_gpu(lambda x, y: y + x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_forward_gpu(self):
         self.forward_gpu(lambda x, y: x - y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_forward_gpu(self):
         self.forward_gpu(lambda x, y: y - x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_forward_gpu(self):
         self.forward_gpu(lambda x, y: x * y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_forward_gpu(self):
         self.forward_gpu(lambda x, y: y * x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_forward_gpu(self):
         self.forward_gpu(lambda x, y: x / y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_forward_gpu(self):
         self.forward_gpu(lambda x, y: y / x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_forward_gpu(self):
         self.forward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_forward_gpu(self):
         self.forward_gpu(lambda x, y: y ** x, positive=True)
 
@@ -593,43 +593,43 @@ class TestVariableConstantArrayOp(unittest.TestCase):
     def backward_cpu(self, op, positive=False):
         self.check_backward(op, self.x, self.gy, False, positive)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_backward_cpu(self):
         self.backward_cpu(lambda x, y: x + y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_backward_cpu(self):
         self.backward_cpu(lambda x, y: y + x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_backward_cpu(self):
         self.backward_cpu(lambda x, y: x - y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rsub_backward_cpu(self):
         self.backward_cpu(lambda x, y: y - x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_backward_cpu(self):
         self.backward_cpu(lambda x, y: x * y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_backward_cpu(self):
         self.backward_cpu(lambda x, y: y * x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_backward_cpu(self):
         self.backward_cpu(lambda x, y: x / y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_backward_cpu(self):
         self.backward_cpu(lambda x, y: y / x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_backward_cpu(self):
         self.backward_cpu(lambda x, y: x ** y)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_backward_cpu(self):
         self.backward_cpu(lambda x, y: y ** x, positive=True)
 
@@ -638,47 +638,47 @@ class TestVariableConstantArrayOp(unittest.TestCase):
             op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy), True, positive)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_add_backward_gpu(self):
         self.backward_gpu(lambda x, y: x + y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_radd_backward_gpu(self):
         self.backward_gpu(lambda x, y: y + x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_sub_backward_gpu(self):
         self.backward_gpu(lambda x, y: x - y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_mul_backward_gpu(self):
         self.backward_gpu(lambda x, y: x * y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rmul_backward_gpu(self):
         self.backward_gpu(lambda x, y: y * x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_div_backward_gpu(self):
         self.backward_gpu(lambda x, y: x / y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rdiv_backward_gpu(self):
         self.backward_gpu(lambda x, y: y / x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_pow_backward_gpu(self):
         self.backward_gpu(lambda x, y: x ** y)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_rpow_backward_gpu(self):
         self.backward_gpu(lambda x, y: y ** x, positive=True)
 
@@ -700,19 +700,19 @@ class UnaryFunctionsTestBase(object):
     def forward_cpu(self, op, op_np):
         self.check_forward(op, op_np, self.x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_neg_forward_cpu(self):
         self.forward_cpu(lambda x: -x, lambda x: -x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_abs_forward_cpu(self):
         self.forward_cpu(lambda x: abs(x), lambda x: abs(x))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_exp_forward_cpu(self):
         self.forward_cpu(F.exp, numpy.exp)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_log_forward_cpu(self):
         self.forward_cpu(F.log, numpy.log)
 
@@ -720,22 +720,22 @@ class UnaryFunctionsTestBase(object):
         self.check_forward(op, op_np, cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_neg_forward_gpu(self):
         self.forward_gpu(lambda x: -x, lambda x: -x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_abs_forward_gpu(self):
         self.forward_gpu(lambda x: abs(x), lambda x: abs(x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_exp_forward_gpu(self):
         self.forward_gpu(F.exp, numpy.exp)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_log_forward_gpu(self):
         self.forward_gpu(F.log, numpy.log)
 
@@ -754,19 +754,19 @@ class UnaryFunctionsTestBase(object):
     def backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_neg_backward_cpu(self):
         self.backward_cpu(lambda x: -x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_abs_backward_cpu(self):
         self.backward_cpu(lambda x: abs(x))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_exp_backward_cpu(self):
         self.backward_cpu(F.exp)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_log_backward_cpu(self):
         self.backward_cpu(F.log)
 
@@ -774,22 +774,22 @@ class UnaryFunctionsTestBase(object):
         self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_neg_backward_gpu(self):
         self.backward_gpu(lambda x: -x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_abs_backward_gpu(self):
         self.backward_gpu(lambda x: abs(x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_exp_backward_gpu(self):
         self.backward_gpu(F.exp)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_log_backward_gpu(self):
         self.backward_gpu(F.log)
 

--- a/tests/functions_tests/test_batch_normalization.py
+++ b/tests/functions_tests/test_batch_normalization.py
@@ -45,12 +45,12 @@ class TestBatchNormalization(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -70,12 +70,12 @@ class TestBatchNormalization(unittest.TestCase):
         gradient_check.assert_allclose(ggamma, func.ggamma)
         gradient_check.assert_allclose(gbeta, func.gbeta)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_batch_normalization.py
+++ b/tests/functions_tests/test_batch_normalization.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -44,10 +45,12 @@ class TestBatchNormalization(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -67,10 +70,12 @@ class TestBatchNormalization(unittest.TestCase):
         gradient_check.assert_allclose(ggamma, func.ggamma)
         gradient_check.assert_allclose(gbeta, func.gbeta)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_concat.py
+++ b/tests/functions_tests/test_concat.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -27,19 +28,23 @@ class Concat(unittest.TestCase):
         y = functions.concat(xs, axis=axis)
         gradient_check.assert_allclose(y_data, y.data, atol=0, rtol=0)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu_0(self):
         self.check_forward(self.xs0, self.y0, axis=1)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu_1(self):
         self.check_forward(self.xs1, self.y1, axis=0)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_0(self):
         self.check_forward(
             [cuda.to_gpu(x.copy()) for x in self.xs0],
             cuda.to_gpu(self.y0), axis=1)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_1(self):
         self.check_forward(
             [cuda.to_gpu(x.copy()) for x in self.xs1],
@@ -54,16 +59,20 @@ class Concat(unittest.TestCase):
         for x in xs:
             gradient_check.assert_allclose(x.data, x.grad, atol=0, rtol=0)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu_0(self):
         self.check_backward(self.xs0, axis=1)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu_1(self):
         self.check_backward(self.xs1, axis=0)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_0(self):
         self.check_backward([cuda.to_gpu(x.copy()) for x in self.xs0], axis=1)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_1(self):
         self.check_backward([cuda.to_gpu(x.copy()) for x in self.xs1], axis=0)

--- a/tests/functions_tests/test_concat.py
+++ b/tests/functions_tests/test_concat.py
@@ -28,23 +28,23 @@ class Concat(unittest.TestCase):
         y = functions.concat(xs, axis=axis)
         gradient_check.assert_allclose(y_data, y.data, atol=0, rtol=0)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu_0(self):
         self.check_forward(self.xs0, self.y0, axis=1)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu_1(self):
         self.check_forward(self.xs1, self.y1, axis=0)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_0(self):
         self.check_forward(
             [cuda.to_gpu(x.copy()) for x in self.xs0],
             cuda.to_gpu(self.y0), axis=1)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_1(self):
         self.check_forward(
             [cuda.to_gpu(x.copy()) for x in self.xs1],
@@ -59,20 +59,20 @@ class Concat(unittest.TestCase):
         for x in xs:
             gradient_check.assert_allclose(x.data, x.grad, atol=0, rtol=0)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu_0(self):
         self.check_backward(self.xs0, axis=1)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu_1(self):
         self.check_backward(self.xs1, axis=0)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_0(self):
         self.check_backward([cuda.to_gpu(x.copy()) for x in self.xs0], axis=1)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_1(self):
         self.check_backward([cuda.to_gpu(x.copy()) for x in self.xs1], axis=0)

--- a/tests/functions_tests/test_convolution_2d.py
+++ b/tests/functions_tests/test_convolution_2d.py
@@ -47,7 +47,7 @@ class TestConvolution2D(unittest.TestCase):
         gradient_check.assert_allclose(im_cpu, im_gpu.get())
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_consistency(self):
         x_cpu = chainer.Variable(self.x)
         y_cpu = self.func(x_cpu)
@@ -80,18 +80,18 @@ class TestConvolution2D(unittest.TestCase):
         gradient_check.assert_allclose(gW, func.gW)
         gradient_check.assert_allclose(gb, func.gb)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_im2col(self):
         self.func.use_cudnn = False
         self.test_backward_gpu()

--- a/tests/functions_tests/test_convolution_2d.py
+++ b/tests/functions_tests/test_convolution_2d.py
@@ -9,6 +9,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 from chainer.utils import conv
 
 
@@ -46,6 +47,7 @@ class TestConvolution2D(unittest.TestCase):
         gradient_check.assert_allclose(im_cpu, im_gpu.get())
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_consistency(self):
         x_cpu = chainer.Variable(self.x)
         y_cpu = self.func(x_cpu)
@@ -78,15 +80,18 @@ class TestConvolution2D(unittest.TestCase):
         gradient_check.assert_allclose(gW, func.gW)
         gradient_check.assert_allclose(gb, func.gb)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_im2col(self):
         self.func.use_cudnn = False
         self.test_backward_gpu()

--- a/tests/functions_tests/test_embed_id.py
+++ b/tests/functions_tests/test_embed_id.py
@@ -8,6 +8,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -38,10 +39,12 @@ class TestEmbedID(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data, atol=0, rtol=0)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -57,10 +60,12 @@ class TestEmbedID(unittest.TestCase):
         gW, = gradient_check.numerical_grad(f, (func.W,), (y.grad,))
         gradient_check.assert_allclose(gW, func.gW)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_embed_id.py
+++ b/tests/functions_tests/test_embed_id.py
@@ -39,12 +39,12 @@ class TestEmbedID(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data, atol=0, rtol=0)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -60,12 +60,12 @@ class TestEmbedID(unittest.TestCase):
         gW, = gradient_check.numerical_grad(f, (func.W,), (y.grad,))
         gradient_check.assert_allclose(gW, func.gW)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_hierarchical_softmax.py
+++ b/tests/functions_tests/test_hierarchical_softmax.py
@@ -57,6 +57,6 @@ class TestBinaryHierarchicalSoftmax(unittest.TestCase):
         gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
         gradient_check.assert_allclose(cuda.to_cpu(gW), cuda.to_cpu(func.gW))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t, self.gy)

--- a/tests/functions_tests/test_hierarchical_softmax.py
+++ b/tests/functions_tests/test_hierarchical_softmax.py
@@ -6,6 +6,7 @@ import chainer
 from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
+from chainer.testing import condition
 
 
 class TestHuffmanTree(unittest.TestCase):
@@ -56,5 +57,6 @@ class TestBinaryHierarchicalSoftmax(unittest.TestCase):
         gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
         gradient_check.assert_allclose(cuda.to_cpu(gW), cuda.to_cpu(func.gW))
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t, self.gy)

--- a/tests/functions_tests/test_leaky_relu.py
+++ b/tests/functions_tests/test_leaky_relu.py
@@ -8,6 +8,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -34,10 +35,12 @@ class TestLeakyReLU(unittest.TestCase):
 
         gradient_check.assert_allclose(expected, y.data)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -53,9 +56,11 @@ class TestLeakyReLU(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_leaky_relu.py
+++ b/tests/functions_tests/test_leaky_relu.py
@@ -35,12 +35,12 @@ class TestLeakyReLU(unittest.TestCase):
 
         gradient_check.assert_allclose(expected, y.data)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -56,11 +56,11 @@ class TestLeakyReLU(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_linear.py
+++ b/tests/functions_tests/test_linear.py
@@ -43,12 +43,12 @@ class TestLinear(unittest.TestCase):
         y = self.func(x)
         gradient_check.assert_allclose(self.y, y.data)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -68,12 +68,12 @@ class TestLinear(unittest.TestCase):
         gradient_check.assert_allclose(gW, func.gW)
         gradient_check.assert_allclose(gb, func.gb)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_linear.py
+++ b/tests/functions_tests/test_linear.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -42,10 +43,12 @@ class TestLinear(unittest.TestCase):
         y = self.func(x)
         gradient_check.assert_allclose(self.y, y.data)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -65,10 +68,12 @@ class TestLinear(unittest.TestCase):
         gradient_check.assert_allclose(gW, func.gW)
         gradient_check.assert_allclose(gb, func.gb)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_local_response_normalization.py
+++ b/tests/functions_tests/test_local_response_normalization.py
@@ -39,12 +39,12 @@ class TestLocalResponseNormalization(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y_data, atol=1e-4)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -60,11 +60,11 @@ class TestLocalResponseNormalization(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad, atol=1e-3)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_local_response_normalization.py
+++ b/tests/functions_tests/test_local_response_normalization.py
@@ -8,6 +8,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -38,10 +39,12 @@ class TestLocalResponseNormalization(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y_data, atol=1e-4)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -57,9 +60,11 @@ class TestLocalResponseNormalization(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad, atol=1e-3)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_lstm.py
+++ b/tests/functions_tests/test_lstm.py
@@ -52,22 +52,22 @@ class TestLSTM(unittest.TestCase):
         gradient_check.assert_allclose(c_expect, c.data)
         gradient_check.assert_allclose(h_expect, h.data)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.c_prev, self.x)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_forward_cpu(self):
         self.flat()
         self.test_forward_cpu()
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_forward_gpu(self):
         self.flat()
         self.test_forward_gpu()
@@ -88,68 +88,68 @@ class TestLSTM(unittest.TestCase):
         gradient_check.assert_allclose(gc_prev, c_prev.grad)
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_full_backward_cpu(self):
         self.check_backward(self.c_prev, self.x, self.gc, self.gh)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_full_backward_cpu(self):
         self.flat()
         self.test_full_backward_cpu()
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_no_gc_backward_cpu(self):
         self.check_backward(self.c_prev, self.x, None, self.gh)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_no_gc_backward_cpu(self):
         self.flat()
         self.test_no_gc_backward_cpu()
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_no_gh_backward_cpu(self):
         self.check_backward(self.c_prev, self.x, self.gc, None)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_no_gh_backward_cpu(self):
         self.flat()
         self.test_no_gh_backward_cpu()
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_full_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x),
             cuda.to_gpu(self.gc), cuda.to_gpu(self.gh))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_full_backward_gpu(self):
         self.flat()
         self.test_full_backward_gpu()
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_no_gc_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x),
             None, cuda.to_gpu(self.gh))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_no_gc_backward_gpu(self):
         self.flat()
         self.test_no_gc_backward_gpu()
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_no_gh_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x),
             cuda.to_gpu(self.gc), None)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_flat_no_gh_backward_gpu(self):
         self.flat()
         self.test_no_gh_backward_gpu()

--- a/tests/functions_tests/test_lstm.py
+++ b/tests/functions_tests/test_lstm.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -51,18 +52,22 @@ class TestLSTM(unittest.TestCase):
         gradient_check.assert_allclose(c_expect, c.data)
         gradient_check.assert_allclose(h_expect, h.data)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.c_prev, self.x)
 
+    @condition.success_at_least(3, 1)
     def test_flat_forward_cpu(self):
         self.flat()
         self.test_forward_cpu()
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_flat_forward_gpu(self):
         self.flat()
         self.test_forward_gpu()
@@ -83,56 +88,68 @@ class TestLSTM(unittest.TestCase):
         gradient_check.assert_allclose(gc_prev, c_prev.grad)
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_full_backward_cpu(self):
         self.check_backward(self.c_prev, self.x, self.gc, self.gh)
 
+    @condition.success_at_least(3, 1)
     def test_flat_full_backward_cpu(self):
         self.flat()
         self.test_full_backward_cpu()
 
+    @condition.success_at_least(3, 1)
     def test_no_gc_backward_cpu(self):
         self.check_backward(self.c_prev, self.x, None, self.gh)
 
+    @condition.success_at_least(3, 1)
     def test_flat_no_gc_backward_cpu(self):
         self.flat()
         self.test_no_gc_backward_cpu()
 
+    @condition.success_at_least(3, 1)
     def test_no_gh_backward_cpu(self):
         self.check_backward(self.c_prev, self.x, self.gc, None)
 
+    @condition.success_at_least(3, 1)
     def test_flat_no_gh_backward_cpu(self):
         self.flat()
         self.test_no_gh_backward_cpu()
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_full_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x),
             cuda.to_gpu(self.gc), cuda.to_gpu(self.gh))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_flat_full_backward_gpu(self):
         self.flat()
         self.test_full_backward_gpu()
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_no_gc_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x),
             None, cuda.to_gpu(self.gh))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_flat_no_gc_backward_gpu(self):
         self.flat()
         self.test_no_gc_backward_gpu()
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_no_gh_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.c_prev), cuda.to_gpu(self.x),
             cuda.to_gpu(self.gc), None)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_flat_no_gh_backward_gpu(self):
         self.flat()
         self.test_no_gh_backward_gpu()

--- a/tests/functions_tests/test_mean_squared_error.py
+++ b/tests/functions_tests/test_mean_squared_error.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -35,10 +36,12 @@ class TestMeanSquaredError(unittest.TestCase):
 
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x0, self.x1)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forwrad_gpu(self):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
 
@@ -58,9 +61,11 @@ class TestMeanSquaredError(unittest.TestCase):
         self.assertEqual(x0.grad.dtype, numpy.float32)
         self.assertEqual(x1.grad.dtype, numpy.float32)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x0, self.x1)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))

--- a/tests/functions_tests/test_mean_squared_error.py
+++ b/tests/functions_tests/test_mean_squared_error.py
@@ -36,12 +36,12 @@ class TestMeanSquaredError(unittest.TestCase):
 
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x0, self.x1)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forwrad_gpu(self):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
 
@@ -61,11 +61,11 @@ class TestMeanSquaredError(unittest.TestCase):
         self.assertEqual(x0.grad.dtype, numpy.float32)
         self.assertEqual(x1.grad.dtype, numpy.float32)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x0, self.x1)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))

--- a/tests/functions_tests/test_negative_sampling.py
+++ b/tests/functions_tests/test_negative_sampling.py
@@ -6,6 +6,8 @@ import chainer
 from chainer import cuda
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
+
 
 if cuda.available:
     cuda.init()
@@ -36,6 +38,7 @@ class TestNegativeSampling(unittest.TestCase):
                                        atol=1.e-4)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         x = chainer.Variable(self.x)
         t = chainer.Variable(self.t)
@@ -48,10 +51,12 @@ class TestNegativeSampling(unittest.TestCase):
 
         gradient_check.assert_allclose(y.data, y_g.data, atol=1.e-4)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x),

--- a/tests/functions_tests/test_negative_sampling.py
+++ b/tests/functions_tests/test_negative_sampling.py
@@ -38,7 +38,7 @@ class TestNegativeSampling(unittest.TestCase):
                                        atol=1.e-4)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         x = chainer.Variable(self.x)
         t = chainer.Variable(self.t)
@@ -51,12 +51,12 @@ class TestNegativeSampling(unittest.TestCase):
 
         gradient_check.assert_allclose(y.data, y_g.data, atol=1.e-4)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x),

--- a/tests/functions_tests/test_pooling_2d.py
+++ b/tests/functions_tests/test_pooling_2d.py
@@ -8,6 +8,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -53,14 +54,17 @@ class TestMaxPooling2D(unittest.TestCase):
                             k, c, 1:4, 1:3].max()]])
                 gradient_check.assert_allclose(expect, y_data[k, c])
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
@@ -78,14 +82,17 @@ class TestMaxPooling2D(unittest.TestCase):
 
         gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
 
@@ -123,14 +130,17 @@ class TestAveragePooling2D(unittest.TestCase):
                         k, c, 1:4, 1:3].sum()]]) / 9
                 gradient_check.assert_allclose(expect, y_data[k, c])
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
@@ -147,13 +157,16 @@ class TestAveragePooling2D(unittest.TestCase):
 
         gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_pooling_2d.py
+++ b/tests/functions_tests/test_pooling_2d.py
@@ -54,17 +54,17 @@ class TestMaxPooling2D(unittest.TestCase):
                             k, c, 1:4, 1:3].max()]])
                 gradient_check.assert_allclose(expect, y_data[k, c])
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
@@ -82,17 +82,17 @@ class TestMaxPooling2D(unittest.TestCase):
 
         gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
 
@@ -130,17 +130,17 @@ class TestAveragePooling2D(unittest.TestCase):
                         k, c, 1:4, 1:3].sum()]]) / 9
                 gradient_check.assert_allclose(expect, y_data[k, c])
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
@@ -157,16 +157,16 @@ class TestAveragePooling2D(unittest.TestCase):
 
         gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_prelu.py
+++ b/tests/functions_tests/test_prelu.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -39,10 +40,12 @@ class TestPReLUSingle(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -60,10 +63,12 @@ class TestPReLUSingle(unittest.TestCase):
         gradient_check.assert_allclose(gx, x.grad)
         gradient_check.assert_allclose(gW, func.gW, atol=1e-4)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_prelu.py
+++ b/tests/functions_tests/test_prelu.py
@@ -40,12 +40,12 @@ class TestPReLUSingle(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.func.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -63,12 +63,12 @@ class TestPReLUSingle(unittest.TestCase):
         gradient_check.assert_allclose(gx, x.grad)
         gradient_check.assert_allclose(gW, func.gW, atol=1e-4)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.func.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_relu.py
+++ b/tests/functions_tests/test_relu.py
@@ -34,16 +34,16 @@ class TestReLU(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_relu.py
+++ b/tests/functions_tests/test_relu.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -33,13 +34,16 @@ class TestReLU(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_cpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_sigmoid.py
+++ b/tests/functions_tests/test_sigmoid.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -20,6 +21,7 @@ class TestSigmoid(unittest.TestCase):
         self.gy = numpy.random.uniform(-.1, .1, (3, 2)).astype(numpy.float32)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self, use_cudnn=True):
         x = chainer.Variable(cuda.to_gpu(self.x))
         y = functions.sigmoid(x, use_cudnn=use_cudnn)
@@ -28,6 +30,7 @@ class TestSigmoid(unittest.TestCase):
         gradient_check.assert_allclose(y_expect.data, y.data)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_no_cudnn(self):
         self.test_forward_gpu(False)
 
@@ -43,13 +46,16 @@ class TestSigmoid(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_sigmoid.py
+++ b/tests/functions_tests/test_sigmoid.py
@@ -21,7 +21,7 @@ class TestSigmoid(unittest.TestCase):
         self.gy = numpy.random.uniform(-.1, .1, (3, 2)).astype(numpy.float32)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self, use_cudnn=True):
         x = chainer.Variable(cuda.to_gpu(self.x))
         y = functions.sigmoid(x, use_cudnn=use_cudnn)
@@ -30,7 +30,7 @@ class TestSigmoid(unittest.TestCase):
         gradient_check.assert_allclose(y_expect.data, y.data)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.test_forward_gpu(False)
 
@@ -46,16 +46,16 @@ class TestSigmoid(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_sigmoid_cross_entropy.py
+++ b/tests/functions_tests/test_sigmoid_cross_entropy.py
@@ -38,17 +38,17 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
         loss_expect /= self.t.shape[0]
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)
 
@@ -65,16 +65,16 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)

--- a/tests/functions_tests/test_sigmoid_cross_entropy.py
+++ b/tests/functions_tests/test_sigmoid_cross_entropy.py
@@ -9,6 +9,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -37,14 +38,17 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
         loss_expect /= self.t.shape[0]
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)
 
@@ -61,13 +65,16 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)

--- a/tests/functions_tests/test_softmax.py
+++ b/tests/functions_tests/test_softmax.py
@@ -8,6 +8,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -30,14 +31,17 @@ class TestSoftmax(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forwrad_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
@@ -53,13 +57,16 @@ class TestSoftmax(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_softmax.py
+++ b/tests/functions_tests/test_softmax.py
@@ -31,17 +31,17 @@ class TestSoftmax(unittest.TestCase):
 
         gradient_check.assert_allclose(y_expect, y.data)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forwrad_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
@@ -57,16 +57,16 @@ class TestSoftmax(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -37,17 +37,17 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)
 
@@ -64,16 +64,16 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -9,6 +9,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -36,14 +37,17 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)
 
@@ -60,13 +64,16 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)

--- a/tests/functions_tests/test_sum.py
+++ b/tests/functions_tests/test_sum.py
@@ -26,12 +26,12 @@ class TestSum(unittest.TestCase):
         y_expect = self.x.sum()
         gradient_check.assert_allclose(y_expect, y.data)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -44,11 +44,11 @@ class TestSum(unittest.TestCase):
         gx_expect = numpy.full_like(self.x, self.gy[0])
         gradient_check.assert_allclose(gx_expect, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_sum.py
+++ b/tests/functions_tests/test_sum.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -25,10 +26,12 @@ class TestSum(unittest.TestCase):
         y_expect = self.x.sum()
         gradient_check.assert_allclose(y_expect, y.data)
 
+    @condition.success_at_least(3, 1)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -41,9 +44,11 @@ class TestSum(unittest.TestCase):
         gx_expect = numpy.full_like(self.x, self.gy[0])
         gradient_check.assert_allclose(gx_expect, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_tanh.py
+++ b/tests/functions_tests/test_tanh.py
@@ -9,6 +9,7 @@ from chainer import gradient_check
 from chainer.testing import attr
 from chainer.testing import condition
 
+
 if cuda.available:
     cuda.init()
 

--- a/tests/functions_tests/test_tanh.py
+++ b/tests/functions_tests/test_tanh.py
@@ -7,7 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
-
+from chainer.testing import condition
 
 if cuda.available:
     cuda.init()
@@ -20,6 +20,7 @@ class TestSigmoid(unittest.TestCase):
         self.gy = numpy.random.uniform(-.1, .1, (3, 2)).astype(numpy.float32)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_forward_gpu(self, use_cudnn=True):
         x = chainer.Variable(cuda.to_gpu(self.x))
         y = functions.tanh(x, use_cudnn=use_cudnn)
@@ -27,6 +28,7 @@ class TestSigmoid(unittest.TestCase):
         gradient_check.assert_allclose(y_expect.data, y.data)
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_forward_gpu_no_cudnn(self):
         self.test_forward_gpu(False)
 
@@ -41,13 +43,16 @@ class TestSigmoid(unittest.TestCase):
         gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
         gradient_check.assert_allclose(gx, x.grad)
 
+    @condition.success_at_least(3, 1)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
+    @condition.success_at_least(3, 1)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.success_at_least(3, 1)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/functions_tests/test_tanh.py
+++ b/tests/functions_tests/test_tanh.py
@@ -20,7 +20,7 @@ class TestSigmoid(unittest.TestCase):
         self.gy = numpy.random.uniform(-.1, .1, (3, 2)).astype(numpy.float32)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu(self, use_cudnn=True):
         x = chainer.Variable(cuda.to_gpu(self.x))
         y = functions.tanh(x, use_cudnn=use_cudnn)
@@ -28,7 +28,7 @@ class TestSigmoid(unittest.TestCase):
         gradient_check.assert_allclose(y_expect.data, y.data)
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.test_forward_gpu(False)
 
@@ -43,16 +43,16 @@ class TestSigmoid(unittest.TestCase):
         gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
         gradient_check.assert_allclose(gx, x.grad)
 
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.success_at_least(3, 1)
+    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)

--- a/tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -8,6 +8,7 @@ from chainer import cuda
 import chainer.functions as F
 from chainer import optimizers
 from chainer.testing import attr
+from chainer.testing import condition
 
 if cuda.available:
     cuda.init()
@@ -84,12 +85,14 @@ class OptimizerTestBase(object):
     def setUp(self):
         self.model = LinearModel(self.create())
 
+    @condition.success_at_least(5, 1)
     def test_linear_model_cpu(self):
-        self.assertGreater(self.model.accuracy(False), 0.7)
+        self.assertGreater(self.model.accuracy(False), 0.9)
 
     @attr.gpu
+    @condition.success_at_least(5, 1)
     def test_linear_model_gpu(self):
-        self.assertGreater(self.model.accuracy(True), 0.7)
+        self.assertGreater(self.model.accuracy(True), 0.9)
 
 
 class TestAdaDelta(OptimizerTestBase, unittest.TestCase):

--- a/tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -85,12 +85,12 @@ class OptimizerTestBase(object):
     def setUp(self):
         self.model = LinearModel(self.create())
 
-    @condition.success_at_least(5, 1)
+    @condition.retry(10)
     def test_linear_model_cpu(self):
         self.assertGreater(self.model.accuracy(False), 0.9)
 
     @attr.gpu
-    @condition.success_at_least(5, 1)
+    @condition.retry(10)
     def test_linear_model_gpu(self):
         self.assertGreater(self.model.accuracy(True), 0.9)
 

--- a/tests/testing_tests/test_condition.py
+++ b/tests/testing_tests/test_condition.py
@@ -1,0 +1,111 @@
+import unittest
+
+from chainer.testing import condition
+
+
+# The test fixtures of this TestCase is used to be decorated by
+# decorator in test. So we do not run them alone.
+class MockUnitTest(unittest.TestCase):
+
+    counter = 0
+
+    def failure_case(self):
+        self.fail()
+
+    def success_case(self):
+        self.assertTrue(True)
+
+    def probabilistic_case(self):
+        self.counter += 1
+        if self.counter % 2 == 0:
+            self.assertTrue(True)
+        else:
+            self.fail()
+
+    def runTest(self):
+        pass
+
+
+def _should_fail(self, f):
+    self.assertRaises(AssertionError, f, self.unit_test)
+
+
+def _should_pass(self, f):
+    f(self.unit_test)
+
+
+class TestRepeatWithSuccessAtLeast(unittest.TestCase):
+
+    def _decorate(self, f, times, min_success):
+        return condition.repeat_with_success_at_least(
+            times, min_success)(f)
+
+    def setUp(self):
+        self.unit_test = MockUnitTest()
+
+    def test_all_trials_fail(self):
+        f = self._decorate(MockUnitTest.failure_case, 10, 1)
+        _should_fail(self, f)
+
+    def test_all_trials_fail2(self):
+        f = self._decorate(MockUnitTest.failure_case, 10, 0)
+        _should_pass(self, f)
+
+    def test_all_trials_succeed(self):
+        f = self._decorate(MockUnitTest.success_case, 10, 10)
+        _should_pass(self, f)
+
+    def test_all_trials_succeed2(self):
+        self.assertRaises(AssertionError,
+                          condition.repeat_with_success_at_least,
+                          10, 11)
+
+    def test_half_of_trials_succeed(self):
+        f = self._decorate(MockUnitTest.probabilistic_case, 10, 5)
+        _should_pass(self, f)
+
+    def test_half_of_trials_succeed2(self):
+        f = self._decorate(MockUnitTest.probabilistic_case, 10, 6)
+        _should_fail(self, f)
+
+
+class TestRepeat(unittest.TestCase):
+
+    def _decorate(self, f, times):
+        return condition.repeat(times)(f)
+
+    def setUp(self):
+        self.unit_test = MockUnitTest()
+
+    def test_failure_case(self):
+        f = self._decorate(MockUnitTest.failure_case, 10)
+        _should_fail(self, f)
+
+    def test_success_case(self):
+        f = self._decorate(MockUnitTest.success_case, 10)
+        _should_pass(self, f)
+
+    def test_probabilistic_case(self):
+        f = self._decorate(MockUnitTest.probabilistic_case, 10)
+        _should_fail(self, f)
+
+
+class TestRetry(unittest.TestCase):
+
+    def _decorate(self, f, times):
+        return condition.retry(times)(f)
+
+    def setUp(self):
+        self.unit_test = MockUnitTest()
+
+    def test_failure_case(self):
+        f = self._decorate(MockUnitTest.failure_case, 10)
+        _should_fail(self, f)
+
+    def test_success_case(self):
+        f = self._decorate(MockUnitTest.success_case, 10)
+        _should_pass(self, f)
+
+    def test_probabilistic_case(self):
+        f = self._decorate(MockUnitTest.probabilistic_case, 10)
+        _should_pass(self, f)

--- a/tests/testing_tests/test_condition.py
+++ b/tests/testing_tests/test_condition.py
@@ -75,15 +75,19 @@ class TestRepeatWithSuccessAtLeast(unittest.TestCase):
         f = self._decorate(MockUnitTest.probabilistic_case, 10, 5)
         _should_pass(self, f)
         self.assertLessEqual(self.unit_test.probabilistic_case_counter, 10)
-        self.assertGreaterEqual(self.unit_test.probabilistic_case_success_counter, 5)
-        self.assertLessEqual(self.unit_test.probabilistic_case_failure_counter, 5)
+        self.assertGreaterEqual(
+            self.unit_test.probabilistic_case_success_counter, 5)
+        self.assertLessEqual(
+            self.unit_test.probabilistic_case_failure_counter, 5)
 
     def test_half_of_trials_succeed2(self):
         f = self._decorate(MockUnitTest.probabilistic_case, 10, 6)
         _should_fail(self, f)
         self.assertLessEqual(self.unit_test.probabilistic_case_counter, 10)
-        self.assertLess(self.unit_test.probabilistic_case_success_counter, 6)
-        self.assertGreaterEqual(self.unit_test.probabilistic_case_failure_counter, 5)
+        self.assertLess(
+            self.unit_test.probabilistic_case_success_counter, 6)
+        self.assertGreaterEqual(
+            self.unit_test.probabilistic_case_failure_counter, 5)
 
 
 class TestRepeat(unittest.TestCase):
@@ -109,7 +113,8 @@ class TestRepeat(unittest.TestCase):
         _should_fail(self, f)
         self.assertLessEqual(self.unit_test.probabilistic_case_counter, 10)
         self.assertLess(self.unit_test.probabilistic_case_success_counter, 10)
-        self.assertGreater(self.unit_test.probabilistic_case_failure_counter, 0)
+        self.assertGreater(
+            self.unit_test.probabilistic_case_failure_counter, 0)
 
 
 class TestRetry(unittest.TestCase):
@@ -133,6 +138,8 @@ class TestRetry(unittest.TestCase):
     def test_probabilistic_case(self):
         f = self._decorate(MockUnitTest.probabilistic_case, 10)
         _should_pass(self, f)
-        self.assertLessEqual(self.unit_test.probabilistic_case_counter, 10)
-        self.assertGreater(self.unit_test.probabilistic_case_success_counter, 0)
+        self.assertLessEqual(
+            self.unit_test.probabilistic_case_counter, 10)
+        self.assertGreater(
+            self.unit_test.probabilistic_case_success_counter, 0)
         self.assertLess(self.unit_test.probabilistic_case_failure_counter, 10)


### PR DESCRIPTION
This PR fixes #85 .
This PR implements decorators for test cases that make them run multiple times.

Decorators are as follows
* repeat_with_success_at_least(n, m) : Pass the test case if it succeeded m times among n trials.
* retry(n) : Pass the test case if it succeeded at least once among n trials.
* repeat(n) : Pass the test case if it succeeded all n trials.
