### PR TITLE
Extend a softmax function and the loss layer to support replicated softmax units

### DIFF
--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -136,8 +136,8 @@ class Softmax(function.Function):
             cuda.elementwise(
                 'float* sum_ydy, const float* ydy, int n_channel, int n_unit',
                 '''
-                   int n = i / n_unit;
-                   int m = i % n_unit;
+                   const int n = i / n_unit;
+                   const int m = i % n_unit;
                    const float* row = ydy + n * n_channel * n_unit + m;
                    float sum = 0;
                    for (int c = 0; c < n_channel; ++c) {

--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -82,7 +82,7 @@ class Softmax(function.Function):
                 ''',
                 '''
                    const int n = i / (n_channel * n_unit);
-                   const int m = (i % (n_channel * n_unit)) % n_unit;
+                   const int m = i % n_unit;
                    y[i] = __expf(x[i] - maxes[n * n_unit + m]);
                 ''',
                 'softmax_exp')(y, x[0], maxes, c, n_unit)
@@ -103,7 +103,7 @@ class Softmax(function.Function):
                 'float* y, const float* coeff, int n_channel, int n_unit',
                 '''
                    const int n = i / (n_channel * n_unit);
-                   const int m = (i % (n_channel * n_unit)) % n_unit;
+                   const int m = i % n_unit;
                    y[i] *= coeff[n * n_unit + m];
                 ''',
                 'softmax_rowmul')(y, coeff, c, n_unit)
@@ -152,7 +152,7 @@ class Softmax(function.Function):
                 ''',
                 '''
                    const int n = i / (n_channel * n_unit);
-                   const int m = (i % (n_channel * n_unit)) % n_unit;
+                   const int m = i % n_unit;
                    gx[i] -= y[i] * sum_ydy[n * n_unit + m];
                 ''',
                 'softmax_bwd_diff')(gx, self.y, sum_ydy, c, n_unit)

--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -48,10 +48,10 @@ class Softmax(function.Function):
 
     def forward_gpu(self, x):
         y = cuda.empty_like(x[0])
-        n_units = int(numpy.prod(x[0].shape[2:]))
+        n_unit = int(numpy.prod(x[0].shape[2:]))
         if cudnn.enabled and self.use_cudnn:
             handle = cudnn.get_default_handle()
-            desc = cudnn.get_tensor_desc(x[0], n_units, 1)
+            desc = cudnn.get_tensor_desc(x[0], n_unit, 1)
             libcudnn.cudnnSoftmaxForward(
                 handle, _algorithm, _mode, 1, desc.value, cudnn.get_ptr(x[0]),
                 0, desc.value, cudnn.get_ptr(y))
@@ -61,52 +61,52 @@ class Softmax(function.Function):
             maxes = cuda.empty(maxes_shape, dtype=numpy.float32)
             c = x[0].shape[1]
             cuda.elementwise(
-                'float* maxes, const float* x, int n_channel, int n_units',
+                'float* maxes, const float* x, int n_channel, int n_unit',
                 '''
-                   const int n = i / n_units;
-                   const int m = i % n_units;
-                   const float* row = x + n * n_channel * n_units + m;
+                   const int n = i / n_unit;
+                   const int m = i % n_unit;
+                   const float* row = x + n * n_channel * n_unit + m;
                    float maxval = row[0];
                    for (int c = 1; c < n_channel; ++c) {
-                     const int v = c * n_units;
+                     const int v = c * n_unit;
                      if (maxval < row[v]) {
                        maxval = row[v];
                      }
                    }
                    maxes[i] = maxval;
