### PR TITLE
Fix NumericalGradientTest that fails in python3

### DIFF
--- a/tests/test_gradient_check.py
+++ b/tests/test_gradient_check.py
@@ -81,7 +81,7 @@ class NumericalGradientTest(unittest.TestCase):
                     for gy in self.gys)
 
         self.check_numerical_grad(self.f, self.df,
-                                  map(cuda.to_gpu, self.xs), gys)
+                                  tuple(map(cuda.to_gpu, self.xs)), gys)
 
 
 class NumericalGradientTest2(NumericalGradientTest):


### PR DESCRIPTION
In python3 map returns iterator, which causes failure in unit tests of numerical_grad. This PR fixes this failure.