### PR TITLE
Add volatile option to Parameter.__call__

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -129,7 +129,10 @@ class Function(object):
         # First copy itself to avoid duplication within the graph.
         self = copy.copy(self)
 
-        if any(x.volatile for x in inputs):  # not build graph
+        if not hasattr(self, 'volatile'):
+            self.volatile = any(x.volatile for x in inputs)
+
+        if self.volatile:
             # do not mix multiple volatility
             assert all(x.volatile for x in inputs)
 

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -129,10 +129,7 @@ class Function(object):
         # First copy itself to avoid duplication within the graph.
         self = copy.copy(self)
 
-        if not hasattr(self, 'volatile'):
-            self.volatile = any(x.volatile for x in inputs)
-
-        if self.volatile:
+        if any(x.volatile for x in inputs):  # not build graph
             # do not mix multiple volatility
             assert all(x.volatile for x in inputs)
 

--- a/chainer/functions/parameter.py
+++ b/chainer/functions/parameter.py
@@ -22,6 +22,13 @@ class Parameter(function.Function):
         self.W = array
         self.gW = numpy.empty_like(array)
 
+    def __call__(self, *inputs, **kwargs):
+        if 'volatile' in kwargs:
+            self.volatile = kwargs['volatile']
+        else:
+            self.volatile = False
+        return super(Parameter, self).__call__(*inputs)
+
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 0)
 

--- a/chainer/functions/parameter.py
+++ b/chainer/functions/parameter.py
@@ -22,12 +22,12 @@ class Parameter(function.Function):
         self.W = array
         self.gW = numpy.empty_like(array)
 
-    def __call__(self, *inputs, **kwargs):
-        if 'volatile' in kwargs:
-            self.volatile = kwargs['volatile']
-        else:
-            self.volatile = False
-        return super(Parameter, self).__call__(*inputs)
+    def __call__(self, volatile=False):
+        ret = super(Parameter, self).__call__()
+        if volatile:
+            ret.unchain_backward()
+        ret.volatile = volatile
+        return ret
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 0)

--- a/tests/functions_tests/test_parameter.py
+++ b/tests/functions_tests/test_parameter.py
@@ -56,4 +56,34 @@ class TestParameter(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.gW))
 
 
+class TestVolatile(unittest.TestCase):
+
+    def setUp(self):
+        self.W = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
+        self.func = functions.Parameter(self.W)
+
+    def tearDown(self):
+        del self.func
+
+    def check_volatile(self, volatile):
+        y = self.func(volatile=volatile)
+        self.assertEqual(y.volatile, volatile)
+
+    def test_volatile_cpu_volatile(self):
+        self.check_volatile(True)
+
+    def test_volatile_cpu_not_volatile(self):
+        self.check_volatile(False)
+
+    @attr.gpu
+    def test_volatile_gpu_volatile(self):
+        self.func.to_gpu()
+        self.check_volatile(True)
+
+    @attr.gpu
+    def test_volatile_gpu_not_volatile(self):
+        self.func.to_gpu()
+        self.check_volatile(False)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/functions_tests/test_parameter.py
+++ b/tests/functions_tests/test_parameter.py
@@ -26,34 +26,54 @@ class TestParameter(unittest.TestCase):
     def to_gpu(self):
         self.func.to_gpu()
 
-    def check_forward(self):
-        y = self.func()
+    def check_forward(self, volatile):
+        y = self.func(volatile)
         self.assertEqual(y.data.dtype, numpy.float32)
         self.assertTrue((self.W == cuda.to_cpu(y.data)).all())
 
     def test_forward_cpu(self):
-        self.check_forward()
+        self.check_forward(False)
+
+    def test_forward_cpu_volatile(self):
+        self.check_forward(True)
 
     @attr.gpu
     def test_forward_gpu(self):
         self.to_gpu()
-        self.check_forward()
+        self.check_forward(False)
 
-    def check_backward(self, y_grad):
+    @attr.gpu
+    def test_forward_gpu_volatile(self):
+        self.to_gpu()
+        self.check_forward(True)
+
+    def check_backward(self, y_grad, volatile):
         self.func.gW.fill(0)
-        y = self.func()
+        y = self.func(volatile)
         y.grad = y_grad
         y.backward()
-        self.assertTrue(
-            (cuda.to_cpu(y_grad) == cuda.to_cpu(self.func.gW)).all())
+        if volatile:
+            self.assertTrue(
+                (cuda.to_cpu(self.func.gW) == numpy.zeros_like(y_grad)).all())
+        else:
+            self.assertTrue(
+                (cuda.to_cpu(self.func.gW) == cuda.to_cpu(y_grad)).all())
 
     def test_backward_cpu(self):
-        self.check_backward(self.gW)
+        self.check_backward(self.gW, False)
+
+    def test_backward_cpu_volatile(self):
+        self.check_backward(self.gW, True)
 
     @attr.gpu
     def test_backward_gpu(self):
         self.to_gpu()
-        self.check_backward(cuda.to_gpu(self.gW))
+        self.check_backward(cuda.to_gpu(self.gW), False)
+
+    @attr.gpu
+    def test_backward_gpu_volatile(self):
+        self.to_gpu()
+        self.check_backward(cuda.to_gpu(self.gW), True)
 
 
 class TestVolatile(unittest.TestCase):


### PR DESCRIPTION
This PR fixes #259.

As discussed in this issue, we add `volatile` option to `Parameter.__call__` as an keyword argument.
If volatile option is omitted, this function behaves as though all inputs had `False` volatile values.