-                ''', 'softmax_rowmax')(maxes, x[0], c, n_units)
+                ''', 'softmax_rowmax')(maxes, x[0], c, n_unit)
             cuda.elementwise(
                 '''
                    float* y, const float* x, const float* maxes,
-                   int n_channel, int n_units
+                   int n_channel, int n_unit
                 ''',
                 '''
-                   const int n = i / (n_channel * n_units);
-                   const int m = (i % (n_channel * n_units)) % n_units;
-                   y[i] = __expf(x[i] - maxes[n * n_units + m]);
+                   const int n = i / (n_channel * n_unit);
+                   const int m = (i % (n_channel * n_unit)) % n_unit;
+                   y[i] = __expf(x[i] - maxes[n * n_unit + m]);
                 ''',
-                'softmax_exp')(y, x[0], maxes, c, n_units)
+                'softmax_exp')(y, x[0], maxes, c, n_unit)
             coeff = maxes  # reuse memory
             cuda.elementwise(
-                'float* coeff, const float* y, int n_channel, int n_units',
+                'float* coeff, const float* y, int n_channel, int n_unit',
                 '''
-                   const int n = i / n_units;
-                   const int m = i % n_units;
-                   const float* row = y + n * n_channel * n_units + m;
+                   const int n = i / n_unit;
+                   const int m = i % n_unit;
+                   const float* row = y + n * n_channel * n_unit + m;
                    float sum = 0;
                    for (int c = 0; c < n_channel; ++c) {
-                     sum += row[c * n_units];
+                     sum += row[c * n_unit];
                    }
                    coeff[i] = 1 / sum;
-                ''', 'softmax_invrowsum')(coeff, y, c, n_units)
+                ''', 'softmax_invrowsum')(coeff, y, c, n_unit)
             cuda.elementwise(
-                'float* y, const float* coeff, int n_channel, int n_units',
+                'float* y, const float* coeff, int n_channel, int n_unit',
                 '''
-                   const int n = i / (n_channel * n_units);
-                   const int m = (i % (n_channel * n_units)) % n_units;
-                   y[i] *= coeff[n * n_units + m];
+                   const int n = i / (n_channel * n_unit);
+                   const int m = (i % (n_channel * n_unit)) % n_unit;
+                   y[i] *= coeff[n * n_unit + m];
                 ''',
-                'softmax_rowmul')(y, coeff, c, n_units)
+                'softmax_rowmul')(y, coeff, c, n_unit)
             self.y = y
 
         return y,
@@ -118,11 +118,11 @@ class Softmax(function.Function):
         return gx,
 
     def backward_gpu(self, x, gy):
-        n_units = int(numpy.prod(x[0].shape[2:]))
+        n_unit = int(numpy.prod(x[0].shape[2:]))
         if cudnn.enabled and self.use_cudnn:
             handle = cudnn.get_default_handle()
             gx = cuda.empty_like(x[0])
-            desc = cudnn.get_tensor_desc(x[0], n_units, 1)
+            desc = cudnn.get_tensor_desc(x[0], n_unit, 1)
             libcudnn.cudnnSoftmaxBackward(
                 handle, _algorithm, _mode, 1, desc.value, cudnn.get_ptr(
                     self.y),
@@ -134,28 +134,28 @@ class Softmax(function.Function):
             sum_ydy_shape = (gx.shape[0],) + gx.shape[2:]
             sum_ydy = cuda.empty(sum_ydy_shape, dtype=numpy.float32)
             cuda.elementwise(
-                'float* sum_ydy, const float* ydy, int n_channel, int n_units',
+                'float* sum_ydy, const float* ydy, int n_channel, int n_unit',
                 '''
-                   int n = i / n_units;
-                   int m = i % n_units;
-                   const float* row = ydy + n * n_channel * n_units + m;
+                   int n = i / n_unit;
+                   int m = i % n_unit;
+                   const float* row = ydy + n * n_channel * n_unit + m;
                    float sum = 0;
                    for (int c = 0; c < n_channel; ++c) {
-                     sum += row[c * n_units];
+                     sum += row[c * n_unit];
                    }
                    sum_ydy[i] = sum;
-                ''', 'softmax_bwd_sum_ydy')(sum_ydy, gx, c, n_units)
+                ''', 'softmax_bwd_sum_ydy')(sum_ydy, gx, c, n_unit)
             cuda.elementwise(
                 '''
                    float* gx, const float* y, const float* sum_ydy,
-                   int n_channel, int n_units
+                   int n_channel, int n_unit
                 ''',
                 '''
-                   const int n = i / (n_channel * n_units);
-                   const int m = (i % (n_channel * n_units)) % n_units;
-                   gx[i] -= y[i] * sum_ydy[n * n_units + m];
+                   const int n = i / (n_channel * n_unit);
+                   const int m = (i % (n_channel * n_unit)) % n_unit;
+                   gx[i] -= y[i] * sum_ydy[n * n_unit + m];
                 ''',
-                'softmax_bwd_diff')(gx, self.y, sum_ydy, c, n_units)
+                'softmax_bwd_diff')(gx, self.y, sum_ydy, c, n_unit)
 
         return gx,
 

