### PR TITLE
Fix cupy.expand_dims() is missing in the docs

### DIFF
--- a/docs/source/cupy-reference/manipulation.rst
+++ b/docs/source/cupy-reference/manipulation.rst
@@ -30,6 +30,7 @@ Edit dimensionalities
 .. autofunction:: cupy.atleast_3d
 .. autoclass:: cupy.broadcast
 .. autofunction:: cupy.broadcast_arrays
+.. autofunction:: cupy.expand_dims
 .. autofunction:: cupy.squeeze
 
 

--- a/docs/source/cupy-reference/overview.rst
+++ b/docs/source/cupy-reference/overview.rst
@@ -221,6 +221,7 @@ Array manipulation routines
 :func:`atleast_3d`
 :class:`broadcast`
 :func:`broadcast_arrays`
+:func:`expand_dims`
 :func:`squeeze`
 
 :func:`column_stack`


### PR DESCRIPTION
cupy.expand_dims() is available in version 1.3.1 (#343), but missing in the docs.