### PR TITLE
Add missing explicit dtype to accum los variable.

### DIFF
--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -114,7 +114,7 @@ epoch = 0
 start_at = time.time()
 cur_at = start_at
 state = make_initial_state()
-accum_loss = chainer.Variable(mod.zeros(()))
+accum_loss = chainer.Variable(mod.zeros((), dtype=np.float32))
 print('going to train {} iterations'.format(jump * n_epoch))
 for i in six.moves.range(jump * n_epoch):
     x_batch = np.array([train_data[(jump * j + i) % whole_len]
@@ -129,7 +129,7 @@ for i in six.moves.range(jump * n_epoch):
         optimizer.zero_grads()
         accum_loss.backward()
         accum_loss.unchain_backward()  # truncate
-        accum_loss = chainer.Variable(mod.zeros(()))
+        accum_loss = chainer.Variable(mod.zeros((), dtype=np.float32))
 
         optimizer.clip_grads(grad_clip)
         optimizer.update()


### PR DESCRIPTION
It might have been working without problems for this example data, but
technically speaking, by omitting dtype in the zeros() call the grad
could become too small beyond float32 precision.  As a result, it would
stop updating function parameters if you run it in GPU, as the grad
values just vanish. 