### PR TITLE
Remove check_type_backward and its relevants

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -190,11 +190,6 @@ class Function(object):
         in_type = type_check.get_types(in_data, 'in_types', False)
         self.check_type_forward(in_type)
 
-    def _check_data_type_backward(self, in_data, grad_data):
-        in_type = type_check.get_types(in_data, 'in_types', False)
-        grad_type = type_check.get_types(grad_data, 'grad_types', True)
-        self.check_type_backward(in_type, grad_type)
-
     def check_type_forward(self, in_types):
         """Checks types of input data before forward propagation.
 
@@ -205,25 +200,6 @@ class Function(object):
         Args:
             in_types (~chainer.utils.type_check.TypeInfoTuple): The type
                 information of input data for :meth:`forward`.
-        """
-        pass
-
-    def check_type_backward(self, in_types, grad_types):
-        """Checks types of gradient data before back propagation.
-
-        Before :meth:`backward` is called, this function is called.
-        You need to validate types of gradient data in this function
-        using :ref:`the type checking utilities <type-check-utils>`.
-
-        :meth:`check_type_backward` is always called after
-        :meth:`check_type_forward`, so each function does not need to check
-        the same condition here.
-
-        Args:
-            in_types (~chainer.utils.type_check.TypeInfoTuple): The type
-                information of input data for :meth:`backward`.
-            grad_types (~chainer.utils.type_check.TypeInfoTuple): The type
-                information of gradient data for :meth:`backward`.
         """
         pass
 

--- a/chainer/functions/batch_normalization.py
+++ b/chainer/functions/batch_normalization.py
@@ -149,17 +149,6 @@ class BatchNormalization(function.Function):
             x_type.shape[1:len(self.size)+1] == self_.size
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(out_types.size() == 1)
-        x_type, = in_types
-        y_type, = out_types
-
-        type_check.expect(
-            x_type.dtype == y_type.dtype,
-            x_type.ndim == y_type.ndim,
-            x_type.shape == y_type.shape
-        )
-
     def start_finetuning(self):
         self.N[0] = numpy.array(0)
 

--- a/chainer/functions/concat.py
+++ b/chainer/functions/concat.py
@@ -39,23 +39,6 @@ class Concat(function.Function):
                     continue
                 type_check.expect(in_types[0].shape[d] == in_types[i].shape[d])
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            in_types.size() > 0,
-            out_types.size() == 1,
-        )
-        y_type, = out_types
-
-        type_check.expect(y_type.dtype == in_types[0].dtype)
-        ndim = in_types[0].ndim.eval()
-        concat_size = sum(typ.shape[self.axis] for typ in in_types)
-        type_check.expect(concat_size == y_type.shape[self.axis])
-
-        for d in range(0, ndim):
-            if d == self.axis:
-                continue
-            type_check.expect(y_type.shape[d] == in_types[0].shape[d])
-
     def forward_cpu(self, xs):
         return numpy.concatenate(xs, axis=self.axis),
 

--- a/chainer/functions/convolution_2d.py
+++ b/chainer/functions/convolution_2d.py
@@ -143,29 +143,6 @@ class Convolution2D(function.Function):
             x_type.shape[1] == self.in_channels
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(out_types.size() == 1)
-        x_type, = in_types
-        y_type, = out_types
-
-        in_h = x_type.shape[2].eval()
-        out_h = type_check.Variable(
-            conv.get_conv_outsize(in_h, self.kh, self.sy, self.ph),
-            'out_h')
-        in_w = x_type.shape[3].eval()
-        out_w = type_check.Variable(
-            conv.get_conv_outsize(in_w, self.kw, self.sx, self.pw),
-            'out_w')
-
-        type_check.expect(
-            y_type.dtype == numpy.float32,
-            y_type.ndim == 4,
-            y_type.shape[0] == x_type.shape[0],
-            y_type.shape[1] == self.out_channels,
-            y_type.shape[2] == out_h,
-            y_type.shape[3] == out_w
-        )
-
     @property
     def parameter_names(self):
         if self.b is None:

