### PR TITLE
Use function.__name__ instead of func_name to support Python3

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -17,7 +17,7 @@ class FunctionSwitcher(object):
 
     def __init__(self, f):
         self.tmp = f
-        self.func_name = f.func_name
+        self.func_name = f.__name__
 
     def __enter__(self):
         setattr(curand, self.func_name, mock.Mock())


### PR DESCRIPTION
`functon.func_name` is not available in Python 3. This PR change to use `__name__` instead of `func_name` 