### PR TITLE
Enhancement: Added getitem to FunctionSet

### DIFF
--- a/chainer/function_set.py
+++ b/chainer/function_set.py
@@ -41,6 +41,23 @@ class FunctionSet(object):
         """
         return self.parameters, self.gradients
 
+    def __getitem__(self, key):
+        """Returns the :class:`Function` objects by name
+
+        Args:
+            key (str)
+                Name of the function.
+
+        Returns:
+            :class:`Function` object
+
+        Example:
+        >>> model = FunctionSet(l1=F.Linear(100, 100), l2=F.Linear(100, 100))
+        >>> l1 = model['l1']
+        """
+
+        return getattr(self, key)
+
     def to_gpu(self, device=None):
         """Migrates all parameters and gradients onto GPU.
 


### PR DESCRIPTION
This very simple PR lets you do:

```python
>>> model = FunctionSet(l1=F.Linear(100, 100), l2=F.Linear(100, 100))
>>> l1 = model['l1']
```

I've been seeing lots of other folks doing `getattr(model, 'l1')` -- like [here](http://nbviewer.ipython.org/gist/duschendestroyer/a41fcab5f7f9ffa45387), so this is likely a better way to the same end.