--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -8,7 +8,7 @@ from chainer.utils import type_check
 if cudnn.available:
     from chainer.cudnn import libcudnn
     _algorithm = libcudnn.cudnnSoftmaxAlgorithm['CUDNN_SOFTMAX_ACCURATE']
-    _mode = libcudnn.cudnnSoftmaxMode['CUDNN_SOFTMAX_MODE_INSTANCE']
+    _mode = libcudnn.cudnnSoftmaxMode['CUDNN_SOFTMAX_MODE_CHANNEL']
 
 
 class Softmax(function.Function):
@@ -24,7 +24,7 @@ class Softmax(function.Function):
 
         type_check.expect(
             x_type.dtype == numpy.float32,
-            x_type.ndim == 2,
+            x_type.ndim > 1,
         )
 
     def check_type_backward(self, in_types, out_types):
@@ -36,10 +36,8 @@ class Softmax(function.Function):
         y_type, = out_types
 
         type_check.expect(
-            y_type.ndim == 2,
-
-            y_type.shape[0] == x_type.shape[0],
-            y_type.shape[1] == x_type.shape[1],
+            y_type.ndim > 1,
+            y_type.shape == x_type.shape,
         )
 
     def forward_cpu(self, x):
@@ -50,46 +48,65 @@ class Softmax(function.Function):
 
     def forward_gpu(self, x):
         y = cuda.empty_like(x[0])
+        n_units = int(numpy.prod(x[0].shape[2:]))
         if cudnn.enabled and self.use_cudnn:
             handle = cudnn.get_default_handle()
-            desc = cudnn.get_tensor_desc(x[0], 1, 1)
+            desc = cudnn.get_tensor_desc(x[0], n_units, 1)
             libcudnn.cudnnSoftmaxForward(
                 handle, _algorithm, _mode, 1, desc.value, cudnn.get_ptr(x[0]),
                 0, desc.value, cudnn.get_ptr(y))
             self.y = y
         else:
-            maxes = cuda.empty((x[0].shape[0],), dtype=numpy.float32)
+            maxes_shape = (x[0].shape[0],) + x[0].shape[2:]
+            maxes = cuda.empty(maxes_shape, dtype=numpy.float32)
             c = x[0].shape[1]
             cuda.elementwise(
-                'float* maxes, const float* x, int c',
+                'float* maxes, const float* x, int n_channel, int n_units',
                 '''
-                   const float* row = x + i * c;
+                   const int n = i / n_units;
+                   const int m = i % n_units;
+                   const float* row = x + n * n_channel * n_units + m;
                    float maxval = row[0];
-                   for (int j = 1; j < c; ++j) {
-                     if (maxval < row[j]) {
-                       maxval = row[j];
+                   for (int c = 1; c < n_channel; ++c) {
+                     const int v = c * n_units;
+                     if (maxval < row[v]) {
+                       maxval = row[v];
                      }
                    }
                    maxes[i] = maxval;
-                ''', 'softmax_rowmax')(maxes, x[0], c)
+                ''', 'softmax_rowmax')(maxes, x[0], c, n_units)
             cuda.elementwise(
-                'float* y, const float* x, const float* maxes, int c',
-                'y[i] = __expf(x[i] - maxes[i / c])',
-                'softmax_exp')(y, x[0], maxes, c)
+                '''
+                   float* y, const float* x, const float* maxes,
+                   int n_channel, int n_units
+                ''',
+                '''
+                   const int n = i / (n_channel * n_units);
+                   const int m = (i % (n_channel * n_units)) % n_units;
+                   y[i] = __expf(x[i] - maxes[n * n_units + m]);
+                ''',
+                'softmax_exp')(y, x[0], maxes, c, n_units)
             coeff = maxes  # reuse memory
             cuda.elementwise(
-                'float* coeff, const float* y, int c',
+                'float* coeff, const float* y, int n_channel, int n_units',
                 '''
