### PR TITLE
Restrict dtype of arguments in some of unary operators in basic_math

### DIFF
--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -574,6 +574,10 @@ class Sin(function.Function):
     def label(self):
         return 'sin'
 
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype.kind == 'f')
+
     def forward_cpu(self, x):
         self.y = utils.force_array(numpy.sin(x[0]))
         return self.y,
@@ -599,6 +603,10 @@ class Cos(function.Function):
     @property
     def label(self):
         return 'cos'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype.kind == 'f')
 
     def forward_cpu(self, x):
         self.y = utils.force_array(numpy.cos(x[0]))

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -62,6 +62,7 @@ class Absolute(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype == numpy.float32)
 
     def forward(self, x):
         return utils.force_array(abs(x[0])),
@@ -260,6 +261,7 @@ class DivFromConstant(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype == numpy.float32)
 
     def forward(self, x):
         return utils.force_array(_force_type(x[0].dtype, self.value) / x[0]),
@@ -339,6 +341,7 @@ class PowVarConst(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype == numpy.float32)
 
     def forward(self, x):
         return utils.force_array(x[0] ** _force_type(x[0].dtype, self.value)),
@@ -386,6 +389,7 @@ class PowConstVar(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype == numpy.float32)
 
     def forward_cpu(self, x):
         self.y = utils.force_array(_force_type(x[0].dtype, self.value) ** x[0])

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -27,6 +27,16 @@ def _convert_value_to_string(value):
             'value must be float, ndarray, GPUArray, or Variable')
 
 
+def _check_constant_type(value):
+    if numpy.isscalar(value):
+        return
+    elif isinstance(value, (numpy.ndarray, cuda.GPUArray)):
+        return
+    else:
+        raise ValueError(
+            'value must be float, ndarray, GPUArray, or Variable')
+
+
 class Neg(function.Function):
 
     @property
@@ -120,6 +130,7 @@ class AddConstant(function.Function):
 def add(lhs, rhs):  # lhs + rhs
     if isinstance(rhs, variable.Variable):
         return Add()(lhs, rhs)
+    _check_constant_type(rhs)
     return AddConstant(rhs)(lhs)
 
 
@@ -146,6 +157,7 @@ class Sub(function.Function):
 def sub(lhs, rhs):  # lhs - rhs
     if isinstance(rhs, variable.Variable):
         return Sub()(lhs, rhs)
+    _check_constant_type(rhs)
     return AddConstant(-rhs)(lhs)
 
 
@@ -172,6 +184,7 @@ class SubFromConstant(function.Function):
 def rsub(lhs, rhs):  # rhs - lhs
     if isinstance(rhs, variable.Variable):
         return Sub()(rhs, lhs)
+    _check_constant_type(rhs)
     return SubFromConstant(rhs)(lhs)
 
 
@@ -233,6 +246,7 @@ class MulConstant(function.Function):
 def mul(lhs, rhs):  # lhs * rhs
     if isinstance(rhs, variable.Variable):
         return Mul()(lhs, rhs)
+    _check_constant_type(rhs)
     return MulConstant(rhs)(lhs)
 
 
@@ -274,6 +288,7 @@ class Div(function.Function):
 def div(lhs, rhs):  # lhs / rhs
     if isinstance(rhs, variable.Variable):
         return Div()(lhs, rhs)
+    _check_constant_type(rhs)
     return MulConstant(1. / rhs)(lhs)
 
 
@@ -322,6 +337,7 @@ class DivFromConstant(function.Function):
 def rdiv(lhs, rhs):  # rhs / lhs
     if isinstance(rhs, variable.Variable):
         return Div()(rhs, lhs)
+    _check_constant_type(rhs)
     return DivFromConstant(rhs)(lhs)
 
 
@@ -412,6 +428,7 @@ class PowVarConst(function.Function):
 def pow(lhs, rhs):  # lhs ** rhs
     if isinstance(rhs, variable.Variable):
         return PowVarVar()(lhs, rhs)
+    _check_constant_type(rhs)
     return PowVarConst(rhs)(lhs)
 
 
@@ -474,6 +491,7 @@ class PowConstVar(function.Function):
 def rpow(lhs, rhs):  # rhs ** lhs
     if isinstance(rhs, variable.Variable):
         return PowVarVar()(rhs, lhs)
+    _check_constant_type(rhs)
     return PowConstVar(rhs)(lhs)
 
 

--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -506,6 +506,7 @@ class Exp(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype.kind == 'f')
 
     def forward_cpu(self, x):
         self.y = utils.force_array(numpy.exp(x[0]))
