### PR TITLE
Fix wrong device destination in optimizer.accumulate_grads().

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -208,7 +208,7 @@ class Optimizer(object):
             with cuda.get_device(g_dst):
                 if (isinstance(g_src, cuda.ndarray) and
                         g_dst.gpudata.device != g_src.gpudata.device):
-                    g_dst += cuda.copy(g_src, out_device=g_src.gpudata.device)
+                    g_dst += cuda.copy(g_src, out_device=g_dst.gpudata.device)
                 else:
                     g_dst += cuda.to_gpu(g_src)
 


### PR DESCRIPTION
It looks to me simply wrong to copy the src variable to src device.  In fact, I bumped into "invalid memory access" error when I tried to accumulate grads between multiple GPUs.