### PR TITLE
Add partial Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Minimum requirements:
 Requirements for some features:
 - CUDA support
   - CUDA 6.5+
+  - filelock
 - CuDNN support
   - CuDNN v2
 - Caffe model support

--- a/chainer/functions/clipped_relu.py
+++ b/chainer/functions/clipped_relu.py
@@ -42,7 +42,7 @@ class ClippedReLU(function.Function):
     def backward_gpu(self, x, gy):
         gx = cuda.elementwise(
             'T x, T gy, T z', 'T gx',
-            'gx = ((x > 0) and (x < z))? gy : 0',
+            'gx = ((x > 0) & (x < z))? gy : 0',
             'clipped_relu_bwd')(x[0], gy[0], self.cap)
         return gx,
 

--- a/cupy/carray.cuh
+++ b/cupy/carray.cuh
@@ -111,8 +111,8 @@ class CArray {
 private:
   T* data_;
   int size_;
-  int shape_[ndim == 0 ? 1 : ndim];
-  int strides_[ndim == 0 ? 1 : ndim];
+  int shape_[ndim];
+  int strides_[ndim];
 
 public:
   __device__ int size() const {
@@ -120,11 +120,11 @@ public:
   }
 
   __device__ T& operator[](const int* idx) {
-    int offset = 0;
+    char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = 0; dim < ndim; ++dim) {
-      offset += strides_[dim] * idx[dim];
+      ptr += strides_[dim] * idx[dim];
     }
-    return *reinterpret_cast<T*>(reinterpret_cast<char*>(data_) + offset);
+    return *reinterpret_cast<T*>(ptr);
   }
 
   __device__ T operator[](const int* idx) const {
@@ -132,16 +132,16 @@ public:
   }
 
   __device__ T& operator[](int i) {
-    int offset = 0;
+    char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = ndim; --dim > 0; ) {
-      offset += strides_[dim] * (i % shape_[dim]);
+      ptr += strides_[dim] * (i % shape_[dim]);
       i /= shape_[dim];
     }
     if (ndim > 0) {
-      offset += strides_[0] * i;
+      ptr += strides_[0] * i;
     }
 
-    return *reinterpret_cast<T*>(reinterpret_cast<char*>(data_) + offset);
+    return *reinterpret_cast<T*>(ptr);
   }
 
   __device__ T operator[](int i) const {
@@ -149,13 +149,40 @@ public:
   }
 };
 
+template <typename T>
+class CArray<T, 0> {
+private:
+  T* data_;
+  int size_;
+
+public:
+  __device__ int size() const {
+    return size_;
+  }
+
+  __device__ T& operator[](const int* idx) {
+    return *reinterpret_cast<T*>(data_);
+  }
+
+  __device__ T operator[](const int* idx) const {
+    return (*const_cast<CArray<T, 0>*>(this))[idx];
+  }
+
+  __device__ T& operator[](int i) {
+    return *reinterpret_cast<T*>(data_);
+  }
+
+  __device__ T operator[](int i) const {
+    return (*const_cast<CArray<T, 0>*>(this))[i];
+  }
+};
 
 template <int ndim>
 class CIndexer {
 private:
   int size_;
-  int shape_[ndim == 0 ? 1 : ndim];
-  int index_[ndim == 0 ? 1 : ndim];
+  int shape_[ndim];
+  int index_[ndim];
 
 public:
   __device__ int size() const {
@@ -179,6 +206,23 @@ public:
   }
 };
 
