### PR TITLE
Fix device switching by "with" statement

### DIFF
--- a/cupy/cuda/device.py
+++ b/cupy/cuda/device.py
@@ -48,7 +48,7 @@ class Device(object):
         dev = Device()
         self._device_stack.append(dev)
         if self.id != dev.id:
-            dev.use()
+            self.use()
         return self
 
     def __exit__(self, *args):


### PR DESCRIPTION
Device switching does not work. This change fixes it.
(This bug is found by the investigation for the forum report by Amit. Thank you!)