### PR TITLE
bugfix: backprop now works when concatenating a single element array

### DIFF
--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -34,6 +34,9 @@ class Concat(function.Function):
         return xp.concatenate(xs, axis=self.axis),
 
     def backward(self, xs, gy):
+        if not xs[:-1]:
+            return gy
+
         xp = cuda.get_array_module(*xs)
         sizes = numpy.array([x.shape[self.axis] for x in xs[:-1]]).cumsum()
         return xp.split(gy[0], sizes, axis=self.axis)

--- a/tests/chainer_tests/functions_tests/array_tests/test_concat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_concat.py
@@ -69,4 +69,12 @@ class TestConcatLastAxis(unittest.TestCase, ConcatTestBase):
         self.axis = 0
 
 
+class TestConcatOneElement(unittest.TestCase, ConcatTestBase):
+
+    def setUp(self):
+        self.y = numpy.arange(2, dtype=numpy.float32)
+        self.xs = [self.y]
+        self.axis = 0
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
When backprop'ing `functions.array.concat` the following exception is raised if the array only contains one element (see the test)

```
File "/home/eddie/chainer/chainer/variable.py", line 180, in backward
  gxs = func.backward(in_data, out_grad)
File "/home/eddie/chainer/chainer/functions/array/concat.py", line 42, in backward
  return xp.split(gy[0], sizes, axis=self.axis)
File "/home/eddie/chainer/cupy/manipulation/split.py", line 96, in split
  return array_split(ary, indices_or_sections, axis)
File "/home/eddie/chainer/cupy/manipulation/split.py", line 32, in array_split
  ret.append(ary[skip + (slice(index, size),)])
UnboundLocalError: local variable 'index' referenced before assignment
```

This was caused by `functions.array.concat.backwards` passing in None to `cupy.manipulation.split.array_split` for the number / position of splits. With this fix concat now returns the original array if it only contains a single element. 

This could also be fixed in `cupy.manipulation.split.array_split`. Happy to change the fix if there is a better way to do it.

cheers