### PR TITLE
Fix to_gpu() of Convolution2D

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -288,7 +288,12 @@ class Convolution2D(function.Function):
                 gcol, self.sy, self.sx, self.ph, self.pw, h, w)
 
         return gx,
-
+        
+    def to_gpu(self, device=None):
+        super(Convolution2D, self).to_gpu(device=device)
+        if cuda.cudnn_enabled and self.use_cudnn:
+            self.max_workspace_size = self.in_channels * self.kh * self.kw * 4
+            
 
 class NonparameterizedConvolution2D(function.Function):
 


### PR DESCRIPTION
When the 'Convolution2D' function is migrated to GPU, it doesn't create the variable 'max_workspace_size' for the operation in cuDNN mode.