### PR TITLE
Added sin and cos to basic_math

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -40,6 +40,7 @@ NonparameterizedLinear = \
     nonparameterized_linear.NonparameterizedLinear
 Concat = concat.Concat
 Copy = copy.Copy
+Cos = basic_math.Cos
 Dropout = dropout.Dropout
 Identity = identity.Identity
 Reshape = reshape.Reshape
@@ -52,6 +53,7 @@ LSTM = lstm.LSTM
 MatMul = matmul.MatMul
 ReLU = relu.ReLU
 Sigmoid = sigmoid.Sigmoid
+Sin = basic_math.Sin
 Softmax = softmax.Softmax
 Tanh = tanh.Tanh
 AveragePooling2D = pooling_2d.AveragePooling2D
@@ -89,6 +91,7 @@ split_axis = split_axis.split_axis
 
 absolute = basic_math.absolute
 batch_matmul = matmul.batch_matmul
+cos = basic_math.cos
 exp = basic_math.exp
 log = basic_math.log
 leaky_relu = leaky_relu.leaky_relu
@@ -96,6 +99,7 @@ lstm = lstm.lstm
 matmul = matmul.matmul
 relu = relu.relu
 sigmoid = sigmoid.sigmoid
+sin = basic_math.sin
 softmax = softmax.softmax
 tanh = tanh.tanh
 

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -475,7 +475,7 @@ class Sin(function.Function):
         return 'sin'
 
     def forward_cpu(self, x):
-        self.y = utils.force_array(np.sin(x[0]))
+        self.y = utils.force_array(numpy.sin(x[0]))
         return self.y,
 
     def forward_gpu(self, x):
@@ -483,7 +483,7 @@ class Sin(function.Function):
         return y,
 
     def backward_cpu(self, x, gy):
-        return utils.force_array(np.cos(x) * gy[0]),
+        return utils.force_array(numpy.cos(x) * gy[0]),
 
     def backward_gpu(self, x, gy):
         return utils.force_array(cuda.cumath.cos(x) * gy[0]),
@@ -498,7 +498,7 @@ class Cos(function.Function):
         return 'cos'
 
     def forward_cpu(self, x):
-        self.y = utils.force_array(np.cos(x[0]))
+        self.y = utils.force_array(numpy.cos(x[0]))
         return self.y,
 
     def forward_gpu(self, x):
@@ -506,7 +506,7 @@ class Cos(function.Function):
         return y,
 
     def backward_cpu(self, x, gy):
-        return utils.force_array(-np.sin(x) * gy[0]),
+        return utils.force_array(-numpy.sin(x) * gy[0]),
 
     def backward_gpu(self, x, gy):
         return utils.force_array(-cuda.cumath.sin(x) * gy[0]),

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -485,10 +485,10 @@ class Sin(function.Function):
         return y,
 
     def backward_cpu(self, x, gy):
-        return utils.force_array(numpy.cos(x) * gy[0]),
+        return utils.force_array(numpy.cos(x[0]) * gy[0]),
 
     def backward_gpu(self, x, gy):
-        return utils.force_array(cuda.cumath.cos(x) * gy[0]),
+        return utils.force_array(cuda.cumath.cos(x[0]) * gy[0]),
 
 
 def sin(x):
@@ -511,10 +511,10 @@ class Cos(function.Function):
         return y,
 
     def backward_cpu(self, x, gy):
-        return utils.force_array(-numpy.sin(x) * gy[0]),
+        return utils.force_array(-numpy.sin(x[0]) * gy[0]),
 
     def backward_gpu(self, x, gy):
-        return utils.force_array(-cuda.cumath.sin(x) * gy[0]),
+        return utils.force_array(-cuda.cumath.sin(x[0]) * gy[0]),
 
 
 def cos(x):

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -468,3 +468,49 @@ class Log(function.Function):
 def log(x):
     """Elementwise natural logarithm function."""
     return Log()(x)
+
+class Sin(Function):
+    @property
+    def label(self):
+        return 'sin'
+
+    def forward_cpu(self, x):
+        self.y = utils.force_array(np.sin(x[0]))
+        return self.y,
+
+    def forward_gpu(self, x):
+        y = cuda.cumath.sin(x[0])
+        return y,
+
+    def backward_cpu(self, x, gy):
+        return utils.force_array(np.cos(x) * gy[0]),
+
+    def backward_gpu(self, x, gy):
+        return utils.force_array(cuda.cumath.cos(x) * gy[0]),
+
+def sin(x):
+    """Elementwise sin function."""
+    return Sin()(x)
+
+class Cos(Function):
+    @property
+    def label(self):
+        return 'cos'
+
+    def forward_cpu(self, x):
+        self.y = utils.force_array(np.cos(x[0]))
+        return self.y,
+
+    def forward_gpu(self, x):
+        y = cuda.cumath.cos(x[0])
+        return y,
+
+    def backward_cpu(self, x, gy):
+        return utils.force_array(-np.sin(x) * gy[0]),
+
+    def backward_gpu(self, x, gy):
+        return utils.force_array(-cuda.cumath.sin(x) * gy[0]),
+
+def cos(x):
+    """Elementwise cos function."""
+    return Cos()(x)

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -469,7 +469,9 @@ def log(x):
     """Elementwise natural logarithm function."""
     return Log()(x)
 
