### PR TITLE
API: Consistent to_gpu/to_cpu API

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -457,6 +457,9 @@ def to_gpu(array, device=None):
         copy GPUArray into specified device.
 
     """
+    if hasattr(array, 'to_gpu'):
+        return array.to_gpu(device=device)
+
     if isinstance(array, GPUArray):
         return array
     with using_device(device):
@@ -511,6 +514,9 @@ def to_cpu(array):
         ``array`` without performing any copy.
 
     """
+    if hasattr(array, 'to_cpu'):
+        return array.to_cpu()
+
     if isinstance(array, GPUArray):
         return array.get()
     return array

--- a/tests/test_function_set.py
+++ b/tests/test_function_set.py
@@ -100,3 +100,9 @@ class TestFunctionSet(unittest.TestCase):
         self.fs.to_cpu()
         fs2.to_cpu()
         self.check_equal_fs(self.fs, fs2)
+
+    @attr.gpu
+    def test_to_gpu_roundtrip(self):
+        fsg = cuda.to_gpu(self.fs)
+        fsc = cuda.to_cpu(fsg)
+        self.check_equal_fs(self.fs, fsc)

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -48,6 +48,9 @@ class TestVariable(unittest.TestCase):
         x = chainer.Variable(x)
         self.assertEqual(len(x), 10)
 
+        x2 = chainer.Variable(x)
+        self.assertEqual(len(x2), 10)
+
     def test_len_cpu(self):
         self.check_len(False)
 
@@ -68,6 +71,14 @@ class TestVariable(unittest.TestCase):
     @attr.gpu
     def test_label_gpu(self):
         self.check_label('(2, 5), float32', True)
+
+    @attr.gpu
+    def test_to_gpu_roundtrip(self):
+        v = chainer.Variable(np.array([1]))
+        result = v.to_gpu()
+        self.assertTrue(isinstance(result.data, cuda.GPUArray))
+        result = v.to_cpu()
+        self.assertTrue(isinstance(result.data, np.ndarray))
 
     def check_backward(self, inputs, intermediates, outputs, retain_grad):
         for o in outputs:
@@ -133,5 +144,10 @@ class TestVariable(unittest.TestCase):
         self.check_backward((ret[1], ), (ret[2], ), (ret[3], ), False)
 
     def test_invalid_value_type(self):
-        with self.assertRaises(AssertionError):
+        msg = "'data' must be numpy.ndarray, cuda.GPUArray or Variable"
+        with self.assertRaisesRegexp(ValueError, msg):
             chainer.Variable(1)
+
+        msg = "'volatile' must be bool type"
+        with self.assertRaisesRegexp(ValueError, msg):
+            chainer.Variable(np.array([1]), volatile='INVALID')


### PR DESCRIPTION
I felt inconsistencies in following differences.

- array-like must be moved to CPU/GPU via ``cuda.to_cpu`` / ``cuda.to_gpu``.
- ``Function`` and ``FunctionSet`` has its own ``to_cpu`` and ``to_gpu``. But ``Variable`` doesn't.

```
import chainer
f = chainer.FunctionSet(f=chainer.functions.Linear(2, 3))
chainer.cuda.to_gpu(f)
# AttributeError: 'FunctionSet' object has no attribute 'shape'

import numpy as np
chainer.Variable(np.array([1])).to_gpu()
# AttributeError: 'Variable' object has no attribute 'to_gpu'
```

This PR makes:

- All ``chainer`` instance movable between CPU/GPU  should have ``to_cpu`` and ``to_gpu``. In case of ``Variable``, internal data is moved to CPU/GPU resetting progressing calculation status.
- ``cuda.to_cpu`` and ``cuda.to_gpu`` should accept ``chainer`` instances.

