### PR TITLE
Multi-GPU tests for Function.Copy

### DIFF
--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -2,3 +2,7 @@ from nose.plugins import attrib
 
 gpu = attrib.attr('gpu')
 cudnn = attrib.attr('gpu', 'cudnn')
+
+
+def multi_gpu(gpu_num):
+    return attrib.attr(gpu=gpu_num)

--- a/tests/chainer_tests/functions_tests/array_tests/test_copy.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_copy.py
@@ -2,10 +2,10 @@ import unittest
 
 import numpy
 
+
 import chainer
 from chainer import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 
@@ -30,8 +30,8 @@ class Copy(unittest.TestCase):
 
         y = functions.copy(x, dst_id)
 
-        y_data = _to_gpu(y.data, dst_id)
-        gradient_check.assert_allclose(self.x_data, y_data, atol=0, rtol=0)
+        numpy.testing.assert_array_equal(
+            self.x_data, cuda.to_cpu(y.data))
 
     def check_backward(self, src_id, dst_id):
         x_data = _to_gpu(self.x_data, src_id)
@@ -44,9 +44,8 @@ class Copy(unittest.TestCase):
         y.backward()
 
         x_grad = x.grad
-        if src_id >= 0:
-            x_grad = x_grad.get()
-        gradient_check.assert_allclose(x_grad, self.gy, atol=0, rtol=0)
+        numpy.testing.assert_array_equal(
+            cuda.to_cpu(x_grad), self.gy)
 
     def test_forward_cpu(self):
         self.check_forward(-1, -1)

--- a/tests/chainer_tests/functions_tests/array_tests/test_copy.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_copy.py
@@ -3,9 +3,18 @@ import unittest
 import numpy
 
 import chainer
+from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer import testing
+from chainer.testing import attr
+
+
+def _to_gpu(x, device_id):
+    if device_id >= 0:
+        return cuda.to_gpu(x, device_id)
+    else:
+        return x
 
 
 class Copy(unittest.TestCase):
@@ -15,17 +24,53 @@ class Copy(unittest.TestCase):
             -1, 1, (10, 5)).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, (10, 5)).astype(numpy.float32)
 
-    def test_check_forward_cpu(self):
-        x = chainer.Variable(self.x_data)
-        y = functions.copy(x, -1)
-        gradient_check.assert_allclose(self.x_data, y.data, atol=0, rtol=0)
+    def check_forward(self, src_id, dst_id):
+        x_data = _to_gpu(self.x_data, src_id)
+        x = chainer.Variable(x_data)
 
-    def test_check_backward_cpu(self):
-        x = chainer.Variable(self.x_data)
-        y = functions.copy(x, -1)
-        y.grad = self.gy
+        y = functions.copy(x, dst_id)
+
+        y_data = _to_gpu(y.data, dst_id)
+        gradient_check.assert_allclose(self.x_data, y_data, atol=0, rtol=0)
+
+    def check_backward(self, src_id, dst_id):
+        x_data = _to_gpu(self.x_data, src_id)
+        x = chainer.Variable(x_data)
+
+        y = functions.copy(x, dst_id)
+        gy = _to_gpu(self.gy, dst_id)
+        y.grad = gy
+
         y.backward()
-        gradient_check.assert_allclose(x.grad, self.gy, atol=0, rtol=0)
+
+        x_grad = x.grad
+        if src_id >= 0:
+            x_grad = x_grad.get()
+        gradient_check.assert_allclose(x_grad, self.gy, atol=0, rtol=0)
+
+    def test_forward_cpu(self):
+        self.check_forward(-1, -1)
+
+    def test_backward_cpu(self):
+        self.check_backward(-1, -1)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        device_id = cuda.Device().id
+        self.check_forward(device_id, device_id)
+
+    @attr.gpu
+    def test_check_backward_gpu(self):
+        device_id = cuda.Device().id
+        self.check_forward(device_id, device_id)
+
+    @attr.multi_gpu(2)
+    def test_forward_multigpu(self):
+        self.check_forward(0, 1)
+
+    @attr.multi_gpu(2)
+    def test_backward_multigpu(self):
+        self.check_backward(0, 1)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR implements multi-gpu unit tests for `Function.Copy`.
See #418 

This PR also includes `multi_gpu(N)` decorator, which specifies that decorated test should be run in the environment with at least N GPUs.

e.g.
* Run only CPU tests
```
nosetests -A "gpu<1" tests/
nosetests -a '!gpu' tests/
```

* Run only single GPU tests
```
nosetests -a gpu=1 tests/
```

* Run only multiple GPU tests
```
nosetests -A "gpu>1" tests/
nosetests -A "gpu>=2" tests/
```

* Run CPU tests and single GPU tests
```
nosetests -A "gpu<=1" tests/
nosetests -A "gpu<2" tests/
```

See [nose references](http://nose.readthedocs.org/en/latest/plugins/attrib.html) for details.
