### PR TITLE
Add information that an external library is required to use Pillow

### DIFF
--- a/examples/imagenet/README.md
+++ b/examples/imagenet/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Pillow
+- Pillow (Pillow requires an external library that corresponds to the image format)
 
 ## Description
 

--- a/examples/modelzoo/README.md
+++ b/examples/modelzoo/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Caffe model support (Python 2.7+, Protocol Buffers)
-- Pillow
+- Pillow (Pillow requires an external library that corresponds to the image format)
 
 ## Description
 


### PR DESCRIPTION
I fixed `README.md` in example.