### PR TITLE
Write coveragerc to omit caffe_pb2 file from a coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit = chainer/functions/caffe/caffe_pb2.py
+
+[report]
+exclude_lines =
+    if __name__ == .__main__.:


### PR DESCRIPTION
I wrote `.coveragerc` file which is used in `coveralls` command to ignore `caffe_pb2.py` file.