### PR TITLE
Avoid values around zero

### DIFF
--- a/tests/chainer_tests/functions_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/test_clipped_relu.py
@@ -13,9 +13,11 @@ from chainer.testing import attr
 class TestClippedReLU(unittest.TestCase):
 
     def setUp(self):
-        x = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
-        # Avoid values around zero for stability of numerical gradient
-        self.x = x + (x > 0) - (x <= 0)
+        self.x = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
+        # Avoid values around zero and z for stability of numerical gradient
+        for i in range(self.x.size):
+            if -0.01 < self.x.flat[i] < 0.01 or 0.74 < self.x.flat[i] < 0.76:
+                self.x.flat[i] = 0.5
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
         self.z = 0.75
 

--- a/tests/chainer_tests/functions_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/test_clipped_relu.py
@@ -13,7 +13,9 @@ from chainer.testing import attr
 class TestClippedReLU(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
+        x = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
+        # Avoid values around zero for stability of numerical gradient
+        self.x = x + (x > 0) - (x <= 0)
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
         self.z = 0.75
 

--- a/tests/chainer_tests/functions_tests/test_leaky_relu.py
+++ b/tests/chainer_tests/functions_tests/test_leaky_relu.py
@@ -16,8 +16,10 @@ class TestLeakyReLU(unittest.TestCase):
 
     def setUp(self):
         # Avoid unstability of numeraical grad
-        self.x = numpy.random.uniform(.5, 1, (5, 4)).astype(numpy.float32)
-        self.x *= numpy.random.randint(2, size=(5, 4)) * 2 - 1
+        self.x = numpy.random.uniform(-1, 1, (5, 4)).astype(numpy.float32)
+        for i in range(self.x.size):
+            if -0.01 < self.x.flat[i] < 0.01:
+                self.x.flat[i] = 0.5
         self.gy = numpy.random.uniform(-1, 1, (5, 4)).astype(numpy.float32)
         self.slope = random.random()
 

--- a/tests/chainer_tests/functions_tests/test_prelu.py
+++ b/tests/chainer_tests/functions_tests/test_prelu.py
@@ -22,8 +22,10 @@ class TestPReLUSingle(unittest.TestCase):
         self.W = self.func.W.copy()  # fixed on CPU
 
         # Avoid unstability of numerical gradient
-        self.x = numpy.random.uniform(.5, 1, (4, 3, 2)).astype(numpy.float32)
-        self.x *= numpy.random.randint(2, size=(4, 3, 2)) * 2 - 1
+        self.x = numpy.random.uniform(-1, 1, (4, 3, 2)).astype(numpy.float32)
+        for i in range(self.x.size):
+            if -0.01 < self.x.flat[i] < 0.01:
+                self.x.flat[i] = 0.5
         self.gy = numpy.random.uniform(-1, 1, (4, 3, 2)).astype(numpy.float32)
 
     def check_forward(self, x_data):

--- a/tests/chainer_tests/functions_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/test_relu.py
@@ -15,8 +15,10 @@ class TestReLU(unittest.TestCase):
 
     def setUp(self):
         # Avoid unstability of numerical grad
-        self.x = numpy.random.uniform(.5, 1, (3, 2)).astype(numpy.float32)
-        self.x *= numpy.random.randint(2, size=(3, 2)) * 2 - 1
+        self.x = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
+        for i in range(self.x.size):
+            if -0.01 < self.x.flat[i] < 0.01:
+                self.x.flat[i] = 0.5
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):


### PR DESCRIPTION
Unit test for `crelu` sometimes fails when a random value is around zero.