### PR TITLE
Update cuda dependency paragraph in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,7 @@ Then, install CUDA-related dependent packages via pip:
 ```
 pip install chainer-cuda-deps
 ```
-or, from the source:
-```
-python cuda_deps/setup.py install
-```
+If you install the chainer from the source, the cuda dependencies are automatically installed.
 
 ## More information
 


### PR DESCRIPTION
The file mentioned at README
```
python cuda_deps/setup.py install
```
seems to have been vanished.
Would you please update the paragraph and let us, the users, know how to  install the latest cuda dependencies?