-                   const float* row = y + i * c;
+                   const int n = i / n_units;
+                   const int m = i % n_units;
+                   const float* row = y + n * n_channel * n_units + m;
                    float sum = 0;
-                   for (int j = 0; j < c; ++j) {
-                     sum += row[j];
+                   for (int c = 0; c < n_channel; ++c) {
+                     sum += row[c * n_units];
                    }
                    coeff[i] = 1 / sum;
-                ''', 'softmax_invrowsum')(coeff, y, c)
+                ''', 'softmax_invrowsum')(coeff, y, c, n_units)
             cuda.elementwise(
-                'float* y, const float* coeff, int c', 'y[i] *= coeff[i / c]',
-                'softmax_rowmul')(y, coeff, c)
+                'float* y, const float* coeff, int n_channel, int n_units',
+                '''
+                   const int n = i / (n_channel * n_units);
+                   const int m = (i % (n_channel * n_units)) % n_units;
+                   y[i] *= coeff[n * n_units + m];
+                ''',
+                'softmax_rowmul')(y, coeff, c, n_units)
             self.y = y
 
         return y,
@@ -101,10 +118,11 @@ class Softmax(function.Function):
         return gx,
 
     def backward_gpu(self, x, gy):
+        n_units = int(numpy.prod(x[0].shape[2:]))
         if cudnn.enabled and self.use_cudnn:
             handle = cudnn.get_default_handle()
             gx = cuda.empty_like(x[0])
