### PR TITLE
Fixes relating to cross-device array copy

### DIFF
--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -3,7 +3,6 @@ import ctypes
 import numpy
 
 import cupy
-from cupy import cuda
 from cupy import elementwise
 
 

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -137,19 +137,10 @@ def copy(a):
     if a.size == 0:
         return cupy.empty_like(a)
 
-    if a.data.device != cuda.Device():
-        # peer copy
-        a = ascontiguousarray(a)
-        newarray = cupy.empty_like(a)
-        newarray.data.copy_from_peer(a.data, a.nbytes)
-        return newarray
-
-    # in-device copy
     newarray = cupy.empty_like(a)
-    if a.flags.c_contiguous:
-        newarray.data.copy_from(a.data, a.nbytes)
-    else:
-        elementwise.copy(a, newarray)
+    if not a.flags.c_contiguous:
+        a = ascontiguousarray(a)
+    newarray.data.copy_from(a.data, a.nbytes)
     return newarray
 
 

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -3,6 +3,7 @@ import ctypes
 import numpy
 
 import cupy
+from cupy import cuda
 from cupy import elementwise
 
 
@@ -136,9 +137,11 @@ def copy(a):
     if a.size == 0:
         return cupy.empty_like(a)
 
-    newarray = cupy.empty_like(a)
     if not a.flags.c_contiguous:
         a = ascontiguousarray(a)
+        if a.data.device == cuda.Device():
+            return a
+    newarray = cupy.empty_like(a)
     newarray.data.copy_from(a.data, a.nbytes)
     return newarray
 

--- a/cupy/cuda/memory.py
+++ b/cupy/cuda/memory.py
@@ -113,7 +113,7 @@ class MemoryPointer(object):
         """
         if size > 0:
             runtime.memcpyAsync(self.ptr, src.ptr, size,
-                                runtime.memcpyDeviceToDevice)
+                                runtime.memcpyDeviceToDevice, stream)
 
     def copy_from_host(self, mem, size):
         """Copies a memory sequence from the host memory.

--- a/cupy/cuda/memory.py
+++ b/cupy/cuda/memory.py
@@ -99,8 +99,16 @@ class MemoryPointer(object):
 
         """
         if size > 0:
-            runtime.memcpy(self.ptr, src.ptr, size,
-                           runtime.memcpyDeviceToDevice)
+            if (self.device.compute_capability[0] >= '2' and
+                src.device.compute_capability[0] >= '2'):
+                runtime.memcpy(self.ptr, src.ptr, size,
+                               runtime.memcpyDeviceToDevice)
+            else:
+                buf = ctypes.create_string_buffer(size)
+                runtime.memcpy(self.ptr, buf, size,
+                               runtime.memcpyDeviceToHost)
+                runtime.memcpy(buf, src.ptr, size,
+                               runtime.memcpyHostToDevice)
 
     def copy_from_device_async(self, src, size, stream):
         """Copies a memory sequence from a (possibly different) device asynchronously.
@@ -112,8 +120,16 @@ class MemoryPointer(object):
 
         """
         if size > 0:
-            runtime.memcpyAsync(self.ptr, src.ptr, size, stream,
-                                runtime.memcpyDeviceToDevice)
+            if (self.device.compute_capability[0] >= '2' and
+                src.device.compute_capability[0] >= '2'):
+                runtime.memcpyAsync(self.ptr, src.ptr, size,
+                                    runtime.memcpyDeviceToDevice)
+            else:
+                buf = ctypes.create_string_buffer(size)
+                runtime.memcpyAsync(self.ptr, buf, size,
+                                    runtime.memcpyDeviceToHost)
+                runtime.memcpyAsync(buf, src.ptr, size,
+                                    runtime.memcpyHostToDevice)
 
     def copy_from_host(self, mem, size):
         """Copies a memory sequence from the host memory.

--- a/cupy/cuda/memory.py
+++ b/cupy/cuda/memory.py
@@ -99,8 +99,8 @@ class MemoryPointer(object):
 
         """
         if size > 0:
-            if (self.device.compute_capability[0] >= '2' and
-                src.device.compute_capability[0] >= '2'):
+            if self.device.compute_capability[0] >= '2' and \
+               src.device.compute_capability[0] >= '2':
                 runtime.memcpy(self.ptr, src.ptr, size,
                                runtime.memcpyDeviceToDevice)
             else:
@@ -120,8 +120,8 @@ class MemoryPointer(object):
 
         """
         if size > 0:
-            if (self.device.compute_capability[0] >= '2' and
-                src.device.compute_capability[0] >= '2'):
+            if self.device.compute_capability[0] >= '2' and \
+               src.device.compute_capability[0] >= '2':
                 runtime.memcpyAsync(self.ptr, src.ptr, size,
                                     runtime.memcpyDeviceToDevice)
             else:

--- a/cupy/cuda/memory.py
+++ b/cupy/cuda/memory.py
@@ -91,7 +91,7 @@ class MemoryPointer(object):
         return self._device
 
     def copy_from_device(self, src, size):
-        """Copies a memory sequence from the same device.
+        """Copies a memory sequence from a (possibly different) device.
 
         Args:
             src (cupy.cuda.MemoryPointer): Source memory pointer.
@@ -103,7 +103,7 @@ class MemoryPointer(object):
                            runtime.memcpyDeviceToDevice)
 
     def copy_from_device_async(self, src, size, stream):
-        """Copies a memory sequence from the same device asynchronously.
+        """Copies a memory sequence from a (possibly different) device asynchronously.
 
         Args:
             src (cupy.cuda.MemoryPointer): Source memory pointer.