@@ -532,6 +533,7 @@ class Log(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype.kind == 'f')
 
     def forward_cpu(self, x):
         return utils.force_array(numpy.log(x[0])),

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -249,35 +249,98 @@ class TestBinaryOpConstant(unittest.TestCase):
         y4.backward()
         self.assertEqual(x4.grad.dtype, numpy.float32)
 
-    def test_add_constnt(self):
+    def _test_constant_array_one(self, func, lhs, rhs):
+        x = chainer.Variable(lhs)
+        y = func(x, rhs)
+        self.assertEqual(y.data.dtype, numpy.float32)
+        y.grad = numpy.ones_like(y.data, numpy.float32)
+        y.backward()
+        self.assertEqual(x.grad.dtype, numpy.float32)
+
+    def _test_constant_array(self, func):
+        x_data = numpy.array([1.0, 2.0], numpy.float32)
+
+        self._test_constant_array_one(
+            func, x_data, numpy.array([3.0, 4.0], numpy.int32))
+        self._test_constant_array_one(
+            func, x_data, numpy.array([3.0, 4.0], numpy.int64))
+        self._test_constant_array_one(
+            func, x_data, numpy.array([3.0, 4.0], numpy.float32))
+        self._test_constant_array_one(
+            func, x_data, numpy.array([3.0, 4.0], numpy.float64))
+
+        with self.assertRaises(ValueError):
+            self._test_constant_array_one(func, x_data, [3.0, 4.0])
+        with self.assertRaises(ValueError):
+            self._test_constant_array_one(func, x_data, (3.0, 4.0))
+
+        with self.assertRaises(ValueError):
+            self._test_constant_array_one(func, x_data, [3.0, 4.0, 5.0])
+        with self.assertRaises(ValueError):
+            self._test_constant_array_one(func, x_data, (3.0, 4.0, 5.0))
+        with self.assertRaises(ValueError):
+            self._test_constant_array_one(
+                func, x_data, numpy.array([3.0, 4.0, 5.0], numpy.float32))
+
+    def test_add_constant(self):
         self._test_constant(lambda x, y: x + y)
 
-    def test_radd_constnt(self):
+    def test_add_constant_array(self):
+        self._test_constant_array(lambda x, y: x + y)
+
+    def test_radd_constant(self):
         self._test_constant(lambda x, y: y + x)
 
-    def test_sub_constnt(self):
+    def test_radd_constant_array(self):
+        self._test_constant_array(lambda x, y: y + x)
+
+    def test_sub_constant(self):
         self._test_constant(lambda x, y: x - y)
 
-    def test_rsub_constnt(self):
+    def test_sub_constant_array(self):
+        self._test_constant_array(lambda x, y: x - y)
+
+    def test_rsub_constant(self):
         self._test_constant(lambda x, y: y - x)
 
-    def test_mul_constnt(self):
+    def test_rsub_constant_array(self):
+        self._test_constant_array(lambda x, y: y - x)
+
+    def test_mul_constant(self):
         self._test_constant(lambda x, y: x * y)
 
-    def test_rmul_constnt(self):
+    def test_mul_constant_array(self):
+        self._test_constant_array(lambda x, y: x * y)
+
+    def test_rmul_constant(self):
         self._test_constant(lambda x, y: y * x)
 
-    def test_div_constnt(self):
+    def test_rmul_constant_array(self):
+        self._test_constant_array(lambda x, y: y * x)
+
+    def test_div_constant(self):
         self._test_constant(lambda x, y: x / y)
 
-    def test_rdiv_constnt(self):
+    def test_div_constant_array(self):
+        self._test_constant_array(lambda x, y: x / y)
+
+    def test_rdiv_constant(self):
         self._test_constant(lambda x, y: y / x)
 
-    def test_pow_constnt(self):
+    def test_rdiv_constant_array(self):
+        self._test_constant_array(lambda x, y: y / x)
+
+    def test_pow_constant(self):
         self._test_constant(lambda x, y: x ** y)
 
-    def test_rpow_constnt(self):
+    def test_pow_constant_array(self):
+        self._test_constant_array(lambda x, y: x ** y)
+
+    def test_rpow_constant(self):
         self._test_constant(lambda x, y: y ** x)
+
+    def test_rpow_constant_array(self):
+        self._test_constant_array(lambda x, y: y ** x)
 
 
 class VariableConstantOpTestBase(object):

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -243,8 +243,8 @@ class TestBinaryOpConstant(unittest.TestCase):
     def _test_constant_gpu(self, func):
         x_data = numpy.array(1, numpy.float32)
 
