### PR TITLE
Fix error message of _check_constant_type

### DIFF
--- a/chainer/functions/basic_math.py
+++ b/chainer/functions/basic_math.py
@@ -31,7 +31,7 @@ def _check_constant_type(value):
         return
     else:
         raise ValueError(
-            'value must be float, ndarray, or Variable')
+            'value must be scalar, ndarray, or Variable')
 
 
 class Neg(function.Function):


### PR DESCRIPTION
I found a minor mistake in error message of `_check_constant_type` function in `basic_math`