### PR TITLE
Fix dependency to scikit-cuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements for some features:
 - CUDA support
   - CUDA 6.5+
   - PyCUDA
-  - scikits.cuda (pip install scikits.cuda>=0.5.0b2,!=0.042)
+  - scikits.cuda (pip install scikit-cuda>=0.5.0)
   - Mako (depending through PyCUDA)
 - CuDNN support
   - CuDNN v2

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -42,7 +42,7 @@ import six
 try:
     _requires = [
         'pycuda>=2014.1',
-        'scikits.cuda>=0.5.0b2,!=0.042',
+        'scikit-cuda>=0.5.0',
         'Mako',
         'six>=1.9.0',
     ]

--- a/cuda_deps/setup.py
+++ b/cuda_deps/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'chainer',
         'pycuda>=2014.1',
-        'scikits.cuda>=0.5.0b2,!=0.042',
+        'scikit-cuda>=0.5.0',
         'Mako',
         'six>=1.9.0',
     ],


### PR DESCRIPTION
fix #196 

After this PR, we will release `chainer-cuda-deps 1.1.0.1`, and then fix all import in chainer.