### PR TITLE
Make cupy.cudnn importable only if cuDNN is available

### DIFF
--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -5,12 +5,7 @@ import numpy
 import six
 
 from cupy import cuda
-
-try:
-    from cupy.cuda import cudnn
-    available = True
-except Exception:
-    available = False
+from cupy.cuda import cudnn
 
 
 _handles = {}


### PR DESCRIPTION
Fix #339. It actually just makes `cupy.cudnn` not importable if cuDNN is not available.