### PR TITLE
Evaluate values in lists and ruples recursively

### DIFF
--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -212,6 +212,10 @@ class Expr(object):
 def _eval_expr(v):
     if isinstance(v, Expr):
         return v.eval()
+    elif isinstance(v, list):
+        return list(map(_eval_expr, v))
+    elif isinstance(v, tuple):
+        return tuple(map(_eval_expr, v))
     else:
         return v
 

--- a/tests/utils_tests/test_type_check.py
+++ b/tests/utils_tests/test_type_check.py
@@ -310,4 +310,13 @@ class TestLazyGetItem(unittest.TestCase):
             self.t().eval()
 
 
+class TestListItem(unittest.TestCase):
+
+    def test_eval_list_items(self):
+        self.assertTrue((T.Constant([0]) == [T.Constant(0)]).eval())
+
+    def test_eval_tuple_items(self):
+        self.assertTrue((T.Constant((0,)) == (T.Constant(0),)).eval())
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
When we evaluate a list of `Expr`s, type check system doesn't evaluate each value in the list. It causes confusing error.
I fixed this behavior to evaluate values in a given list.