--- a/chainer/functions/copy.py
+++ b/chainer/functions/copy.py
@@ -15,14 +15,6 @@ class Copy(function.Function):
             in_types.size() == 1
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            out_types.size() == 1,
-            in_types[0].dtype == out_types[0].dtype,
-            in_types[0].ndim == out_types[0].ndim,
-            in_types[0].shape == out_types[0].shape
-        )
-
     def forward_cpu(self, x):
         return x[0].copy(),
 

--- a/chainer/functions/cross_covariance.py
+++ b/chainer/functions/cross_covariance.py
@@ -27,17 +27,6 @@ class CrossCovariance(function.Function):
             z_type.shape[0] == y_type.shape[0]
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            in_types.size() == 2,
-            out_types.size() == 1,
-        )
-        y_in_type, z_in_type = in_types
-        out_type, = out_types
-
-        type_check.expect(out_type.dtype == y_in_type.dtype)
-        type_check.expect(out_type.dtype == z_in_type.dtype)
-
     def forward_cpu(self, inputs):
         y, z = inputs
         y_mean = y.mean(axis=0, keepdims=True)

--- a/chainer/functions/embed_id.py
+++ b/chainer/functions/embed_id.py
@@ -42,22 +42,6 @@ class EmbedID(function.Function):
             x_type.ndim == 1,
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            in_types.size() == 1,
-            out_types.size() == 1,
-        )
-        x_type, = in_types
-        y_type, = out_types
-
-        type_check.expect(
-            y_type.dtype == numpy.float32,
-            y_type.ndim == 2,
-            y_type.shape[0] == x_type.shape[0],
-            y_type.shape[1] == type_check.Variable(self.W.shape[1],
-                                                   'W.shape[1]'),
-        )
-
     def forward_cpu(self, x):
         return self.W[x[0]],
 

--- a/chainer/functions/gaussian.py
+++ b/chainer/functions/gaussian.py
@@ -26,16 +26,6 @@ class Gaussian(function.Function):
             m_type.shape == v_type.shape,
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(out_types.size() == 1)
-        m_type, v_type = in_types
-        g_type, = out_types
-
-        type_check.expect(
-            g_type.dtype == numpy.float32,
-            g_type.shape == m_type.shape,
-        )
-
     def forward_cpu(self, inputs):
         mean, ln_var = inputs
         if self.eps is None:

--- a/chainer/functions/hierarchical_softmax.py
+++ b/chainer/functions/hierarchical_softmax.py
@@ -122,13 +122,6 @@ class BinaryHierarchicalSoftmax(function.Function):
             x_type.shape[0] == t_type.shape[0]
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            out_types.size() == 1,
-            out_types[0].dtype == numpy.float32,
-            out_types[0].ndim == 0
-        )
-
     def forward_cpu(self, args):
         x, t = args
 

--- a/chainer/functions/linear.py
+++ b/chainer/functions/linear.py
@@ -105,22 +105,6 @@ class Linear(function.Function):
              type_check.Variable(self.W.shape[1], 'W.shape[1]')),
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            in_types.size() == 1,
-            out_types.size() == 1,
-        )
-        x_type, = in_types
-        y_type, = out_types
-
-        type_check.expect(
-            y_type.dtype == numpy.float32,
-            y_type.ndim == 2,
-            y_type.shape[0] == x_type.shape[0],
-            y_type.shape[1] == type_check.Variable(self.W.shape[0],
-                                                   'W.shape[0]'),
-        )
-
     def zero_grads(self):
         self.gW.fill(0)
         if self.gb is not None:

