### PR TITLE
Fix memory init

### DIFF
--- a/cupy/cuda/memory.py
+++ b/cupy/cuda/memory.py
@@ -18,12 +18,11 @@ class Memory(object):
     """
     def __init__(self, size):
         self.size = size
-        self._device = device.Device()
+        self._device = None
+        self.ptr = ctypes.c_void_p()
         if size > 0:
+            self._device = device.Device()
             self.ptr = runtime.malloc(size)
-        else:
-            self.ptr = ctypes.c_void_p()
-            self._device = None
 
     def __del__(self):
         if self.ptr:


### PR DESCRIPTION
This PR modified to `self.ptr` exists when the exception raised(e.g. CUDARuntimeError).