### PR TITLE
set offset.

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -168,6 +168,7 @@ class RandomState(object):
             seed = numpy.uint64(seed)
 
         curand.setPseudoRandomGeneratorSeed(self._generator, seed)
+        curand.setGeneratorOffset(self._generator, 0)
 
     def standard_normal(self, size=None, dtype=float):
         """Returns samples drawn from the standard normal distribution.


### PR DESCRIPTION
Hi,

Current `RandomState.seed()` does not really reset all of random state.
Here is a small code to reproduce this issue:

```
from __future__ import print_function
from cupy.random import get_random_state, seed
from chainer import cuda

gpu = 0
device = cuda.get_device(gpu)
with device:
    seed(0)
    rs = get_random_state()

    for _ in range(10):
        r = rs.rand(1)
        print(r)

    print("====")

    seed(0)
    rs = get_random_state()

    for _ in range(10):
        r = rs.rand(1)
        print(r)
```

The results are here (different values are generated even though seed value is same):
```
[ 0.56154916]
[ 0.5396353]
[ 0.74978529]
[ 0.50525623]
[ 0.94698888]
[ 0.66230074]
[ 0.60323748]
[ 0.12558134]
[ 0.51783317]
[ 0.9571602]
====
[ 0.49158581]
[ 0.3454503]
[ 0.48739564]
[ 0.73569951]
[ 0.94801935]
[ 0.42100349]
[ 0.61444364]
[ 0.09178467]
[ 0.35837964]
[ 0.7166009]
```

This PR fixes this issue to generate same values.
```
[ 0.56154916]
[ 0.5396353]
[ 0.74978529]
[ 0.50525623]
[ 0.94698888]
[ 0.66230074]
[ 0.60323748]
[ 0.12558134]
[ 0.51783317]
[ 0.9571602]
====
[ 0.56154916]
[ 0.5396353]
[ 0.74978529]
[ 0.50525623]
[ 0.94698888]
[ 0.66230074]
[ 0.60323748]
[ 0.12558134]
[ 0.51783317]
[ 0.9571602]
```