+template <>
+class CIndexer<0> {
+private:
+  int size_;
+
+public:
+  __device__ int size() const {
+    return size_;
+  }
+
+  __device__ void set(int i) {
+  }
+
+  __device__ const int* get() const {
+    return NULL;
+  }
+};
 
 __device__ int _floor_divide(int x, int y) {
   if (y == 0) return 0;

--- a/cupy/carray.cuh
+++ b/cupy/carray.cuh
@@ -1,3 +1,8 @@
+// math
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795
+#endif
+
 // float16
 class float16
 {

--- a/cupy/carray.cuh
+++ b/cupy/carray.cuh
@@ -111,8 +111,8 @@ class CArray {
 private:
   T* data_;
   int size_;
-  int shape_[ndim];
-  int strides_[ndim];
+  int shape_[ndim == 0 ? 1 : ndim];
+  int strides_[ndim == 0 ? 1 : ndim];
 
 public:
   __device__ int size() const {
@@ -154,8 +154,8 @@ template <int ndim>
 class CIndexer {
 private:
   int size_;
-  int shape_[ndim];
-  int index_[ndim];
+  int shape_[ndim == 0 ? 1 : ndim];
+  int index_[ndim == 0 ? 1 : ndim];
 
 public:
   __device__ int size() const {

--- a/cupy/carray.py
+++ b/cupy/carray.py
@@ -21,8 +21,6 @@ _carrays = [_make_carray(i) for i in six.moves.range(MAX_NDIM)]
 
 
 def to_carray(data, size, shape, strides):
-    if len(shape) == 0:
-        return _carrays[1](data, size, (1,), (0,))
     return _carrays[len(shape)](data, size, shape, strides)
 
 

--- a/cupy/carray.py
+++ b/cupy/carray.py
@@ -21,7 +21,8 @@ _carrays = [_make_carray(i) for i in six.moves.range(MAX_NDIM)]
 
 
 def to_carray(data, size, shape, strides):
-    global _carrays
+    if len(shape) == 0:
+        return _carrays[1](data, size, (1,), (0,))
     return _carrays[len(shape)](data, size, shape, strides)
 
 

--- a/cupy/cindexer.py
+++ b/cupy/cindexer.py
@@ -18,8 +18,6 @@ _cindexers = [_make_cindexer(i) for i in six.moves.range(carray.MAX_NDIM)]
 
 
 def to_cindexer(size, shape):
-    if len(shape) == 0:
-        return _cindexers[1](size, (1,), (0,))
     return _cindexers[len(shape)](size, shape, (0,) * len(shape))
 
 

--- a/cupy/cindexer.py
+++ b/cupy/cindexer.py
@@ -18,6 +18,8 @@ _cindexers = [_make_cindexer(i) for i in six.moves.range(carray.MAX_NDIM)]
 
 
 def to_cindexer(size, shape):
+    if len(shape) == 0:
+        return _cindexers[1](size, (1,), (0,))
     return _cindexers[len(shape)](size, shape, (0,) * len(shape))
 
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -1,11 +1,13 @@
-import fcntl
 import hashlib
 import os
 import re
 import subprocess
+import sys
 import tempfile
 
+import filelock
 import six
+
 
 from cupy.cuda import device
 from cupy.cuda import module
@@ -45,7 +47,7 @@ def nvcc(source, options=(), arch=None):
             cu_file.write(source)
 
         cmd.append(cu_path)
-        subprocess.check_call(cmd, cwd=root_dir)
+        subprocess.check_output(cmd, cwd=root_dir)
 
         with open(cubin_path, 'rb') as bin_file:
             return bin_file.read()
@@ -62,6 +64,7 @@ def preprocess(source, options=()):
 
         cmd.append(cu_path)
         pp_src = subprocess.check_output(cmd, cwd=root_dir)
+
         if isinstance(pp_src, six.binary_type):
             pp_src = pp_src.decode('utf-8')
         return re.sub('(?m)^#.*$', '', pp_src)
@@ -83,11 +86,19 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
         cache_dir = get_cache_dir()
     if arch is None:
         arch = _get_arch()
+
+    if 'win32' == sys.platform:
+        options += ('-Xcompiler', '/wd 4819')
+        if sys.maxsize == 9223372036854775807:
+            options += '-m64',
+        elif sys.maxsize == 2147483647:
+            options += '-m32',
+
     env = (arch, options)
     if '#include' in source:
         pp_src = '%s %s' % (env, preprocess(source, options))
     else:
-        base = _empty_file_preprocess_cache.pop(env, None)
+        base = _empty_file_preprocess_cache.get(env, None)
         if base is None:
             base = preprocess('', options)
             _empty_file_preprocess_cache[env] = base
@@ -103,23 +114,19 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
         os.makedirs(cache_dir)
 
     lock_path = os.path.join(cache_dir, 'lock_file.lock')
-    if not os.path.exists(lock_path):
-        open(lock_path, 'a').close()
 
     path = os.path.join(cache_dir, name)
-    with open(lock_path, 'r') as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
+    with filelock.FileLock(lock_path) as lock:
         if os.path.exists(path):
             with open(path, 'rb') as file:
                 cubin = file.read()
             mod.load(cubin)
         else:
-            fcntl.flock(lock, fcntl.LOCK_UN)
+            lock.release()
             cubin = nvcc(source, options, arch)
             mod.load(cubin)
-            fcntl.flock(lock, fcntl.LOCK_EX)
+            lock.acquire()
             with open(path, 'wb') as cubin_file:
                 cubin_file.write(cubin)
-        fcntl.flock(lock, fcntl.LOCK_UN)
 
     return mod

--- a/cupy/cuda/cublas.py
+++ b/cupy/cuda/cublas.py
@@ -1,10 +1,17 @@
 """Thin wrapper of CUBLAS."""
 import ctypes
+import sys
 
 from cupy.cuda import driver
 from cupy.cuda import internal
 
-_cublas = internal.load_library('cublas')
+
+if 'win32' == sys.platform:
+    _cublas = internal.load_library(
+        internal.get_windows_cuda_library_names('cublas'))
+else:
+    _cublas = internal.load_library('cublas')
+
 
 _I = ctypes.c_int
 _P = ctypes.c_void_p

--- a/cupy/cuda/cudnn.py
+++ b/cupy/cuda/cudnn.py
@@ -1,11 +1,16 @@
 """Thin wrapper of CuDNN."""
 # NOTE: This wrapper does not cover all APIs of CuDNN v2.
 import ctypes
+import sys
 
 from cupy.cuda import internal
 from cupy.cuda import runtime
 
-_cudnn = internal.load_library('cudnn')
+if 'win32' == sys.platform:
+    _cudnn = internal.load_library(
+        internal.get_windows_cuda_library_names('cudnn'))
+else:
+    _cudnn = internal.load_library('cudnn')
 
 _I = ctypes.c_int
 _S = ctypes.c_size_t

--- a/cupy/cuda/curand.py
+++ b/cupy/cuda/curand.py
@@ -1,10 +1,15 @@
 """Thin wrapper of cuRAND."""
 import ctypes
+import sys
 
 from cupy.cuda import internal
 from cupy.cuda import runtime
 
-_curand = internal.load_library('curand')
+if 'win32' == sys.platform:
+    _curand = internal.load_library(
+        internal.get_windows_cuda_library_names('curand'))
+else:
+    _curand = internal.load_library('curand')
 
 _I = ctypes.c_int
 _U = ctypes.c_uint

--- a/cupy/cuda/driver.py
+++ b/cupy/cuda/driver.py
@@ -10,12 +10,16 @@ There are four differences compared to the original C API.
 
 """
 import ctypes
+import sys
 
 import six
 
 from cupy.cuda import internal
 
-_cuda = internal.load_library('cuda')
+if 'win32' == sys.platform:
+    _cuda = internal.load_library('nvcuda')
+else:
+    _cuda = internal.load_library('cuda')
 
 ###############################################################################
 # Types

--- a/cupy/cuda/internal.py
+++ b/cupy/cuda/internal.py
@@ -1,18 +1,39 @@
 import ctypes
+import platform
 import sys
 
 
-def load_library(name):
+_support_cuda_versions = (75, 70, 65)
+
+
+def load_library(names):
+    if isinstance(names, str):
+        names = [names]
     if 'linux' in sys.platform:
-        libname = 'lib%s.so' % name
+        template = 'lib%s.so'
         module = ctypes.cdll
     elif 'darwin' == sys.platform:
-        libname = 'lib%s.dylib' % name
+        template = 'lib%s.dylib'
         module = ctypes.cdll
-    elif 'windows' == sys.platform:
-        libname = '%s.dll' % name
+    elif 'win32' == sys.platform:
+        template = '%s.dll'
         module = ctypes.windll
     else:
         raise RuntimeError('Unsupported platform: %s' % sys.platform)
 
-    return module.LoadLibrary(libname)
+    names = [template % i for i in names]
+    for name in names:
+        try:
+            return module.LoadLibrary(name)
+        except OSError:
+            pass
+    else:
+        raise OSError('library not found. %s' % names)
+
+
+def get_windows_cuda_library_names(name):
+    if platform.machine().endswith('64'):
+        bit = 64
+    else:
+        bit = 32
+    return ['%s%s_%s' % (name, bit, ver) for ver in _support_cuda_versions]

--- a/cupy/cuda/runtime.py
+++ b/cupy/cuda/runtime.py
@@ -10,10 +10,15 @@ There are four differences compared to the original C API.
 
 """
 import ctypes
+import sys
 
 from cupy.cuda import internal
 
-_cudart = internal.load_library('cudart')
+if 'win32' == sys.platform:
+    _cudart = internal.load_library(
+        internal.get_windows_cuda_library_names('cudart'))
+else:
+    _cudart = internal.load_library('cudart')
 
 ###############################################################################
 # Types

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     package_data={
         'cupy': ['carray.cuh'],
     },
-    install_requires=['nose',
+    install_requires=['filelock',
+                      'nose',
                       'numpy>=1.9.0',
                       'protobuf',
                       'six>=1.9.0'],


### PR DESCRIPTION
This PR add partial windows support.
- Use filelock package instead of fcntl.
- Do not use zero sized array.


I tested that the example of mnist can be run in the following environments.
- WIndows7
- CUDA 7.0
- Python 2.7.10 |Anaconda 2.3.0 (64-bit)|
However, some test cases is not completed successfully.