### PR TITLE
Show the first error message in `repeat_with_success_at_least`

### DIFF
--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -43,15 +43,17 @@ def repeat_with_success_at_least(times, min_success):
             assert isinstance(instance, unittest.TestCase)
             success_counter = 0
             failure_counter = 0
-            failures = []
+            results = []
 
             def fail():
                 msg = '\nFail: {0}, Success: {1}'.format(
                     failure_counter, success_counter)
-                if len(failures) > 0:
-                    first = failures[0]
-                    err_msg = '\n'.join(fail[1] for fail in first)
-                    msg += '\n\nThe first error message:\n' + err_msg
+                if len(results) > 0:
+                    first = results[0]
+                    errs = first.failures + first.errors
+                    if len(errs) > 0:
+                        err_msg = '\n'.join(fail[1] for fail in errs)
+                        msg += '\n\nThe first error message:\n' + err_msg
                 instance.fail(msg)
 
             for _ in six.moves.range(times):
@@ -66,7 +68,7 @@ def repeat_with_success_at_least(times, min_success):
                 if result.wasSuccessful():
                     success_counter += 1
                 else:
-                    failures.append(result.failures)
+                    results.append(result)
                     failure_counter += 1
                 if success_counter >= min_success:
                     instance.assertTrue(True)

--- a/tests/testing_tests/test_condition.py
+++ b/tests/testing_tests/test_condition.py
@@ -21,6 +21,9 @@ class MockUnitTest(unittest.TestCase):
         self.success_case_counter += 1
         self.assertTrue(True)
 
+    def error_case(self):
+        raise Exception()
+
     def probabilistic_case(self):
         self.probabilistic_case_counter += 1
         if self.probabilistic_case_counter % 2 == 0:
@@ -35,7 +38,12 @@ class MockUnitTest(unittest.TestCase):
 
 
 def _should_fail(self, f):
-    self.assertRaises(AssertionError, f, self.unit_test)
+    try:
+        f(self.unit_test)
+        self.fail('AssertionError is expected to be raised, but none is raises')
+    except AssertionError as e:
+        # check if the detail is included in the error object
+        self.assertIn('first error message:', str(e))
 
 
 def _should_pass(self, f):
@@ -60,6 +68,10 @@ class TestRepeatWithSuccessAtLeast(unittest.TestCase):
         f = self._decorate(MockUnitTest.failure_case, 10, 0)
         _should_pass(self, f)
         self.assertLessEqual(self.unit_test.failure_case_counter, 10)
+
+    def test_all_trials_error(self):
+        f = self._decorate(MockUnitTest.error_case, 10, 1)
+        _should_fail(self, f)
 
     def test_all_trials_succeed(self):
         f = self._decorate(MockUnitTest.success_case, 10, 10)

--- a/tests/testing_tests/test_condition.py
+++ b/tests/testing_tests/test_condition.py
@@ -41,7 +41,7 @@ def _should_fail(self, f):
     try:
         f(self.unit_test)
         self.fail(
-            'AssertionError is expected to be raised, but none is raises')
+            'AssertionError is expected to be raised, but none is raised')
     except AssertionError as e:
         # check if the detail is included in the error object
         self.assertIn('first error message:', str(e))

--- a/tests/testing_tests/test_condition.py
+++ b/tests/testing_tests/test_condition.py
@@ -40,7 +40,8 @@ class MockUnitTest(unittest.TestCase):
 def _should_fail(self, f):
     try:
         f(self.unit_test)
-        self.fail('AssertionError is expected to be raised, but none is raises')
+        self.fail(
+            'AssertionError is expected to be raised, but none is raises')
     except AssertionError as e:
         # check if the detail is included in the error object
         self.assertIn('first error message:', str(e))


### PR DESCRIPTION
Simply I stored `failures` information of a result and show the first one.

Fix #150 