--- a/chainer/functions/negative_sampling.py
+++ b/chainer/functions/negative_sampling.py
@@ -93,13 +93,6 @@ class NegativeSampling(function.Function):
             x_type.shape[0] == t_type.shape[0]
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            out_types.size() == 1,
-            out_types[0].dtype == numpy.float32,
-            out_types[0].ndim == 0
-        )
-
     def to_gpu(self, device=None):
         function.Function.to_gpu(self, device)
         self.sampler.to_gpu()

--- a/chainer/functions/reshape.py
+++ b/chainer/functions/reshape.py
@@ -21,13 +21,6 @@ class Reshape(function.Function):
             _type_check_prod(self.shape)
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            out_types.size() == 1,
-            _type_check_prod(in_types[0].shape) ==
-            _type_check_prod(out_types[0].shape)
-        )
-
     def forward(self, x):
         return x[0].reshape(self.shape),
 

--- a/chainer/functions/softmax.py
+++ b/chainer/functions/softmax.py
@@ -27,19 +27,6 @@ class Softmax(function.Function):
             x_type.ndim > 1,
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            in_types.size() == 1,
-            out_types.size() == 1,
-        )
-        x_type, = in_types
-        y_type, = out_types
-
-        type_check.expect(
-            y_type.ndim > 1,
-            y_type.shape == x_type.shape,
-        )
-
     def forward_cpu(self, x):
         self.y = x[0] - numpy.amax(x[0], axis=1, keepdims=True)
         numpy.exp(self.y, out=self.y)

--- a/chainer/functions/softmax_cross_entropy.py
+++ b/chainer/functions/softmax_cross_entropy.py
@@ -28,14 +28,6 @@ class SoftmaxCrossEntropy(function.Function):
             x_type.shape[2:] == t_type.shape[1:],
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            in_types.size() == 2,
-            out_types.size() == 1,
-        )
-        y_type, = out_types
-        type_check.expect(y_type.ndim == 0)  # means scalar
-
     def forward_cpu(self, inputs):
         x, t = inputs
         self.y, = softmax.Softmax().forward_cpu((x,))

--- a/chainer/functions/softplus.py
+++ b/chainer/functions/softplus.py
@@ -21,19 +21,6 @@ class Softplus(function.Function):
             x_type.dtype == numpy.float32,
         )
 
-    def check_type_backward(self, in_types, out_types):
-        type_check.expect(
-            in_types.size() == 1,
-            out_types.size() == 1,
-        )
-        x_type, = in_types
-        g_type, = out_types
-
-        type_check.expect(
-            g_type.dtype == numpy.float32,
-            x_type.shape == g_type.shape,
-        )
-
     def forward_cpu(self, inputs):
         x, = inputs
         # y = log(1 + exp(beta * x)) / beta

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -184,7 +184,6 @@ https://github.com/pfnet/chainer/issues/new.
 
             in_data = tuple(x.data for x in func.inputs)
             out_grad = tuple(None if y is None else y.grad for y in outputs)
-            func._check_data_type_backward(in_data, out_grad)
             with cuda.using_device(*(in_data + out_grad)):
                 gxs = func.backward(in_data, out_grad)
             assert len(gxs) == len(in_data)

--- a/tests/functions_tests/test_dropout.py
+++ b/tests/functions_tests/test_dropout.py
@@ -31,20 +31,5 @@ class TestDropout(unittest.TestCase):
     def test_type_forward_gpu(self):
         self.check_type_forward(cuda.to_gpu(self.x))
 
-    def check_type_backward(self, x_data, gy_data):
-        x = chainer.Variable(x_data)
-        y = functions.dropout(x)
-        y.grad = gy_data
-        y.backward()
-
-    def test_type_backward_cpu(self):
-        self.check_type_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_type_backward_gpu(self):
-        self.check_type_backward(
-            cuda.to_gpu(self.x),
-            cuda.to_gpu(self.gy))
-
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
As discussed in #209, `check_type_backward` is no longer needed. This PR removes this method and codes that relevant to it.

This PR fixes #209 