-            desc = cudnn.get_tensor_desc(x[0], 1, 1)
+            desc = cudnn.get_tensor_desc(x[0], n_units, 1)
             libcudnn.cudnnSoftmaxBackward(
                 handle, _algorithm, _mode, 1, desc.value, cudnn.get_ptr(
                     self.y),
@@ -113,21 +131,31 @@ class Softmax(function.Function):
         else:
             gx = self.y * gy[0]
             c = gx.shape[1]
-            sum_ydy = cuda.empty((gx.shape[0],), dtype=numpy.float32)
+            sum_ydy_shape = (gx.shape[0],) + gx.shape[2:]
+            sum_ydy = cuda.empty(sum_ydy_shape, dtype=numpy.float32)
             cuda.elementwise(
-                'float* sum_ydy, const float* ydy, int c',
+                'float* sum_ydy, const float* ydy, int n_channel, int n_units',
                 '''
-                   const float* row = ydy + i * c;
+                   int n = i / n_units;
+                   int m = i % n_units;
+                   const float* row = ydy + n * n_channel * n_units + m;
                    float sum = 0;
-                   for (int j = 0; j < c; ++j) {
-                     sum += row[j];
+                   for (int c = 0; c < n_channel; ++c) {
+                     sum += row[c * n_units];
                    }
                    sum_ydy[i] = sum;
-                ''', 'softmax_bwd_sum_ydy')(sum_ydy, gx, c)
+                ''', 'softmax_bwd_sum_ydy')(sum_ydy, gx, c, n_units)
             cuda.elementwise(
-                'float* gx, const float* y, const float* sum_ydy, int c',
-                'gx[i] -= y[i] * sum_ydy[i / c]',
-                'softmax_bwd_diff')(gx, self.y, sum_ydy, c)
+                '''
+                   float* gx, const float* y, const float* sum_ydy,
+                   int n_channel, int n_units
+                ''',
+                '''
+                   const int n = i / (n_channel * n_units);
+                   const int m = (i % (n_channel * n_units)) % n_units;
+                   gx[i] -= y[i] * sum_ydy[n * n_units + m];
+                ''',
+                'softmax_bwd_diff')(gx, self.y, sum_ydy, c, n_units)
 
         return gx,
 

--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -163,10 +163,12 @@ class Softmax(function.Function):
 def softmax(x, use_cudnn=True):
     """Channelwise softmax function.
 
-    This function only accepts a two dimensional input array, and computes its
-    softmax along the second axis. For each index :math:`i, j` of the input
-    matrix :math:`x`, it computes
-    :math:`f_{ij}(x)={\\exp(x_{ij}) \\over \\sum_j \\exp(x_{ij})}`.
+    This function computes its softmax along the second axis. Let
+    :math:`x = (x_1, x_2, \\dots, x_d)^{\\top}` be the d dimensional index
+    array and :math:`f(x)` be the d dimensional input array. For each index
+    :math:`x` of the input array :math:`f(x)`, it computes the probability
+    :math:`p(x)` defined as
+    :math:`p(x) = {\\exp(f(x)) \\over \\sum_{x_2} \\exp(f(x))}`.
 
     Args:
         x (~chainer.Variable): Input variable.

--- a/chainer/functions/softmax_cross_entropy.py
+++ b/chainer/functions/softmax_cross_entropy.py
@@ -20,11 +20,11 @@ class SoftmaxCrossEntropy(function.Function):
 
         type_check.expect(
             x_type.dtype == numpy.float32,
-            x_type.ndim == 2,
             t_type.dtype == numpy.int32,
-            t_type.ndim == 1,
+            t_type.ndim == x_type.ndim - 1,
 
             x_type.shape[0] == t_type.shape[0],
+            x_type.shape[2:] == t_type.shape[1:],
         )
 
     def check_type_backward(self, in_types, out_types):
@@ -38,38 +38,56 @@ class SoftmaxCrossEntropy(function.Function):
     def forward_cpu(self, inputs):
         x, t = inputs
         self.y, = softmax.Softmax().forward_cpu((x,))
-        p = self.y[six.moves.range(len(t)), t]
-        y = -numpy.log(p).sum(keepdims=True) / t.size
+        yd = self.y.transpose(
+            [0] + list(six.moves.range(2, self.y.ndim)) + [1])
+        yd = yd.reshape(numpy.prod(yd.shape[:-1]), -1)
+        p = yd[six.moves.range(t.size), t.flat]
+        y = -numpy.log(p).sum(keepdims=True) / t.shape[0]
         return y.reshape(()),
 
     def forward_gpu(self, inputs):
         x, t = inputs
         self.y, = softmax.Softmax(self.use_cudnn).forward_gpu((x,))
+        n_units = int(numpy.prod(self.y.shape[2:]))
+        # the map_expr is equivalent to the pseudo code -log(y[n, c, m]),
+        # where n = i / n_units, c = t[i], and m = i % n_units
         ret = cuda.reduce(
-            'int* t, float* y, int n_channel', '-log(y[i * n_channel + t[i]])',
+            'int* t, float* y, int n_channel, int n_units',
+            '-log(y[n_units * ((i / n_units) * n_channel + t[i])'
+            '       + (i % n_units)])',
             'a+b', '0', 'crossent_fwd', numpy.float32
-        )(t, self.y, self.y.shape[1])
-        ret /= t.size
+        )(t, self.y, self.y.shape[1], n_units)
+        ret /= t.shape[0]
         return ret,
 
     def backward_cpu(self, inputs, grad_outputs):
         t, gloss = inputs[1], grad_outputs[0]
-        gx = self.y.copy()
-        gx[six.moves.range(len(t)), t] -= 1
-        gx *= gloss / t.size
+        n_units = int(numpy.prod(self.y.shape[2:]))
+        gx = self.y.copy().reshape(self.y.shape[0], self.y.shape[1], -1)
+        fst_index = numpy.arange(t.size) // n_units
+        trd_index = numpy.arange(t.size) % n_units
+        gx[fst_index, t.flat, trd_index] -= 1
+        gx = (gloss / t.shape[0]) * gx.reshape(self.y.shape)
         return gx, None
 
     def backward_gpu(self, inputs, grad_outputs):
         t, gloss = inputs[1], grad_outputs[0]
+        n_units = int(numpy.prod(self.y.shape[2:]))
         gx = cuda.empty_like(self.y)
-        coeff = gloss / t.size
+        coeff = gloss / t.shape[0]
         cuda.elementwise(
             '''
                float* gx, const float* y, const int* t, const float* coeff,
-               int n_channel
+               int n_channel, int n_units
             ''',
-            'gx[i] = *coeff * (y[i] - ((i % n_channel) == t[i / n_channel]))',
-            'softmax_crossent_bwd')(gx, self.y, t, coeff, self.y.shape[1])
+            '''
+               const int n = i / (n_channel * n_units);
+               const int c = (i % (n_channel * n_units)) / n_units;
+               const int m = (i % (n_channel * n_units)) % n_units;
+               gx[i] = *coeff * (y[i] - (c == t[n * n_units + m]));
+            ''',
+            'softmax_crossent_bwd')(
+                gx, self.y, t, coeff, self.y.shape[1], n_units)
         return gx, None
 
 

--- a/chainer/functions/softmax_cross_entropy.py
+++ b/chainer/functions/softmax_cross_entropy.py
@@ -103,9 +103,13 @@ def softmax_cross_entropy(x, t, use_cudnn=True):
     """Computes cross entropy loss for pre-softmax activations.
 
     Args:
-        x (Variable): Variable holding a matrix whose (i, j)-th element
-            indicates unnormalized log probability of the class j at the i-th
-            example.
+        x (Variable): Variable holding a multidimensional array whose element
+            indicates unnormalized log probability: the first axis of the
+            variable represents the number of samples, and the second axis
+            represents the number of classes. While this function computes
+            a usual softmax cross entropy if the number of dimensions is equal
+            to 2, it computes a cross entropy of the replicated softmax if the
+            number of dimensions is greater than 2.
         t (Variable): Variable holding an int32 vector of groundtruth labels.
 
     Returns:

--- a/tests/functions_tests/test_softmax.py
+++ b/tests/functions_tests/test_softmax.py
@@ -96,8 +96,10 @@ class TestReplicatedSoftmax1(TestSoftmax):
 class TestReplicatedSoftmax2(TestSoftmax):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (2, 3, 4, 5)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, (2, 3, 4, 5)).astype(numpy.float32)
+        self.x = numpy.random.uniform(
+            -1, 1, (2, 3, 4, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (2, 3, 4, 5)).astype(numpy.float32)
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/functions_tests/test_softmax.py
+++ b/tests/functions_tests/test_softmax.py
@@ -19,8 +19,8 @@ if cuda.available:
 class TestSoftmax(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)
@@ -29,7 +29,8 @@ class TestSoftmax(unittest.TestCase):
 
         y_expect = numpy.exp(self.x)
         for i in six.moves.range(y_expect.shape[0]):
-            y_expect[i] /= y_expect[i].sum()
+            for k in six.moves.range(y_expect.shape[2]):
+                y_expect[i, :, k] /= y_expect[i, :, k].sum()
 
         gradient_check.assert_allclose(y_expect, y.data)
 
@@ -44,7 +45,7 @@ class TestSoftmax(unittest.TestCase):
 
     @attr.gpu
     @condition.retry(3)
-    def test_forwrad_gpu_no_cudnn(self):
+    def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, gy_data, use_cudnn=True):

--- a/tests/functions_tests/test_softmax.py
+++ b/tests/functions_tests/test_softmax.py
@@ -19,8 +19,8 @@ if cuda.available:
 class TestSoftmax(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)
@@ -29,8 +29,7 @@ class TestSoftmax(unittest.TestCase):
 
         y_expect = numpy.exp(self.x)
         for i in six.moves.range(y_expect.shape[0]):
-            for k in six.moves.range(y_expect.shape[2]):
-                y_expect[i, :, k] /= y_expect[i, :, k].sum()
+            y_expect[i] /= y_expect[i].sum()
 
         gradient_check.assert_allclose(y_expect, y.data)
 
@@ -74,5 +73,43 @@ class TestSoftmax(unittest.TestCase):
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
 
+
+class TestReplicatedSoftmax1(TestSoftmax):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
+
+    def check_forward(self, x_data, use_cudnn=True):
+        x = chainer.Variable(x_data)
+        y = functions.softmax(x, use_cudnn)
+        self.assertEqual(y.data.dtype, numpy.float32)
+
+        y_expect = numpy.exp(self.x)
+        for i in six.moves.range(y_expect.shape[0]):
+            for k in six.moves.range(y_expect.shape[2]):
+                y_expect[i, :, k] /= y_expect[i, :, k].sum()
+
+        gradient_check.assert_allclose(y_expect, y.data)
+
+
+class TestReplicatedSoftmax2(TestSoftmax):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (2, 3, 4, 5)).astype(numpy.float32)
+
+    def check_forward(self, x_data, use_cudnn=True):
+        x = chainer.Variable(x_data)
+        y = functions.softmax(x, use_cudnn)
+        self.assertEqual(y.data.dtype, numpy.float32)
+
+        y_expect = numpy.exp(self.x)
+        for i in six.moves.range(y_expect.shape[0]):
+            for k in six.moves.range(y_expect.shape[2]):
+                for l in six.moves.range(y_expect.shape[3]):
+                    y_expect[i, :, k, l] /= y_expect[i, :, k, l].sum()
+
+        gradient_check.assert_allclose(y_expect, y.data)
 
 testing.run_module(__name__, __file__)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -20,8 +20,8 @@ if cuda.available:
 class TestSoftmaxCrossEntropy(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (4, 3, 2)).astype(numpy.float32)
-        self.t = numpy.random.randint(0, 3, (4, 2)).astype(numpy.int32)
+        self.x = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
+        self.t = numpy.random.randint(0, 3, (4,)).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x = chainer.Variable(x_data)
@@ -35,9 +35,8 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         y = numpy.exp(self.x)
         loss_expect = 0.0
         for i in six.moves.range(y.shape[0]):
-            for k in six.moves.range(y.shape[2]):
-                loss_expect -= math.log(
-                    y[i, self.t[i, k], k] / y[i, :, k].sum())
+            loss_expect -= math.log(
+                y[i, self.t[i]] / y[i].sum())
         loss_expect /= y.shape[0]
 
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
@@ -67,7 +66,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         f = lambda: func.forward((x.data, t.data))
         gx, = gradient_check.numerical_grad(f, (x.data,), (1,), eps=0.02)
 
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.assert_allclose(gx, x.grad, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -83,5 +82,57 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)
 
+
+class TestReplicatedSoftmaxCrossEntropy1(TestSoftmaxCrossEntropy):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (4, 3, 2)).astype(numpy.float32)
+        self.t = numpy.random.randint(0, 3, (4, 2)).astype(numpy.int32)
+
+    def check_forward(self, x_data, t_data, use_cudnn=True):
+        x = chainer.Variable(x_data)
+        t = chainer.Variable(t_data)
+        loss = functions.softmax_cross_entropy(x, t, use_cudnn)
+        self.assertEqual(loss.data.shape, ())
+        self.assertEqual(loss.data.dtype, numpy.float32)
+        loss_value = float(cuda.to_cpu(loss.data))
+
+        # Compute expected value
+        y = numpy.exp(self.x)
+        loss_expect = 0.0
+        for i in six.moves.range(y.shape[0]):
+            for k in six.moves.range(y.shape[2]):
+                loss_expect -= math.log(
+                    y[i, self.t[i, k], k] / y[i, :, k].sum())
+        loss_expect /= y.shape[0]
+
+        self.assertAlmostEqual(loss_expect, loss_value, places=4)
+
+
+class TestReplicatedSoftmaxCrossEntropy2(TestSoftmaxCrossEntropy):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (4, 3, 2, 5)).astype(numpy.float32)
+        self.t = numpy.random.randint(0, 3, (4, 2, 5)).astype(numpy.int32)
+
+    def check_forward(self, x_data, t_data, use_cudnn=True):
+        x = chainer.Variable(x_data)
+        t = chainer.Variable(t_data)
+        loss = functions.softmax_cross_entropy(x, t, use_cudnn)
+        self.assertEqual(loss.data.shape, ())
+        self.assertEqual(loss.data.dtype, numpy.float32)
+        loss_value = float(cuda.to_cpu(loss.data))
+
+        # Compute expected value
+        y = numpy.exp(self.x)
+        loss_expect = 0.0
+        for i in six.moves.range(y.shape[0]):
+            for k in six.moves.range(y.shape[2]):
+                for l in six.moves.range(y.shape[3]):
+                    loss_expect -= math.log(
+                        y[i, self.t[i, k, l], k, l] / y[i, :, k, l].sum())
+        loss_expect /= y.shape[0]
+
+        self.assertAlmostEqual(loss_expect, loss_value, places=4)
 
 testing.run_module(__name__, __file__)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -92,7 +92,8 @@ class TestReplicatedSoftmaxCrossEntropy1(TestSoftmaxCrossEntropy):
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
-        loss = functions.softmax_cross_entropy(x, t, use_cudnn)
+        loss = functions.softmax_cross_entropy(
+            x, t, use_cudnn, normalize=True)
         self.assertEqual(loss.data.shape, ())
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = float(cuda.to_cpu(loss.data))
@@ -104,7 +105,7 @@ class TestReplicatedSoftmaxCrossEntropy1(TestSoftmaxCrossEntropy):
             for k in six.moves.range(y.shape[2]):
                 loss_expect -= math.log(
                     y[i, self.t[i, k], k] / y[i, :, k].sum())
-        loss_expect /= y.shape[0]
+        loss_expect /= y.shape[0] * y.shape[2]
 
         self.assertAlmostEqual(loss_expect, loss_value, places=4)
 
@@ -119,7 +120,8 @@ class TestReplicatedSoftmaxCrossEntropy2(TestSoftmaxCrossEntropy):
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
-        loss = functions.softmax_cross_entropy(x, t, use_cudnn)
+        loss = functions.softmax_cross_entropy(
+            x, t, use_cudnn, normalize=False)
         self.assertEqual(loss.data.shape, ())
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = float(cuda.to_cpu(loss.data))

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -35,8 +35,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         y = numpy.exp(self.x)
         loss_expect = 0.0
         for i in six.moves.range(y.shape[0]):
-            loss_expect -= math.log(
-                y[i, self.t[i]] / y[i].sum())
+            loss_expect -= math.log(y[i, self.t[i]] / y[i].sum())
         loss_expect /= y.shape[0]
 
         self.assertAlmostEqual(loss_expect, loss_value, places=5)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -20,8 +20,8 @@ if cuda.available:
 class TestSoftmaxCrossEntropy(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
-        self.t = numpy.random.randint(0, 3, (4,)).astype(numpy.int32)
+        self.x = numpy.random.uniform(-1, 1, (4, 3, 2)).astype(numpy.float32)
+        self.t = numpy.random.randint(0, 3, (4, 2)).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x = chainer.Variable(x_data)
@@ -33,9 +33,11 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
         # Compute expected value
         y = numpy.exp(self.x)
-        loss_expect = 0
+        loss_expect = 0.0
         for i in six.moves.range(y.shape[0]):
-            loss_expect -= math.log(y[i, self.t[i]] / y[i].sum())
+            for k in six.moves.range(y.shape[2]):
+                loss_expect -= math.log(
+                    y[i, self.t[i, k], k] / y[i, :, k].sum())
         loss_expect /= y.shape[0]
 
         self.assertAlmostEqual(loss_expect, loss_value, places=5)

--- a/tests/functions_tests/test_softmax_cross_entropy.py
+++ b/tests/functions_tests/test_softmax_cross_entropy.py
@@ -112,7 +112,8 @@ class TestReplicatedSoftmaxCrossEntropy1(TestSoftmaxCrossEntropy):
 class TestReplicatedSoftmaxCrossEntropy2(TestSoftmaxCrossEntropy):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (4, 3, 2, 5)).astype(numpy.float32)
+        self.x = numpy.random.uniform(
+            -1, 1, (4, 3, 2, 5)).astype(numpy.float32)
         self.t = numpy.random.randint(0, 3, (4, 2, 5)).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data, use_cudnn=True):


### PR DESCRIPTION
This PR extends an existing Softmax function and a SoftmaxCrossEntropy function to support replicated softmax units.

Neural Network models that output multiple discrete values have been frequently used in many fields such as NLP, CV, and audio recognition.
While caffe already supports replicated softmax layer, the current implementation of chainer does not support the replicated softmax units (i.e., SoftmaxFunction only accepts a two dimensional input array).
In this PR, if we pass d (d>2) dimensional array to the SoftmaxFunction, it regards the remaining axis as the replicated units, and computes the replicated softmax.

Please note that currently I assume the second axis as a channel and the remaining axis as replicated units. The softmax layer in caffe already supports the ``axis`` parameter for indicating the channel, however, I do not implement it.