### PR TITLE
Fix SigmoidCrossEntropy to preserve numpy.float32

### DIFF
--- a/chainer/functions/sigmoid_cross_entropy.py
+++ b/chainer/functions/sigmoid_cross_entropy.py
@@ -32,7 +32,7 @@ class SigmoidCrossEntropy(function.Function):
 
     def backward_cpu(self, inputs, grad_outputs):
         t, gloss = inputs[1], grad_outputs[0]
-        gx = gloss * (self.y - t) / t.shape[0]
+        gx = gloss * (self.y - t.astype(numpy.float32)) / t.shape[0]
         return gx, None
 
     def backward_gpu(self, inputs, grad_outputs):


### PR DESCRIPTION
This small PR fixes SigmoidCrossEntropy in order to preserve a dtype to float32
(Sorry I noticed that a current implementation converts gx.dtype in backward_cpu() to float64)