--- a/cupy/cuda/memory.py
+++ b/cupy/cuda/memory.py
@@ -99,16 +99,8 @@ class MemoryPointer(object):
 
         """
         if size > 0:
-            if self.device.compute_capability[0] >= '2' and \
-               src.device.compute_capability[0] >= '2':
-                runtime.memcpy(self.ptr, src.ptr, size,
-                               runtime.memcpyDeviceToDevice)
-            else:
-                buf = ctypes.create_string_buffer(size)
-                runtime.memcpy(self.ptr, buf, size,
-                               runtime.memcpyDeviceToHost)
-                runtime.memcpy(buf, src.ptr, size,
-                               runtime.memcpyHostToDevice)
+            runtime.memcpy(self.ptr, src.ptr, size,
+                           runtime.memcpyDeviceToDevice)
 
     def copy_from_device_async(self, src, size, stream):
         """Copies a memory sequence from a (possibly different) device asynchronously.
@@ -120,16 +112,8 @@ class MemoryPointer(object):
 
         """
         if size > 0:
-            if self.device.compute_capability[0] >= '2' and \
-               src.device.compute_capability[0] >= '2':
-                runtime.memcpyAsync(self.ptr, src.ptr, size,
-                                    runtime.memcpyDeviceToDevice)
-            else:
-                buf = ctypes.create_string_buffer(size)
-                runtime.memcpyAsync(self.ptr, buf, size,
-                                    runtime.memcpyDeviceToHost)
-                runtime.memcpyAsync(buf, src.ptr, size,
-                                    runtime.memcpyHostToDevice)
+            runtime.memcpyAsync(self.ptr, src.ptr, size,
+                                runtime.memcpyDeviceToDevice)
 
     def copy_from_host(self, mem, size):
         """Copies a memory sequence from the host memory.

--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -31,3 +31,4 @@ shaped_reverse_arange = helper.shaped_reverse_arange
 shaped_random = helper.shaped_random
 
 gpu = attr.gpu
+multi_gpu = attr.multi_gpu

--- a/cupy/testing/attr.py
+++ b/cupy/testing/attr.py
@@ -1,3 +1,7 @@
 from nose.plugins import attrib
 
 gpu = attrib.attr('gpu')
+
+
+def multi_gpu(gpu_num):
+    return attrib.attr(gpu=gpu_num)

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -1,10 +1,8 @@
 import unittest
 
-import numpy
-
 import cupy
-from cupy import testing
 from cupy import cuda
+from cupy import testing
 
 
 @testing.gpu
@@ -80,4 +78,3 @@ class TestFromData(unittest.TestCase):
         with cuda.Device(1):
             dst = src.copy()
         testing.assert_allclose(src, dst, rtol=0, atol=0)
-

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -1,6 +1,7 @@
 import unittest
 
 from cupy import testing
+from cupy import cuda
 
 
 @testing.gpu
@@ -40,3 +41,14 @@ class TestBasic(unittest.TestCase):
         c = testing.shaped_arange((2, 3, 4), xp, '?')
         xp.copyto(a, b, where=c)
         return a
+
+    @testing.multi_gpu(2)
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_copyto_multigpu(self, xp, dtype):
+        with cuda.Device(0):
+            a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        with cuda.Device(1):
+            b = xp.empty((2, 3, 4), dtype=dtype)
+        xp.copyto(b, a)
+        return b

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -1,7 +1,7 @@
 import unittest
 
-from cupy import testing
 from cupy import cuda
+from cupy import testing
 
 
 @testing.gpu

--- a/tests/cupy_tests/test_elementwise.py
+++ b/tests/cupy_tests/test_elementwise.py
@@ -1,0 +1,32 @@
+import unittest
+
+import cupy
+from cupy import cuda
+from cupy import testing
+from cupy import elementwise
+
+
+@testing.gpu
+class TestElementwise(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def check_copy(self, dtype, src_id, dst_id):
+        with cuda.Device(src_id):
+            src = testing.shaped_arange((2, 3, 4), dtype=dtype)
+        with cuda.Device(dst_id):
+            dst = cupy.empty((2, 3, 4), dtype=dtype)
+        elementwise.copy(src, dst)
+        testing.assert_allclose(src, dst)
+
+    @testing.for_all_dtypes()
+    def test_copy(self, dtype):
+        device_id = cuda.Device().id
+        self.check_copy(dtype, device_id, device_id)
+
+    @testing.multi_gpu(2)
+    @testing.for_all_dtypes()
+    def test_copy_multigpu(self, dtype):
+        with self.assertRaises(ValueError):
+            self.check_copy(dtype, 0, 1)
+

--- a/tests/cupy_tests/test_elementwise.py
+++ b/tests/cupy_tests/test_elementwise.py
@@ -2,8 +2,8 @@ import unittest
 
 import cupy
 from cupy import cuda
-from cupy import testing
 from cupy import elementwise
+from cupy import testing
 
 
 @testing.gpu
@@ -29,4 +29,3 @@ class TestElementwise(unittest.TestCase):
     def test_copy_multigpu(self, dtype):
         with self.assertRaises(ValueError):
             self.check_copy(dtype, 0, 1)
-


### PR DESCRIPTION
This PR implements
* multi_gpu decorator for cupy
* unittests for `cupy.copy`, `cupy.copyto` and `cupy.elementwise.copy` including multi-GPU ones.
* fixes for #438 
    * Contrary to what I commented there, I tried to support cross-device copy in non-UVA devices. But since I do not have such environment, I could not check the corresponding code.