### PR TITLE
Add type_check.prod

### DIFF
--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -427,3 +427,5 @@ def expect(*bool_exprs):
     for expr in bool_exprs:
         assert isinstance(expr, Testable)
         expr.expect()
+
+prod = Variable(numpy.prod, 'prod')


### PR DESCRIPTION
Typical usage (type check of `Reshape.forward` where size of input shape must equal to that of self.shape)

```
def check_type_forward(self, in_types):
    type_check.expect(
        in_types.size() == 1,
        type_check.prod(in_types[0].shape) ==
        type_check.prod(self.shape)
)
```

Related to #203
