### PR TITLE
Fix download method of examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,8 +147,9 @@
 	    </p>
 	    <p>
 	      Run the MNIST example:<br>
-	      <pre><code>git clone https://github.com/pfnet/chainer.git
-python chainer/examples/mnist/train_mnist.py</code></pre>
+	      <pre><code>wget https://github.com/pfnet/chainer/archive/v1.1.2.tar.gz
+tar xzf v1.1.2.tar.gz
+python chainer-1.1.2/examples/mnist/train_mnist.py</code></pre>
 	    </p>
 	    <p>
 	      Learn more from <a href="http://docs.chainer.org">the official documentation</a>.


### PR DESCRIPTION
Master branch is sometimes incompatible to the latest release. We recommend to download the latest source instead.

fix #147 