### PR TITLE
Multi-GPU tests for accumulate_grads and copy_parameters_from

### DIFF
--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -2,3 +2,7 @@ from nose.plugins import attrib
 
 gpu = attrib.attr('gpu')
 cudnn = attrib.attr('gpu', 'cudnn')
+
+
+def multi_gpu(gpu_num):
+    return attrib.attr(gpu=gpu_num)

--- a/tests/chainer_tests/test_function_set.py
+++ b/tests/chainer_tests/test_function_set.py
@@ -98,7 +98,7 @@ class TestFunctionSet(unittest.TestCase):
         fs2.to_cpu()
         self.check_equal_fs(self.fs, fs2)
 
-    def check_copy_parameters_from(self, src_id=-1, dst_id=-1):
+    def check_copy_parameters_from(self, src_id, dst_id):
         aW = np.random.uniform(-1, 1, (2, 3)).astype(np.float32)
         ab = np.random.uniform(-1, 1, (2,)).astype(np.float32)
         bW = np.random.uniform(-1, 1, (2, 3)).astype(np.float32)

--- a/tests/chainer_tests/test_function_set.py
+++ b/tests/chainer_tests/test_function_set.py
@@ -98,18 +98,18 @@ class TestFunctionSet(unittest.TestCase):
         fs2.to_cpu()
         self.check_equal_fs(self.fs, fs2)
 
-    def check_copy_parameters_from(self, src_gpu=False, dst_gpu=False):
+    def check_copy_parameters_from(self, src_id=-1, dst_id=-1):
         aW = np.random.uniform(-1, 1, (2, 3)).astype(np.float32)
         ab = np.random.uniform(-1, 1, (2,)).astype(np.float32)
         bW = np.random.uniform(-1, 1, (2, 3)).astype(np.float32)
         bb = np.random.uniform(-1, 1, (2,)).astype(np.float32)
         params = [aW.copy(), ab.copy(), bW.copy(), bb.copy()]
 
-        if dst_gpu:
-            self.fs.to_gpu()
+        if dst_id >= 0:
+            self.fs.to_gpu(dst_id)
 
-        if src_gpu:
-            params = map(cuda.to_gpu, params)
+        if src_id >= 0:
+            params = map(lambda p: cuda.to_gpu(p, src_id), params)
 
         self.fs.copy_parameters_from(params)
         self.fs.to_cpu()
@@ -120,19 +120,24 @@ class TestFunctionSet(unittest.TestCase):
         self.assertTrue((self.fs.b.b == bb).all())
 
     def test_copy_parameters_from_cpu_to_cpu(self):
-        self.check_copy_parameters_from(False, False)
+        self.check_copy_parameters_from(-1, -1)
 
     @attr.gpu
     def test_copy_parameters_from_cpu_to_gpu(self):
-        self.check_copy_parameters_from(False, True)
+        self.check_copy_parameters_from(-1, cuda.Device().id)
 
     @attr.gpu
     def test_copy_parameters_from_gpu_to_cpu(self):
-        self.check_copy_parameters_from(True, False)
+        self.check_copy_parameters_from(cuda.Device().id, -1)
 
     @attr.gpu
     def test_copy_parameters_from_gpu_to_gpu(self):
-        self.check_copy_parameters_from(True, True)
+        device_id = cuda.Device().id
+        self.check_copy_parameters_from(device_id, device_id)
+
+    @attr.multi_gpu(2)
+    def test_copy_parameters_from_multigpu(self):
+        self.check_copy_parameters_from(0, 1)
 
     def test_getitem(self):
         self.assertIs(self.fs['a'], self.fs.a)

--- a/tests/chainer_tests/test_function_set.py
+++ b/tests/chainer_tests/test_function_set.py
@@ -109,7 +109,7 @@ class TestFunctionSet(unittest.TestCase):
             self.fs.to_gpu(dst_id)
 
         if src_id >= 0:
-            params = map(lambda p: cuda.to_gpu(p, src_id), params)
+            params = [cuda.to_gpu(p, src_id) for p in params]
 
         self.fs.copy_parameters_from(params)
         self.fs.to_cpu()

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -137,6 +137,7 @@ class TestOptimizer(unittest.TestCase):
         self.optimizer.accumulate_grads([np.arange(3)])
         self.assertTrue((cuda.to_cpu(self.grads[0]) == np.arange(3) * 2).all())
 
+    @attr.gpu
     def check_accumulate_grads_from_gpu(self, src_id):
         with cuda.Device(src_id):
             self.optimizer.accumulate_grads([cp.arange(3)])

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -2,10 +2,10 @@ import unittest
 
 import mock
 import numpy as np
+import cupy as cp
 
 import chainer
 from chainer import cuda
-from chainer.cuda import cupy as cp
 from chainer import gradient_check
 from chainer import optimizer
 from chainer import optimizers

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -1,8 +1,8 @@
 import unittest
 
+import cupy as cp
 import mock
 import numpy as np
