### PR TITLE
Use tuple for shape in split_axis

### DIFF
--- a/chainer/functions/split_axis.py
+++ b/chainer/functions/split_axis.py
@@ -76,7 +76,7 @@ class SplitAxis(function.Function):
             cdimy = max(0, min(i, self.cdimx) - prev_i)
             s = list(xshape)
             s[self.axis] = cdimy
-            y = cuda.empty(s, dtype=x[0].dtype)
+            y = cuda.empty(tuple(s), dtype=x[0].dtype)
             if cdimy == 0:
                 raise ValueError('Not support if shape contains 0')
             kernel(y, x[0], cdimy, self.cdimx, self.rdim, prev_i)

--- a/tests/functions_tests/test_split_axis.py
+++ b/tests/functions_tests/test_split_axis.py
@@ -26,6 +26,7 @@ class TestSplitAxis0(unittest.TestCase):
         x = chainer.Variable(x_data)
         ys = functions.split_axis(x, indices_or_sections, axis)
         for yd, y in zip(ys_data, ys):
+            self.assertIsInstance(y.data.shape, tuple)
             gradient_check.assert_allclose(yd, y.data, atol=0, rtol=0)
 
     def test_forward_cpu(self):


### PR DESCRIPTION
`list` is illegal for `shape` of `GPUArray`. Instead use `tuple`.