### PR TITLE
Fix contiguity after reshape

### DIFF
--- a/cupy/manipulation/shape.py
+++ b/cupy/manipulation/shape.py
@@ -52,7 +52,7 @@ def reshape(a, newshape):
     newarray._strides = newstrides
     if newarray._c_contiguous == 1:
         newarray._f_contiguous = int(
-            not size or len(shape) - shape.count(1) <= 1)
+            not size or len(newshape) - newshape.count(1) <= 1)
     else:
         newarray._f_contiguous = -1
     return newarray

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -1,5 +1,6 @@
 import unittest
 
+import cupy
 from cupy import testing
 
 
@@ -51,3 +52,20 @@ class TestShape(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         a = a.transpose(2, 0, 1)
         return a.ravel()
+
+    def test_reshape_contiguity(self):
+        a = cupy.arange(6).reshape(2, 3)
+        self.assertTrue(a.flags.c_contiguous)
+        self.assertFalse(a.flags.f_contiguous)
+
+        a = a.reshape(1, 6, 1)
+        self.assertTrue(a.flags.c_contiguous)
+        self.assertTrue(a.flags.f_contiguous)
+
+        b = a.T.reshape(1, 6, 1)
+        self.assertTrue(b.flags.c_contiguous)
+        self.assertTrue(b.flags.f_contiguous)
+
+        b = a.T.reshape(2, 3)
+        self.assertTrue(b.flags.c_contiguous)
+        self.assertFalse(b.flags.f_contiguous)


### PR DESCRIPTION
Contiguity is wrong after cupy.reshape:
```python
a = cupy.arange(6).reshape(2, 3)
a.flags.f_contiguous  #=> 1
```
It causes incorrect results on successive computations on the reshaped array. This PR fixes this issue.