-import cupy as cp
 
 import chainer
 from chainer import cuda

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -86,7 +86,7 @@ class TestOptimizer(unittest.TestCase):
     def setup_cpu(self):
         self.optimizer.setup((self.params, self.grads))
 
-    def setup_gpu(self, dst_id):
+    def setup_gpu(self, dst_id=None):
         self.params = [cuda.to_gpu(p, dst_id) for p in self.params]
         self.grads = [cuda.to_gpu(p, dst_id) for p in self.grads]
         self.optimizer.setup((self.params, self.grads))
@@ -129,7 +129,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_update_gpu(self):
-        self.setup_gpu(cuda.Device().id)
+        self.setup_gpu()
         self.check_update(True)
 
     def check_accumulate_grads_from_cpu(self):
@@ -148,7 +148,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_accumulate_grads_cpu_to_gpu(self):
-        self.setup_gpu(cuda.Device().id)
+        self.setup_gpu()
         self.check_accumulate_grads_from_cpu()
 
     @attr.gpu
@@ -177,7 +177,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_compute_grads_norm_gpu(self):
-        self.setup_gpu(cuda.Device().id)
+        self.setup_gpu()
         self.check_compute_grads_norm()
 
     def check_weight_decay(self):
@@ -192,7 +192,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_weight_decay_gpu(self):
-        self.setup_gpu(cuda.Device().id)
+        self.setup_gpu()
         self.check_weight_decay()
 
     def check_clip_grads(self):
@@ -207,7 +207,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_clip_grads_gpu(self):
-        self.setup_gpu(cuda.Device().id)
+        self.setup_gpu()
         self.check_clip_grads()
 
 

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -87,8 +87,8 @@ class TestOptimizer(unittest.TestCase):
         self.optimizer.setup((self.params, self.grads))
 
     def setup_gpu(self, dst_id):
-        self.params = list(map(lambda p: cuda.to_gpu(p, dst_id), self.params))
-        self.grads = list(map(lambda p: cuda.to_gpu(p, dst_id), self.grads))
+        self.params = [cuda.to_gpu(p, dst_id) for p in self.params]
+        self.grads = [cuda.to_gpu(p, dst_id) for p in self.grads]
         self.optimizer.setup((self.params, self.grads))
 
     def check_init_state(self, param, grad, gpu):

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -1,6 +1,5 @@
 import unittest
 
-import cupy as cp
 import mock
 import numpy as np
 
@@ -140,7 +139,7 @@ class TestOptimizer(unittest.TestCase):
     @attr.gpu
     def check_accumulate_grads_from_gpu(self, src_id):
         with cuda.Device(src_id):
-            self.optimizer.accumulate_grads([cp.arange(3)])
+            self.optimizer.accumulate_grads([cuda.cupy.arange(3)])
         self.assertTrue((cuda.to_cpu(self.grads[0]) == np.arange(3) * 2).all())
 
     def test_accumulate_grads_cpu_to_cpu(self):

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import chainer
 from chainer import cuda
+from chainer.cuda import cupy as cp
 from chainer import gradient_check
 from chainer import optimizer
 from chainer import optimizers
@@ -86,9 +87,9 @@ class TestOptimizer(unittest.TestCase):
     def setup_cpu(self):
         self.optimizer.setup((self.params, self.grads))
 
-    def setup_gpu(self):
-        self.params = list(map(cuda.to_gpu, self.params))
-        self.grads = list(map(cuda.to_gpu, self.grads))
+    def setup_gpu(self, dst_id):
+        self.params = list(map(lambda p: cuda.to_gpu(p, dst_id), self.params))
+        self.grads = list(map(lambda p: cuda.to_gpu(p, dst_id), self.grads))
         self.optimizer.setup((self.params, self.grads))
 
     def check_init_state(self, param, grad, gpu):
@@ -129,7 +130,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_update_gpu(self):
-        self.setup_gpu()
+        self.setup_gpu(cuda.Device().id)
         self.check_update(True)
 
     def check_accumulate_grads(self):
@@ -155,7 +156,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_compute_grads_norm_gpu(self):
-        self.setup_gpu()
+        self.setup_gpu(cuda.Device().id)
         self.check_compute_grads_norm()
 
     def check_weight_decay(self):
@@ -170,7 +171,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_weight_decay_gpu(self):
-        self.setup_gpu()
+        self.setup_gpu(cuda.Device().id)
         self.check_weight_decay()
 
     def check_clip_grads(self):
@@ -185,7 +186,7 @@ class TestOptimizer(unittest.TestCase):
 
     @attr.gpu
     def test_clip_grads_gpu(self):
-        self.setup_gpu()
+        self.setup_gpu(cuda.Device().id)
         self.check_clip_grads()
 
 


### PR DESCRIPTION
This PR implements multi-GPU tests for `optimizer.accumulate_grads` and `copy_parameters_from`
See #418

I test these methods preferentially because most of typical model-parallel training procedures will use these methods.

Since this PR includes same changes same as #436, please merge #436 before this PR.