### PR TITLE
Add check_type_forward to binary operators in basic_math

### DIFF
--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -88,6 +88,13 @@ class Add(function.Function):
     def label(self):
         return '_ + _'
 
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+        type_check.expect(
+            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].shape == in_types[1].shape
+        )
+
     def forward(self, x):
         y = utils.force_array(x[0] + x[1])
         return y,
@@ -126,6 +133,13 @@ class Sub(function.Function):
     @property
     def label(self):
         return '_ - _'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+        type_check.expect(
+            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].shape == in_types[1].shape
+        )
 
     def forward(self, x):
         return utils.force_array(x[0] - x[1]),
@@ -170,6 +184,13 @@ class Mul(function.Function):
     @property
     def label(self):
         return '_ * _'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+        type_check.expect(
+            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].shape == in_types[1].shape
+        )
 
     def forward(self, x):
         return utils.force_array(x[0] * x[1]),
@@ -221,6 +242,13 @@ class Div(function.Function):
     @property
     def label(self):
         return '_ / _'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+        type_check.expect(
+            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].shape == in_types[1].shape
+        )
 
     def forward(self, x):
         return utils.force_array(x[0] / x[1]),
@@ -300,6 +328,13 @@ class PowVarVar(function.Function):
     @property
     def label(self):
         return '_ ** _'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+        type_check.expect(
+            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].shape == in_types[1].shape
+        )
 
     def forward_cpu(self, x):
         self.y = utils.force_array(x[0] ** x[1])

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -188,7 +188,8 @@ class Mul(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
-            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].dtype == numpy.float32,
+            in_types[1].dtype == numpy.float32,
             in_types[0].shape == in_types[1].shape
         )
 
@@ -246,7 +247,8 @@ class Div(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
-            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].dtype == numpy.float32,
+            in_types[1].dtype == numpy.float32,
             in_types[0].shape == in_types[1].shape
         )
 
@@ -332,7 +334,8 @@ class PowVarVar(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
-            in_types[0].dtype == in_types[1].dtype,
+            in_types[0].dtype == numpy.float32,
+            in_types[1].dtype == numpy.float32,
             in_types[0].shape == in_types[1].shape
         )
 


### PR DESCRIPTION
Related to #123 

It is worth discussion whether we admit broadcast in binary operators in `basic_math` (i.e. shapes of first and second argument do not match, but their data can be computed by means of broadcast of numpy
). For now, we decided not to admit broadcast because in order to admit broadcast, we must fix backward of each operators to maintain consistency of forward and backward.

Binary operators' support of broadcast is issued as #228 .
