### PR TITLE
Restore CHAINER_SEED

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -226,7 +226,7 @@ def get_random_state():
     dev = cuda.Device()
     rs = _random_states.get(dev.id, None)
     if rs is None:
-        rs = RandomState()
+        rs = RandomState(os.getenv('CHAINER_SEED'))
         _random_states[dev.id] = rs
     return rs
 


### PR DESCRIPTION
Use CHAINER_SEED random variable when get_random_state creats an instance of RandomState

This PR fixes #401 