-        self._test_constant_one(func, x_data, 1)
-        self._test_constant_one(func, x_data, 1.0)
+        self._test_constant_one(func, x_data, 1, True)
+        self._test_constant_one(func, x_data, 1.0, True)
         self._test_constant_one(func, x_data, numpy.int64(1), True)
         self._test_constant_one(func, x_data, numpy.float64(1), True)
 

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -223,7 +223,9 @@ class TestBinaryOpZeroDimension(BinaryOpTestBase, unittest.TestCase):
 
 class TestBinaryOpConstant(unittest.TestCase):
 
-    def _test_constant_one(self, func, lhs, rhs):
+    def _test_constant_one(self, func, lhs, rhs, gpu=False):
+        if gpu:
+            lhs = cuda.to_gpu(lhs)
         x = chainer.Variable(lhs)
         y = func(x, rhs)
         self.assertEqual(y.data.dtype, numpy.float32)
@@ -237,6 +239,14 @@ class TestBinaryOpConstant(unittest.TestCase):
         self._test_constant_one(func, x_data, 1.0)
         self._test_constant_one(func, x_data, numpy.int64(1))
         self._test_constant_one(func, x_data, numpy.float64(1.0))
+
+    def _test_constant_gpu(self, func):
+        x_data = numpy.array(1, numpy.float32)
+
+        self._test_constant_one(func, x_data, 1)
+        self._test_constant_one(func, x_data, 1.0)
+        self._test_constant_one(func, x_data, numpy.int64(1), True)
+        self._test_constant_one(func, x_data, numpy.float64(1), True)
 
     def _test_constant_array_one(self, func, lhs, rhs):
         x = chainer.Variable(lhs)
@@ -304,6 +314,10 @@ class TestBinaryOpConstant(unittest.TestCase):
     def test_add_constant(self):
         self._test_constant(lambda x, y: x + y)
 
+    @attr.gpu
+    def test_add_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: x + y)
+
     def test_add_constant_array(self):
         self._test_constant_array(lambda x, y: x + y)
 
@@ -313,6 +327,10 @@ class TestBinaryOpConstant(unittest.TestCase):
 
     def test_radd_constant(self):
         self._test_constant(lambda x, y: y + x)
+
+    @attr.gpu
+    def test_radd_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: y + x)
 
     def test_radd_constant_array(self):
         self._test_constant_array(lambda x, y: y + x)
@@ -324,6 +342,10 @@ class TestBinaryOpConstant(unittest.TestCase):
     def test_sub_constant(self):
         self._test_constant(lambda x, y: x - y)
 
+    @attr.gpu
+    def test_sub_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: x - y)
+
     def test_sub_constant_array(self):
         self._test_constant_array(lambda x, y: x - y)
 
@@ -333,6 +355,10 @@ class TestBinaryOpConstant(unittest.TestCase):
 
     def test_rsub_constant(self):
         self._test_constant(lambda x, y: y - x)
+
+    @attr.gpu
+    def test_rsub_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: y - x)
 
     def test_rsub_constant_array(self):
         self._test_constant_array(lambda x, y: y - x)
@@ -344,6 +370,10 @@ class TestBinaryOpConstant(unittest.TestCase):
     def test_mul_constant(self):
         self._test_constant(lambda x, y: x * y)
 
+    @attr.gpu
+    def test_mul_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: x * y)
+
     def test_mul_constant_array(self):
         self._test_constant_array(lambda x, y: x * y)
 
@@ -353,6 +383,10 @@ class TestBinaryOpConstant(unittest.TestCase):
 
     def test_rmul_constant(self):
         self._test_constant(lambda x, y: y * x)
+
+    @attr.gpu
+    def test_rmul_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: y * x)
 
     def test_rmul_constant_array(self):
         self._test_constant_array(lambda x, y: y * x)
@@ -365,6 +399,10 @@ class TestBinaryOpConstant(unittest.TestCase):
     def test_div_constant(self):
         self._test_constant(lambda x, y: x / y)
 
+    @attr.gpu
+    def test_div_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: x / y)
+
     def test_div_constant_array(self):
         self._test_constant_array(lambda x, y: x / y)
 
@@ -376,6 +414,10 @@ class TestBinaryOpConstant(unittest.TestCase):
     def test_rdiv_constant(self):
         self._test_constant(lambda x, y: y / x)
 
+    @attr.gpu
+    def test_rdiv_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: y / x)
+
     def test_rdiv_constant_array(self):
         self._test_constant_array(lambda x, y: y / x)
 
@@ -386,6 +428,10 @@ class TestBinaryOpConstant(unittest.TestCase):
     def test_pow_constant(self):
         self._test_constant(lambda x, y: x ** y)
 
+    @attr.gpu
+    def test_pow_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: x ** y)
+
     def test_pow_constant_array(self):
         self._test_constant_array(lambda x, y: x ** y)
 
