### PR TITLE
Restore mocked objects in teardown of RandomState's unit tests

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -13,6 +13,19 @@ from cupy.random import generator
 from cupy import testing
 
 
+class FunctionSwitcher(object):
+
+    def __init__(self, f):
+        self.tmp = f
+        self.func_name = f.func_name
+
+    def __enter__(self):
+        setattr(curand, self.func_name, mock.Mock())
+
+    def __exit__(self, *args):
+        setattr(curand, self.func_name, self.tmp)
+
+
 @testing.gpu
 class TestRandomState(unittest.TestCase):
 
@@ -39,16 +52,16 @@ class TestRandomState(unittest.TestCase):
         self.assertEqual(out.shape, shape)
 
     def test_lognormal_float(self):
-        curand.generateLogNormalDouble = mock.Mock()
-        self.check_lognormal(curand.generateLogNormalDouble, float)
+        with FunctionSwitcher(curand.generateLogNormalDouble):
+            self.check_lognormal(curand.generateLogNormalDouble, float)
 
     def test_lognormal_float32(self):
-        curand.generateLogNormal = mock.Mock()
-        self.check_lognormal(curand.generateLogNormal, numpy.float32)
+        with FunctionSwitcher(curand.generateLogNormal):
+            self.check_lognormal(curand.generateLogNormal, numpy.float32)
 
     def test_lognormal_float64(self):
-        curand.generateLogNormalDouble = mock.Mock()
-        self.check_lognormal(curand.generateLogNormalDouble, numpy.float64)
+        with FunctionSwitcher(curand.generateLogNormalDouble):
+            self.check_lognormal(curand.generateLogNormalDouble, numpy.float64)
 
     def check_normal(self, curand_func, dtype):
         shape = cupy._get_size(self.size)
@@ -66,12 +79,12 @@ class TestRandomState(unittest.TestCase):
         self.assertEqual(out.shape, shape)
 
     def test_normal_float32(self):
-        curand.generateNormal = mock.Mock()
-        self.check_normal(curand.generateNormal, numpy.float32)
+        with FunctionSwitcher(curand.generateNormal):
+            self.check_normal(curand.generateNormal, numpy.float32)
 
     def test_normal_float64(self):
-        curand.generateNormalDouble = mock.Mock()
-        self.check_normal(curand.generateNormalDouble, numpy.float64)
+        with FunctionSwitcher(curand.generateNormalDouble):
+            self.check_normal(curand.generateNormalDouble, numpy.float64)
 
     def check_random_sample(self, curand_func, dtype):
         out = self.rs.random_sample(self.size, dtype)
@@ -79,12 +92,13 @@ class TestRandomState(unittest.TestCase):
             self.rs._generator, out.data.ptr, out.size)
 
     def test_random_sample_float32(self):
-        curand.generateUniform = mock.Mock()
-        self.check_random_sample(curand.generateUniform, numpy.float32)
+        with FunctionSwitcher(curand.generateUniform):
+            self.check_random_sample(curand.generateUniform, numpy.float32)
 
     def test_random_sample_float64(self):
-        curand.generateUniformDouble = mock.Mock()
-        self.check_random_sample(curand.generateUniformDouble, numpy.float64)
+        with FunctionSwitcher(curand.generateUniformDouble):
+            self.check_random_sample(
+                curand.generateUniformDouble, numpy.float64)
 
     def check_seed(self, curand_func, seed):
         self.rs.seed(seed)
@@ -96,13 +110,13 @@ class TestRandomState(unittest.TestCase):
         self.assertEqual(numpy.uint64, call_args[1].dtype)
 
     def test_seed_none(self):
-        curand.setPseudoRandomGeneratorSeed = mock.Mock()
-        self.check_seed(curand.setPseudoRandomGeneratorSeed, None)
+        with FunctionSwitcher(curand.setPseudoRandomGeneratorSeed):
+            self.check_seed(curand.setPseudoRandomGeneratorSeed, None)
 
     @testing.for_all_dtypes()
     def test_seed_not_none(self, dtype):
-        curand.setPseudoRandomGeneratorSeed = mock.Mock()
-        self.check_seed(curand.setPseudoRandomGeneratorSeed, dtype(0))
+        with FunctionSwitcher(curand.setPseudoRandomGeneratorSeed):
+            self.check_seed(curand.setPseudoRandomGeneratorSeed, dtype(0))
 
 
 @testing.gpu


### PR DESCRIPTION
Some test fixtures in `RandomState`'s unit tests substitute objects with mocking ones. But they leave the mocks as they are and it does harm to other unit tests.
This PR fixes so that mocked objects are properly restored in teardown.