### PR TITLE
Add condition.retry decorator to undecorated numerical tests

### DIFF
--- a/tests/functions_tests/test_concat.py
+++ b/tests/functions_tests/test_concat.py
@@ -7,7 +7,6 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 if cuda.available:
@@ -28,23 +27,19 @@ class Concat(unittest.TestCase):
         y = functions.concat(xs, axis=axis)
         gradient_check.assert_allclose(y_data, y.data, atol=0, rtol=0)
 
-    @condition.retry(3)
     def test_forward_cpu_0(self):
         self.check_forward(self.xs0, self.y0, axis=1)
 
-    @condition.retry(3)
     def test_forward_cpu_1(self):
         self.check_forward(self.xs1, self.y1, axis=0)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_0(self):
         self.check_forward(
             [cuda.to_gpu(x.copy()) for x in self.xs0],
             cuda.to_gpu(self.y0), axis=1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_1(self):
         self.check_forward(
             [cuda.to_gpu(x.copy()) for x in self.xs1],
@@ -59,20 +54,16 @@ class Concat(unittest.TestCase):
         for x in xs:
             gradient_check.assert_allclose(x.data, x.grad, atol=0, rtol=0)
 
-    @condition.retry(3)
     def test_backward_cpu_0(self):
         self.check_backward(self.xs0, axis=1)
 
-    @condition.retry(3)
     def test_backward_cpu_1(self):
         self.check_backward(self.xs1, axis=0)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_0(self):
         self.check_backward([cuda.to_gpu(x.copy()) for x in self.xs0], axis=1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_1(self):
         self.check_backward([cuda.to_gpu(x.copy()) for x in self.xs1], axis=0)

--- a/tests/functions_tests/test_hierarchical_softmax.py
+++ b/tests/functions_tests/test_hierarchical_softmax.py
@@ -33,6 +33,7 @@ class TestBinaryHierarchicalSoftmax(unittest.TestCase):
 
         self.W = self.func.W.copy()
 
+    @condition.retry(3)
     def test_sum(self):
         x = numpy.array([[1.0, 2.0, 3.0]], numpy.float32)
         total = 0

--- a/tests/functions_tests/test_matmul.py
+++ b/tests/functions_tests/test_matmul.py
@@ -8,6 +8,7 @@ from chainer import cuda
 import chainer.functions as F
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -24,10 +25,12 @@ class _TestMatMul(unittest.TestCase):
             self.assertTrue(hasattr(y.data.gpudata, 'device'))
         gradient_check.assert_allclose(self.forward_answer, y.data)
 
+    @condition.retry(3)
     def test_matmul_forward_cpu(self):
         self.check_forward(self.x1, self.x2)
 
     @attr.gpu
+    @condition.retry(3)
     def test_matmul_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
@@ -45,10 +48,12 @@ class _TestMatMul(unittest.TestCase):
         gradient_check.assert_allclose(gx1, x1.grad, atol=atol)
         gradient_check.assert_allclose(gx2, x2.grad, atol=atol)
 
+    @condition.retry(3)
     def test_matmul_backward_cpu(self):
         self.check_backward(self.x1, self.x2, self.gy, atol=1e-2)
 
     @attr.gpu
+    @condition.retry(3)
     def test_matmul_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x1), cuda.to_gpu(self.x2),

--- a/tests/functions_tests/test_nonparameterized_convolution_2d.py
+++ b/tests/functions_tests/test_nonparameterized_convolution_2d.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -76,15 +77,18 @@ class TestNonparameterizedConvolution2D(unittest.TestCase):
         gradient_check.assert_allclose(gW, W.grad)
         gradient_check.assert_allclose(gb, b.grad)
 
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.W, self.b, self.gy)
 
     @attr.cudnn
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             cuda.to_gpu(self.b), cuda.to_gpu(self.gy))
 
     @attr.gpu
+    @condition.retry(3)
     def test_backward_gpu_im2col(self):
         self.use_cudnn = False
         self.test_backward_gpu()

--- a/tests/functions_tests/test_nonparameterized_linear.py
+++ b/tests/functions_tests/test_nonparameterized_linear.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -32,11 +33,13 @@ class TestNonparameterizedLinear(unittest.TestCase):
         y = functions.linear(x, W, b)
         gradient_check.assert_allclose(y_expect, y.data)
 
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.W, self.b,
                            self.x.dot(self.W.T) + self.b)
 
     @attr.gpu
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b),
@@ -59,10 +62,12 @@ class TestNonparameterizedLinear(unittest.TestCase):
         gradient_check.assert_allclose(gW, W.grad)
         gradient_check.assert_allclose(gb, b.grad)
 
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.W, self.b, self.gy)
 
     @attr.gpu
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             cuda.to_gpu(self.b), cuda.to_gpu(self.gy))

--- a/tests/functions_tests/test_split_axis.py
+++ b/tests/functions_tests/test_split_axis.py
@@ -7,6 +7,7 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 if cuda.available:
@@ -27,10 +28,12 @@ class TestSplitAxis0(unittest.TestCase):
         for yd, y in zip(ys_data, ys):
             gradient_check.assert_allclose(yd, y.data, atol=0, rtol=0)
 
+    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.ys, self.ys_section, self.axis)
 
     @attr.gpu
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(
             cuda.to_gpu(self.x),
@@ -46,10 +49,12 @@ class TestSplitAxis0(unittest.TestCase):
 
         gradient_check.assert_allclose(x.data, x.grad, atol=0, rtol=0)
 
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.ys_section, axis=self.axis)
 
     @attr.gpu
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), self.ys_section, axis=self.axis)

--- a/tests/functions_tests/test_split_axis.py
+++ b/tests/functions_tests/test_split_axis.py
@@ -7,7 +7,6 @@ from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 if cuda.available:
@@ -28,12 +27,10 @@ class TestSplitAxis0(unittest.TestCase):
         for yd, y in zip(ys_data, ys):
             gradient_check.assert_allclose(yd, y.data, atol=0, rtol=0)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.ys, self.ys_section, self.axis)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(
             cuda.to_gpu(self.x),
@@ -49,12 +46,10 @@ class TestSplitAxis0(unittest.TestCase):
 
         gradient_check.assert_allclose(x.data, x.grad, atol=0, rtol=0)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.ys_section, axis=self.axis)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), self.ys_section, axis=self.axis)


### PR DESCRIPTION
This PR adds `condition.retry` decorator to following functions.

* `TestBinaryHierarchicalSoftmax.test_sum`
* All of numerical test fixtures of `matmul`, non-parameterized `convolution_2d`, non-parameterized `linear` and `split_axis`.