@@ -395,6 +441,10 @@ class TestBinaryOpConstant(unittest.TestCase):
 
     def test_rpow_constant(self):
         self._test_constant(lambda x, y: y ** x)
+
+    @attr.gpu
+    def test_rpow_constant_gpu(self):
+        self._test_constant_gpu(lambda x, y: y ** x)
 
     def test_rpow_constant_array(self):
         self._test_constant_array(lambda x, y: y ** x)

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -301,15 +301,10 @@ class TestBinaryOpConstant(unittest.TestCase):
         self._test_constant_array_gpu_one(
             func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0], numpy.float64)))
 
-        try:
-            self._test_constant_array_one(
-                func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0, 5.0], numpy.float32)))
-        except Exception as e:
-            print type(e)
-
         with self.assertRaises(exception):
             self._test_constant_array_one(
-                func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0, 5.0], numpy.float32)))
+                func, x_data, cuda.to_gpu(
+                    numpy.array([3.0, 4.0, 5.0], numpy.float32)))
 
     def test_add_constant(self):
         self._test_constant(lambda x, y: x + y)
@@ -393,7 +388,7 @@ class TestBinaryOpConstant(unittest.TestCase):
 
     @attr.gpu
     def test_rmul_constant_array_gpu(self):
-        # to be precise, _test_constant_array_one throws pycuda._pvt_struct.error
+        # _test_constant_array_one throws pycuda._pvt_struct.error
         self._test_constant_array_gpu(lambda x, y: y * x, exception=Exception)
 
     def test_div_constant(self):
@@ -408,7 +403,7 @@ class TestBinaryOpConstant(unittest.TestCase):
 
     @attr.gpu
     def test_div_constant_array_gpu(self):
-        # to be precise, _test_constant_array_one throws pycuda._pvt_struct.error
+        # _test_constant_array_one throws pycuda._pvt_struct.error
         self._test_constant_array_gpu(lambda x, y: x / y, exception=Exception)
 
     def test_rdiv_constant(self):
@@ -451,7 +446,7 @@ class TestBinaryOpConstant(unittest.TestCase):
 
     @attr.gpu
     def test_rpow_constant_array_gpu(self):
-        # to be precise, _test_constant_array_one throws pycuda._pvt_struct.error
+        # _test_constant_array_one throws pycuda._pvt_struct.error
         self._test_constant_array_gpu(lambda x, y: y ** x, exception=Exception)
 
 

--- a/tests/functions_tests/test_basic_math.py
+++ b/tests/functions_tests/test_basic_math.py
@@ -223,31 +223,20 @@ class TestBinaryOpZeroDimension(BinaryOpTestBase, unittest.TestCase):
 
 class TestBinaryOpConstant(unittest.TestCase):
 
+    def _test_constant_one(self, func, lhs, rhs):
+        x = chainer.Variable(lhs)
+        y = func(x, rhs)
+        self.assertEqual(y.data.dtype, numpy.float32)
+        y.backward()
+        self.assertEqual(x.grad.dtype, numpy.float32)
+
     def _test_constant(self, func):
         x_data = numpy.array(1, numpy.float32)
-        x1 = chainer.Variable(x_data)
-        y1 = func(x1, 1)
-        self.assertEqual(y1.data.dtype, numpy.float32)
-        y1.backward()
-        self.assertEqual(x1.grad.dtype, numpy.float32)
 
-        x2 = chainer.Variable(x_data)
-        y2 = func(x2, 1.0)
-        self.assertEqual(y2.data.dtype, numpy.float32)
-        y2.backward()
-        self.assertEqual(x2.grad.dtype, numpy.float32)
-
-        x3 = chainer.Variable(x_data)
-        y3 = func(x3, numpy.int64(1))
-        self.assertEqual(y3.data.dtype, numpy.float32)
-        y3.backward()
-        self.assertEqual(x3.grad.dtype, numpy.float32)
-
-        x4 = chainer.Variable(x_data)
-        y4 = func(x4, numpy.float64(1.0))
-        self.assertEqual(y4.data.dtype, numpy.float32)
-        y4.backward()
-        self.assertEqual(x4.grad.dtype, numpy.float32)
+        self._test_constant_one(func, x_data, 1)
+        self._test_constant_one(func, x_data, 1.0)
+        self._test_constant_one(func, x_data, numpy.int64(1))
+        self._test_constant_one(func, x_data, numpy.float64(1.0))
 
     def _test_constant_array_one(self, func, lhs, rhs):
         x = chainer.Variable(lhs)


### PR DESCRIPTION
The objective of this fix is basically same as d7836e .

Some unary operators in `basic_math` is implemented by explicitly writing kernel code. In that case, dtypes of arguments are restricted to float32. This PR imposes this restriction to `check_type_forward` of the functions.

Related to #219 