+
 class Sin(function.Function):
+
     @property
     def label(self):
         return 'sin'
@@ -488,11 +490,14 @@ class Sin(function.Function):
     def backward_gpu(self, x, gy):
         return utils.force_array(cuda.cumath.cos(x) * gy[0]),
 
+
 def sin(x):
     """Elementwise sin function."""
     return Sin()(x)
 
+
 class Cos(function.Function):
+
     @property
     def label(self):
         return 'cos'
@@ -510,6 +515,7 @@ class Cos(function.Function):
 
     def backward_gpu(self, x, gy):
         return utils.force_array(-cuda.cumath.sin(x) * gy[0]),
+
 
 def cos(x):
     """Elementwise cos function."""

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -469,7 +469,7 @@ def log(x):
     """Elementwise natural logarithm function."""
     return Log()(x)
 
-class Sin(Function):
+class Sin(function.Function):
     @property
     def label(self):
         return 'sin'
@@ -492,7 +492,7 @@ def sin(x):
     """Elementwise sin function."""
     return Sin()(x)
 
-class Cos(Function):
+class Cos(function.Function):
     @property
     def label(self):
         return 'cos'

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -41,6 +41,7 @@ Array computations
 
 Activation functions
 --------------------
+.. autofunction:: cos
 .. autofunction:: exp
 .. autofunction:: leaky_relu
 .. autofunction:: log
@@ -48,6 +49,7 @@ Activation functions
 .. autoclass:: PReLU
 .. autofunction:: relu
 .. autofunction:: sigmoid
+.. autofunction:: sin
 .. autofunction:: softmax
 .. autofunction:: tanh
 

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -777,6 +777,14 @@ class UnaryFunctionsTestBase(object):
     def test_log_forward_cpu(self):
         self.forward_cpu(F.log, numpy.log)
 
+    @condition.retry(3)
+    def test_sin_forward_cpu(self):
+        self.forward_cpu(F.sin, numpy.sin)
+
+    @condition.retry(3)
+    def test_cos_forward_cpu(self):
+        self.forward_cpu(F.cos, numpy.cos)
+
     def forward_gpu(self, op, op_np):
         self.check_forward(op, op_np, cuda.to_gpu(self.x))
 
@@ -799,6 +807,16 @@ class UnaryFunctionsTestBase(object):
     @condition.retry(3)
     def test_log_forward_gpu(self):
         self.forward_gpu(F.log, numpy.log)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_sin_forward_gpu(self):
+        self.forward_gpu(F.sin, numpy.sin)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_cos_forward_gpu(self):
+        self.forward_gpu(F.cos, numpy.cos)
 
     def check_backward(self, op, x_data, y_grad):
         x = chainer.Variable(x_data)
@@ -831,6 +849,14 @@ class UnaryFunctionsTestBase(object):
     def test_log_backward_cpu(self):
         self.backward_cpu(F.log)
 
+    @condition.retry(3)
+    def test_sin_backward_cpu(self):
+        self.backward_cpu(F.sin)
+
+    @condition.retry(3)
+    def test_cos_backward_cpu(self):
+        self.backward_cpu(F.cos)
+
     def backward_gpu(self, op):
         self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
@@ -853,6 +879,16 @@ class UnaryFunctionsTestBase(object):
     @condition.retry(3)
     def test_log_backward_gpu(self):
         self.backward_gpu(F.log)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_sin_backward_gpu(self):
+        self.backward_gpu(F.sin)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_cos_backward_gpu(self):
+        self.backward_gpu(F.cos)
 
 
 class TestUnaryFunctionsSimple(UnaryFunctionsTestBase, unittest.TestCase):


### PR DESCRIPTION
This PR adds sin and cos functions to basic math. I implemented them for working with complex number operations, since currently chainer only supports float32. Implementation is a straightforward adaptation of `Exp` that's already implemented in `basic_math.py`. Tests are also going to be easy to translate if there's interest in this feature.