### PR TITLE
Unittest for cupy.get

### DIFF
--- a/cupy/cuda/memory.py
+++ b/cupy/cuda/memory.py
@@ -198,8 +198,8 @@ class MemoryPointer(object):
 
         """
         if size > 0:
-            runtime.memcpyAsync(mem, self.ptr, size, stream,
-                                runtime.memcpyDeviceToHost)
+            runtime.memcpyAsync(mem, self.ptr, size,
+                                runtime.memcpyDeviceToHost, stream)
 
     def memset(self, value, size):
         """Fills a memory sequence by constant byte value.

--- a/tests/cupy_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/test_ndarray_get.py
@@ -1,0 +1,45 @@
+import unittest
+
+import cupy
+from cupy import cuda
+from cupy import testing
+import numpy
+from numpy import testing as np_testing
+
+
+@testing.gpu
+class TestArrayGet(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        self.stream = cuda.Stream()
+
+    def check_get(self, f, stream):
+        a_gpu = f(cupy)
+        a_cpu = f(numpy)
+        np_testing.assert_array_equal(a_gpu.get(stream), a_cpu)
+
+    @testing.for_all_dtypes()
+    def test_contiguous_array(self, dtype):
+        contiguous_array = lambda xp: testing.shaped_arange(
+            (3,), xp=xp, dtype=dtype)
+        self.check_get(contiguous_array, None)
+
+    @testing.for_all_dtypes()
+    def test_non_contiguous_array(self, dtype):
+        non_contiguous_array = lambda xp: testing.shaped_arange(
+            (3,), xp=xp, dtype=dtype)[0::2]
+        self.check_get(non_contiguous_array, None)
+
+    @testing.for_all_dtypes()
+    def test_contiguous_array_stream(self, dtype):
+        contiguous_array = lambda xp: testing.shaped_arange(
+            (3,), xp=xp, dtype=dtype)
+        self.check_get(contiguous_array, self.stream.ptr)
+
+    @testing.for_all_dtypes()
+    def test_non_contiguous_array_stream(self, dtype):
+        non_contiguous_array = lambda xp: testing.shaped_arange(
+            (3,), xp=xp, dtype=dtype)[0::2]
+        self.check_get(non_contiguous_array, self.stream.ptr)


### PR DESCRIPTION
This PR implements unit tests for `cupy.get`.

This PR essentially fixes #430 because `cupy.asnumpy` is same as `cupy.get` get the source array is on the device.