### PR TITLE
add spatial pyramid pooling 2d function

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -56,6 +56,7 @@ Softmax = softmax.Softmax
 Tanh = tanh.Tanh
 AveragePooling2D = pooling_2d.AveragePooling2D
 MaxPooling2D = pooling_2d.MaxPooling2D
+SpatialPyramidPooling2D = pooling_2d.SpatialPyramidPooling2D
 Pooling2D = pooling_2d.Pooling2D
 LocalResponseNormalization = \
     local_response_normalization.LocalResponseNormalization
@@ -101,6 +102,7 @@ tanh = tanh.tanh
 
 average_pooling_2d = pooling_2d.average_pooling_2d
 max_pooling_2d = pooling_2d.max_pooling_2d
+spatial_pyramid_pooling_2d = pooling_2d.spatial_pyramid_pooling_2d
 local_response_normalization = \
     local_response_normalization.local_response_normalization
 

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -383,8 +383,7 @@ class SpatialPyramidPooling2D(function.Function):
             ksize = (ksize_h, ksize_w)
             pad = (pad_h, pad_w)
 
-            if ((pooling_class == MaxPooling2D) or
-                    (pooling_class == AveragePooling2D)):
+            if pooling_class == MaxPooling2D:
                 pooler = pooling_class(ksize=ksize, stride=None, pad=pad,
                                        cover_all=True, use_cudnn=use_cudnn)
                 self.poolers.append(pooler)

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -422,23 +422,47 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
 
     It outputs a fixed-length vector regardless of input feature map size.
 
+    It performs pooling operation to the input 4D-array ``x`` with different
+    kernel sizes and padding sizes, and then flattens all dimensions except
+    first dimension of all pooling results, and finally concatenates them along
+    2nd dimension.
+
+    At :math:`i`-th pyramid level, the kernel size
+    :math:`(k_h^{(i)}, k_w^{(i)})` and padding size
+    :math:`(p_h^{(i)}, p_w^{(i)})` of pooling operation are calculated as
+    below:
+
+    .. math::
+        k_h^{(i)} &= \\lceil b_h / 2^i \\rceil, \\\\
+        k_w^{(i)} &= \\lceil b_w / 2^i \\rceil, \\\\
+        p_h^{(i)} &= (2^i k_h^{(i)} - b_h) / 2, \\\\
+        p_w^{(i)} &= (2^i k_w^{(i)} - b_w) / 2,
+
+    where :math:`\\lceil \\cdot \\rceil` denotes the ceiling function, and
+    :math:`b_h, b_w` are height and width of input variable ``x``,
+    respectively. Note that index of pyramid level :math:`i` is zero-based.
+
     See detail in paper: `Spatial Pyramid Pooling in Deep Convolutional \
     Networks for Visual Recognition \
     <http://arxiv.org/abs/1406.4729>`_.
 
     Args:
-        x (~chainer.Variable): Input variable. The shape of `x` should be
+        x (~chainer.Variable): Input variable. The shape of ``x`` should be
             (batchsize, # of channels, height, width).
         pyramid_height (int): the number of pyramid levels
-        pooling_class (~functions.MaxPooling2D or ~functions.AveragePooling2D):
+        pooling_class (MaxPooling2D or AveragePooling2D):
             Only MaxPooling2D class can be available for now.
         use_cudnn (bool): If True and CuDNN is enabled, then this function
             uses CuDNN as the core implementation.
 
     Returns:
-        ~chainer.Variable: Ouptut variable.
+        ~chainer.Variable: Ouptut variable. The shape of the output variable
+            will be (batchsize, :math:`c \\sum_{h=0}^{H-1} 2^{2h}`, 1, 1),
+            where :math:`c` is the number of channels of input variable ``x``
+            and :math:`H` is the number of pyramid levels.
 
-    .. note:
+    .. note::
+
         This function uses some pooling classes as components to perform
         spatial pyramid pooling. Now it supports only
         :class:`~functions.MaxPooling2D` as elemental pooling operator so far.

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -363,8 +363,6 @@ class SpatialPyramidPooling2D(function.Function):
 
     def __init__(self, x_shape, pyramid_height, pooling_class, use_cudnn=True):
         bottom_c, bottom_h, bottom_w = x_shape
-        assert bottom_h > 3 and bottom_w > 3, \
-            'input feature map size should be larger than 3'
         self.pyramid_height = pyramid_height
 
         # create pooling functions for different pyramid levels

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -369,7 +369,7 @@ class SpatialPyramidPooling2D(function.Function):
 
         # create pooling functions for different pyramid levels
         split_inds = []
-        self.out_dim = 0
+        out_dim = 0
         self.poolers = []
         for pyramid_level in six.moves.range(pyramid_height):
             num_bins = int(2 ** pyramid_level)
@@ -393,9 +393,9 @@ class SpatialPyramidPooling2D(function.Function):
             else:
                 raise NotImplementedError()
 
-            self.out_dim += bottom_c * (num_bins ** 2)
+            out_dim += bottom_c * (num_bins ** 2)
             if pyramid_level < pyramid_height - 1:
-                split_inds.append(self.out_dim)
+                split_inds.append(out_dim)
 
         self.split = split_axis.SplitAxis(split_inds, axis=1)
 

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -385,13 +385,12 @@ class SpatialPyramidPooling2D(function.Function):
             ksize = (int(ksize_h), int(ksize_w))
             pad = (int(pad_h), int(pad_w))
 
-            if pooling_class == MaxPooling2D:
+            if ((pooling_class == MaxPooling2D) or
+                    (pooling_class == AveragePooling2D)):
                 pooler = pooling_class(ksize=ksize, stride=None, pad=pad,
                                        cover_all=True, use_cudnn=use_cudnn)
                 self.poolers.append(pooler)
-
-            if pooling_class == AveragePooling2D:
-                # cover_all mode is needed also for average pooling
+            else:
                 raise NotImplementedError()
 
             self.out_dim += bottom_c * (num_bins ** 2)

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -361,8 +361,8 @@ class SpatialPyramidPooling2D(function.Function):
 
     """Spatial pyramid pooling over a set of 2d planes."""
 
-    def __init__(self, x, pyramid_height, pooling_class, use_cudnn=True):
-        bottom_c, bottom_h, bottom_w = x.data.shape[1:]
+    def __init__(self, x_shape, pyramid_height, pooling_class, use_cudnn=True):
+        bottom_c, bottom_h, bottom_w = x_shape
         assert bottom_h > 3 and bottom_w > 3, \
             'input feature map size should be larger than 3'
         self.pyramid_height = pyramid_height
@@ -455,5 +455,5 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
 
     """
 
-    return SpatialPyramidPooling2D(x, pyramid_height, pooling_class,
-                                   use_cudnn=True)(x)
+    return SpatialPyramidPooling2D(x.data.shape[1:], pyramid_height,
+                                   pooling_class, use_cudnn=True)(x)

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -372,16 +372,16 @@ class SpatialPyramidPooling2D(function.Function):
         for pyramid_level in six.moves.range(pyramid_height):
             num_bins = int(2 ** pyramid_level)
 
-            ksize_h = numpy.ceil(bottom_h / (float(num_bins)))
+            ksize_h = int(numpy.ceil(bottom_h / (float(num_bins))))
             remainder_h = ksize_h * num_bins - bottom_h
             pad_h = remainder_h // 2
 
-            ksize_w = numpy.ceil(bottom_w / (float(num_bins)))
+            ksize_w = int(numpy.ceil(bottom_w / (float(num_bins))))
             remainder_w = ksize_w * num_bins - bottom_w
             pad_w = remainder_w // 2
 
-            ksize = (int(ksize_h), int(ksize_w))
-            pad = (int(pad_h), int(pad_w))
+            ksize = (ksize_h, ksize_w)
+            pad = (pad_h, pad_w)
 
             if ((pooling_class == MaxPooling2D) or
                     (pooling_class == AveragePooling2D)):

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -398,7 +398,6 @@ class SpatialPyramidPooling2D(function.Function):
             if pyramid_level < pyramid_height - 1:
                 split_inds.append(self.out_dim)
 
-        self.concat = concat.Concat(axis=1)
         self.split = split_axis.SplitAxis(split_inds, axis=1)
 
     def forward(self, x):
@@ -408,7 +407,7 @@ class SpatialPyramidPooling2D(function.Function):
             n, c, h, w = pooler.out_shape = y.shape
             self.ys.append(y.reshape((n, c * h * w, 1, 1)))
 
-        return self.concat.forward(self.ys)
+        return concat.Concat(axis=1).forward(self.ys)
 
     def backward(self, x, gy):
         if isinstance(x[0], cuda.GPUArray):

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -382,12 +382,12 @@ class SpatialPyramidPooling2D(function.Function):
             remainder_w = ksize_w * num_bins - bottom_w
             pad_w = remainder_w / 2
 
-            ksize = map(int, [ksize_h, ksize_w])
-            stride = ksize
-            pad = map(int, [pad_h, pad_w])
+            ksize = (int(ksize_h), int(ksize_w))
+            pad = (int(pad_h), int(pad_w))
 
             if pooling_class == MaxPooling2D:
-                pooler = pooling_class(ksize, stride, pad, True, use_cudnn)
+                pooler = pooling_class(ksize=ksize, stride=None, pad=pad,
+                                       cover_all=True, use_cudnn=use_cudnn)
                 self.poolers.append(pooler)
 
             if pooling_class == AveragePooling2D:

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -216,7 +216,7 @@ def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
         ksize (int or (int, int)): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int or (int, int) or None): Stride of pooling applications.
-            ``ksize=k`` and ``ksize=(k, k)`` are equivalent. If None is
+            ``stride=s`` and ``stride=(s, s)`` are equivalent. If None is
             specified, then it uses same stride as the pooling window size.
         pad (int or (int, int)): Spatial padding width for the input array.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
@@ -338,7 +338,7 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
         ksize (int or (int, int)): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int or (int, int) or None): Stride of pooling applications.
-            ``ksize=k`` and ``ksize=(k, k)`` are equivalent. If None is
+            ``stride=s`` and ``stride=(s, s)`` are equivalent. If None is
             specified, then it uses same stride as the pooling window size.
         pad (int or (int, int)): Spatial padding width for the input array.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -410,17 +410,11 @@ class SpatialPyramidPooling2D(function.Function):
 
         return self.concat.forward(self.ys)
 
-    def backward_cpu(self, x, gy):
-        gx = numpy.zeros_like(x[0])
-        gys = self.split.forward(gy)
-        for pooler, gy in zip(self.poolers, gys):
-            gy = gy.reshape(pooler.out_shape)
-            gx += pooler.backward(x, (gy,))[0]
-
-        return gx,
-
-    def backward_gpu(self, x, gy):
-        gx = cuda.zeros_like(x[0])
+    def backward(self, x, gy):
+        if isinstance(x[0], cuda.GPUArray):
+            gx = cuda.zeros_like(x[0])
+        else:
+            gx = numpy.zeros_like(x[0])
         gys = self.split.forward(gy)
         for pooler, gy in zip(self.poolers, gys):
             gy = gy.reshape(pooler.out_shape)

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -376,11 +376,11 @@ class SpatialPyramidPooling2D(function.Function):
 
             ksize_h = numpy.ceil(bottom_h / (float(num_bins)))
             remainder_h = ksize_h * num_bins - bottom_h
-            pad_h = remainder_h / 2
+            pad_h = remainder_h // 2
 
             ksize_w = numpy.ceil(bottom_w / (float(num_bins)))
             remainder_w = ksize_w * num_bins - bottom_w
-            pad_w = remainder_w / 2
+            pad_w = remainder_w // 2
 
             ksize = (int(ksize_h), int(ksize_w))
             pad = (int(pad_h), int(pad_w))

--- a/chainer/functions/pooling_2d.py
+++ b/chainer/functions/pooling_2d.py
@@ -427,17 +427,15 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
                                use_cudnn=True):
     """Spatial pyramid pooling function.
 
-    This function uses some pooling classes as components to perform spatial
-    pyramid pooling. Now it supports only :class:`~functions.MaxPooling2D` as
-    elemental pooling operator so far. It outputs a fixed-length vector
-    regardless of input feature map size.
+    It outputs a fixed-length vector regardless of input feature map size.
 
     See detail in paper: `Spatial Pyramid Pooling in Deep Convolutional \
     Networks for Visual Recognition \
     <http://arxiv.org/abs/1406.4729>`_.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (~chainer.Variable): Input variable. The shape of `x` should be
+            (batchsize, # of channels, height, width).
         pyramid_height (int): the number of pyramid levels
         pooling_class (~functions.MaxPooling2D or ~functions.AveragePooling2D):
             Only MaxPooling2D class can be available for now.
@@ -446,6 +444,11 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
 
     Returns:
         ~chainer.Variable: Ouptut variable.
+
+    .. note:
+        This function uses some pooling classes as components to perform
+        spatial pyramid pooling. Now it supports only
+        :class:`~functions.MaxPooling2D` as elemental pooling operator so far.
 
     """
 

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -55,6 +55,7 @@ Pooling functions
 -----------------
 .. autofunction:: average_pooling_2d
 .. autofunction:: max_pooling_2d
+.. autofunction:: spatial_pyramid_pooling_2d
 
 Normalization functions
 -----------------------

--- a/tests/functions_tests/test_pooling_2d.py
+++ b/tests/functions_tests/test_pooling_2d.py
@@ -181,7 +181,7 @@ class TestAveragePooling2D(unittest.TestCase):
 
 class TestSpatialPyramidPooling2D(unittest.TestCase):
     pyramid_height = 3
-    output_dim = 63  # pyramid_height(=3) * (1 + 4 + 16) = 63
+    output_dim = 63  # channels(c=3) * (1 + 4 + 16) = 63
     n, c, h, w = 2, 3, 9, 8
     pooling_class = functions.MaxPooling2D
 

--- a/tests/functions_tests/test_pooling_2d.py
+++ b/tests/functions_tests/test_pooling_2d.py
@@ -179,4 +179,82 @@ class TestAveragePooling2D(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
 
 
+class TestSpatialPyramidPooling2D(unittest.TestCase):
+    pyramid_height = 3
+    output_dim = 63  # pyramid_height(=3) * (1 + 4 + 16) = 63
+    n, c, h, w = 2, 3, 9, 8
+    pooling_class = functions.MaxPooling2D
+
+    def setUp(self):
+        # Avoid unstability of numerical gradient
+        self.x = numpy.random.randn(
+            self.n, self.c, self.h, self.w).astype(numpy.float32)
+        self.one = numpy.ones(
+            (self.n, self.c, self.h, self.w)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (self.n, self.output_dim, 1, 1))
+        self.gy = self.gy.astype(numpy.float32)
+
+    def check_forward(self, x_data, use_cudnn=True):
+        x = chainer.Variable(x_data)
+        y = functions.spatial_pyramid_pooling_2d(
+            x, self.pyramid_height, self.pooling_class,
+            use_cudnn=use_cudnn)
+        self.assertEqual(y.data.dtype, numpy.float32)
+        y_data = cuda.to_cpu(y.data)
+
+        self.assertEqual(self.gy.shape, y_data.shape)
+
+    def check_forward_ones(self, x_data, use_cudnn=True):
+        x = chainer.Variable(x_data)
+        y = functions.spatial_pyramid_pooling_2d(
+            x, self.pyramid_height, self.pooling_class, use_cudnn=use_cudnn)
+        y_data = cuda.to_cpu(y.data)
+
+        self.assertEqual((self.n, self.output_dim, 1, 1), y_data.shape)
+        gradient_check.assert_allclose(y_data, numpy.ones_like(y_data))
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+        self.check_forward_ones(self.one)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+        self.check_forward_ones(cuda.to_gpu(self.one))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu_no_cudnn(self):
+        self.check_forward(cuda.to_gpu(self.x), False)
+        self.check_forward_ones(cuda.to_gpu(self.one), False)
+
+    def check_backward(self, x_data, y_grad, use_cudnn=True):
+        x = chainer.Variable(x_data)
+        y = functions.spatial_pyramid_pooling_2d(
+            x, self.pyramid_height, self.pooling_class, use_cudnn=use_cudnn)
+        y.grad = y_grad
+        y.backward()
+
+        func = y.creator
+        f = lambda: func.forward((x.data,))
+        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
+
+        gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu_no_cudnn(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds a non-parameterized function which performs Spatial Pyramid Pooling (SPP). This function enables a network to accept input images of an arbitrary shape/size and generate a fixed-length feature vector regardless of the shape/size of feature maps in the next lower layer. The paper linked below shows that a network with SPP (SPP-net) boosts the accuracy of a variety of CNN for object recognition.

I tested `spatial_pyramid_pooling_2d` function as a pooling layer by replacing the last `max_pooling_2d` layer in LeNet architecture with SPP. I trained the network on MNIST dataset, and got the 99.9% accuracy. So I think it works fine.

Please see details about SPP in the paper:
"Spatial Pyramid Pooling in Deep Convolutional Networks for Visual Recognition"
http://arxiv.org/abs/1406.4729

Note that this function supports only `MaxPooling2D` as elemental pooling operator because `AveragePooling2D` does not support `cover_all` mode for now.

I also fixed some typos in documentations of `max_pooling_2d` and `average_pooling_2d` functions in this PR.