### PR TITLE
Implement cupy.all, cupy.ndarray.all, cupy.any and cupy.ndarray.any

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -646,8 +646,12 @@ class ndarray(object):
         return prod(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
     # TODO(okuta): Implement cumprod
-    # TODO(okuta): Implement all
-    # TODO(okuta): Implement any
+
+    def all(self, axis=None, out=None):
+        return all(self, axis, out)
+
+    def any(self, axis=None, out=None):
+        return any(self, axis, out)
 
     # -------------------------------------------------------------------------
     # Arithmetic and comparison operations
@@ -1300,6 +1304,9 @@ less = logic.comparison.less
 less_equal = logic.comparison.less_equal
 equal = logic.comparison.equal
 not_equal = logic.comparison.not_equal
+
+all = logic.truth.all
+any = logic.truth.any
 
 # -----------------------------------------------------------------------------
 # Mathematical functions

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -918,7 +918,7 @@ class ndarray(object):
         else:
             slices = list(slices)
 
-        if _builtin_any(isinstance(s, ndarray) for s in slices):
+        if six.moves.builtins.any(isinstance(s, ndarray) for s in slices):
             raise ValueError('Advanced indexing is not supported')
 
         # Expand ellipsis into empty slices
@@ -1306,7 +1306,6 @@ equal = logic.comparison.equal
 not_equal = logic.comparison.not_equal
 
 all = logic.truth.all
-_builtin_any = any
 any = logic.truth.any
 
 # -----------------------------------------------------------------------------
@@ -1449,7 +1448,7 @@ def get_array_module(*args):
                return xp.maximum(0, x) + xp.log1p(xp.exp(-abs(x)))
 
     """
-    if _builtin_any(isinstance(arg, ndarray) for arg in args):
+    if six.moves.builtins.any(isinstance(arg, ndarray) for arg in args):
         return _cupy
     else:
         return numpy

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -685,7 +685,7 @@ class ndarray(object):
             return bool(self.get())
         else:
             msg = 'The truth value of an array with more than one element is ' \
-                  'ambiguous. Use a.get().any() or a.get().all()'
+                  'ambiguous. Use a.any() or a.all()'
             raise ValueError(msg)
 
     def __bool__(self):

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -648,10 +648,10 @@ class ndarray(object):
     # TODO(okuta): Implement cumprod
 
     def all(self, axis=None, out=None):
-        return all(self, axis, out)
+        return logic.truth.all(self, axis, out)
 
     def any(self, axis=None, out=None):
-        return any(self, axis, out)
+        return logic.truth.any(self, axis, out)
 
     # -------------------------------------------------------------------------
     # Arithmetic and comparison operations

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -918,7 +918,7 @@ class ndarray(object):
         else:
             slices = list(slices)
 
-        if any(isinstance(s, ndarray) for s in slices):
+        if _builtin_any(isinstance(s, ndarray) for s in slices):
             raise ValueError('Advanced indexing is not supported')
 
         # Expand ellipsis into empty slices
@@ -1306,6 +1306,7 @@ equal = logic.comparison.equal
 not_equal = logic.comparison.not_equal
 
 all = logic.truth.all
+_builtin_any = any
 any = logic.truth.any
 
 # -----------------------------------------------------------------------------
@@ -1448,7 +1449,7 @@ def get_array_module(*args):
                return xp.maximum(0, x) + xp.log1p(xp.exp(-abs(x)))
 
     """
-    if any(isinstance(arg, ndarray) for arg in args):
+    if _builtin_any(isinstance(arg, ndarray) for arg in args):
         return _cupy
     else:
         return numpy

--- a/cupy/logic/truth.py
+++ b/cupy/logic/truth.py
@@ -1,7 +1,25 @@
-# flake8: NOQA
-# "flake8: NOQA" to suppress warning "H104  File contains nothing but comments"
-
-# TODO(okuta): Implement all
+from cupy import reduction
 
 
-# TODO(okuta): Implement any
+def all(a, axis=None, out=None, keepdims=False):
+    return _all(a, axis=axis, out=out, keepdims=keepdims)
+
+
+def any(a, axis=None, out=None, keepdims=False):
+    return _any(a, axis=axis, out=out, keepdims=keepdims)
+
+
+_all = reduction.create_reduction_func(
+    'cupy_all',
+    ('?->?', 'B->?', 'h->?', 'H->?', 'i->?', 'I->?', 'l->?', 'L->?',
+     'q->?', 'Q->?', 'e->?', 'f->?', 'd->?'),
+    ('in0', 'a & b', 'out0 = a', 'bool'),
+    'true', '')
+
+
+_any = reduction.create_reduction_func(
+    'cupy_any',
+    ('?->?', 'B->?', 'h->?', 'H->?', 'i->?', 'I->?', 'l->?', 'L->?',
+     'q->?', 'Q->?', 'e->?', 'f->?', 'd->?'),
+    ('in0', 'a | b', 'out0 = a', 'bool'),
+    'false', '')

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -24,81 +24,60 @@ def _calc_out_shape(shape, axis, keepdims):
     return tuple(shape)
 
 
+@testing.parametrize(
+    _product({'f': ['all', 'any'],
+              'x': [numpy.arange((2, 3, 4)) - 10,
+                    numpy.zeros((2, 3, 4)),
+                    numpy.ones((2, 3, 4))],
+              'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
+              'keepdims': [False, True]}))
 @testing.gpu
-class TestAll(unittest.TestCase):
+class TestAllAny(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    def setUp(self):
-        self.f = 'all'
-
-    def check_one_axis(self, x, xp, axis):
-        a = getattr(xp, self.f)(x, axis)
-
-        out_shape = _calc_out_shape(x.shape, axis, False)
-        b = xp.empty(out_shape, dtype=x.dtype)
-        getattr(xp, self.f)(x, axis, out=b)
-
-        c = getattr(xp, self.f)(x, axis, keepdims=True)
-
-        out_shape2 = _calc_out_shape(x.shape, axis, True)
-        d = xp.empty(out_shape2, dtype=x.dtype)
-        getattr(xp, self.f)(x, axis, out=d, keepdims=True)
-        return (a, b, c, d)
-
-    def check(self, x, xp, *axes):
-        return sum([self.check_one_axis(x, xp, a) for a in axes], ())
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_without_out(self, xp, dtype):
+        x = xp.asarray(self.x).astype(dtype)
+        return getattr(xp, self.f)(x, self.axis, None, self.keepdims)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
-    def test_general(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
-        return self.check(x, xp, None, (0, 1, 2), 0, 1, 2, (0, 1))
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_zero(self, xp, dtype):
-        x = xp.zeros((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, None, (0, 1, 2), 0, 1, 2, (0, 1))
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_one(self, xp, dtype):
-        x = xp.ones((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, None, (0, 1, 2), 0, 1, 2, (0, 1))
-
-    @testing.for_dtypes(
-        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
-    @testing.numpy_cupy_array_list_equal()
-    def test_nan(self, xp, dtype):
-        x = xp.array([[numpy.nan]], dtype=dtype)
-        return self.check(x, xp, None, 0, 1, (0, 1))
-
-    @testing.for_dtypes(
-        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
-    @testing.numpy_cupy_array_list_equal()
-    def test_nan_2(self, xp, dtype):
-        x = xp.array([[numpy.nan, 0]], dtype=dtype)
-        return self.check(x, xp, None, 0, 1, (0, 1))
-
-    @testing.for_dtypes(
-        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
-    @testing.numpy_cupy_array_list_equal()
-    def test_nan_3(self, xp, dtype):
-        x = xp.array([[numpy.nan, 1]], dtype=dtype)
-        return self.check(x, xp, None, 0, 1, (0, 1))
-
-    @testing.for_dtypes(
-        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
-    @testing.numpy_cupy_array_list_equal()
-    def test_nan_4(self, xp, dtype):
-        x = xp.array([[numpy.nan, 0, 1]], dtype=dtype)
-        return self.check(x, xp, None, 0, 1, (0, 1))
+    def test_with_out(self, xp, dtype):
+        x = xp.asarray(self.x).astype(dtype)
+        out_shape = _calc_out_shape(x.shape, axis, keepdims)
+        out = xp.empty(out_shape, dtype=x.dtype)
+        getattr(xp, self.f)(x, self.axis, out, self.keepdims)
+        return out
 
 
+@testing.parametrize(
+    _product({'f': ['all', 'any'],
+              'x': [numpy.array([[[numpy.nan]]]),
+                    numpy.array([[[numpy.nan, 0]]]),
+                    numpy.array([[[numpy.nan, 1]]]),
+                    numpy.array([[[numpy.nan, 0, 1]]])],
+              'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
+              'keepdims': [False, True]}))
 @testing.gpu
-class TestAny(TestAll):
+class TestAllAnyWithNaN(unittest.TestCase):
 
-    def setUp(self):
-        super(TestAny, self).setUp()
-        self.f = 'any'
+    _multiprocess_can_split_ = True
+
+    @testing.for_dtypes(
+        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
+    @testing.numpy_cupy_array_list_equal()
+    def test_without_out(self, xp, dtype):
+        x = xp.asarray(self.x).astype(dtype)
+        return getattr(xp, self.f)(x, self.axis, None, self.keepdims)
+
+    @testing.for_dtypes(
+        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
+    @testing.numpy_cupy_array_list_equal()
+    def test_with_out(self, xp, dtype):
+        x = xp.asarray(self.x).astype(dtype)
+        out_shape = _calc_out_shape(x.shape, axis, keepdims)
+        out = xp.empty(out_shape, dtype=x.dtype)
+        getattr(xp, self.f)(x, self.axis, out, self.keepdims)
+        return out

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -60,6 +60,30 @@ class TestAll(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
+    def test_all_reduce_all_zero(self, xp, dtype):
+        x = xp.zeros((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, None)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_reduce_all_zero_2(self, xp, dtype):
+        x = xp.zeros((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, (0, 1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_reduce_all_one(self, xp, dtype):
+        x = xp.ones((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, None)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_reduce_all_one_2(self, xp, dtype):
+        x = xp.ones((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, (0, 1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
     def test_all_partial_reduce(self, xp, dtype):
         x = testing.shaped_arange((2, 3, 4), xp, dtype)
         return self.check(x, xp, 0)
@@ -80,6 +104,54 @@ class TestAll(unittest.TestCase):
     @testing.numpy_cupy_array_list_equal()
     def test_all_partial_reduce_4(self, xp, dtype):
         x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return self.check(x, xp, (0, 1))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_all_zero(self, xp, dtype):
+        x = xp.zeros((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, 0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_2_all_zero(self, xp, dtype):
+        x = xp.zeros((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_3_all_zero(self, xp, dtype):
+        x = xp.zeros((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, 2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_4_all_zero(self, xp, dtype):
+        x = xp.zeros((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, (0, 1))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_all_one(self, xp, dtype):
+        x = xp.ones((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, 0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_2_all_one(self, xp, dtype):
+        x = xp.ones((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_3_all_one(self, xp, dtype):
+        x = xp.ones((2, 3, 4), dtype=dtype)
+        return self.check(x, xp, 2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_4_all_one(self, xp, dtype):
+        x = xp.ones((2, 3, 4), dtype=dtype)
         return self.check(x, xp, (0, 1))
 
 

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -49,13 +49,13 @@ class TestAll(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_all_reduce(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
         return self.check(x, xp, None)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_all_reduce_2(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
         return self.check(x, xp, (0, 1, 2))
 
     @testing.for_all_dtypes()
@@ -85,25 +85,25 @@ class TestAll(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_all_partial_reduce(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
         return self.check(x, xp, 0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_all_partial_reduce_2(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
         return self.check(x, xp, 1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_all_partial_reduce_3(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
         return self.check(x, xp, 2)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_all_partial_reduce_4(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
         return self.check(x, xp, (0, 1))
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -3,7 +3,6 @@ import unittest
 import numpy
 import six
 
-import cupy
 from cupy import testing
 
 
@@ -21,7 +20,7 @@ def calc_out_shape(shape, axis, keepdims):
         shape[axis] = 1
     else:
         shape[axis] = -1
-        shape = filter(lambda x: x != -1 , shape)
+        shape = filter(lambda x: x != -1, shape)
     return tuple(shape)
 
 

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -33,17 +33,17 @@ class TestAll(unittest.TestCase):
         self.f = 'all'
 
     def check(self, x, xp, axis):
-        a = xp.all(x, axis)
+        a = getattr(xp, self.f)(x, axis)
 
         out_shape = calc_out_shape(x.shape, axis, False)
         b = xp.empty(out_shape, dtype=x.dtype)
         getattr(xp, self.f)(x, axis, out=b)
 
-        c = xp.all(x, axis, keepdims=True)
+        c = getattr(xp, self.f)(x, axis, keepdims=True)
 
         out_shape2 = calc_out_shape(x.shape, axis, True)
         d = xp.empty(out_shape2, dtype=x.dtype)
-        xp.all(x, axis, out=d, keepdims=True)
+        getattr(xp, self.f)(x, axis, out=d, keepdims=True)
         return (a, b, c, d)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -67,6 +67,34 @@ class TestAll(unittest.TestCase):
         x = xp.ones((2, 3, 4), dtype=dtype)
         return self.check(x, xp, None, (0, 1, 2), 0, 1, 2, (0, 1))
 
+    @testing.for_dtypes(
+        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
+    @testing.numpy_cupy_array_list_equal()
+    def test_nan(self, xp, dtype):
+        x = xp.array([[numpy.nan]], dtype=dtype)
+        return self.check(x, xp, None, 0, 1, (0, 1))
+
+    @testing.for_dtypes(
+        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
+    @testing.numpy_cupy_array_list_equal()
+    def test_nan_2(self, xp, dtype):
+        x = xp.array([[numpy.nan, 0]], dtype=dtype)
+        return self.check(x, xp, None, 0, 1, (0, 1))
+
+    @testing.for_dtypes(
+        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
+    @testing.numpy_cupy_array_list_equal()
+    def test_nan_3(self, xp, dtype):
+        x = xp.array([[numpy.nan, 1]], dtype=dtype)
+        return self.check(x, xp, None, 0, 1, (0, 1))
+
+    @testing.for_dtypes(
+        (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))
+    @testing.numpy_cupy_array_list_equal()
+    def test_nan_4(self, xp, dtype):
+        x = xp.array([[numpy.nan, 0, 1]], dtype=dtype)
+        return self.check(x, xp, None, 0, 1, (0, 1))
+
 
 @testing.gpu
 class TestAny(TestAll):

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -1,4 +1,3 @@
-import itertools
 import unittest
 
 import numpy

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -32,7 +32,7 @@ class TestAll(unittest.TestCase):
     def setUp(self):
         self.f = 'all'
 
-    def check(self, x, xp, axis):
+    def check_one_axis(self, x, xp, axis):
         a = getattr(xp, self.f)(x, axis)
 
         out_shape = calc_out_shape(x.shape, axis, False)
@@ -46,113 +46,26 @@ class TestAll(unittest.TestCase):
         getattr(xp, self.f)(x, axis, out=d, keepdims=True)
         return (a, b, c, d)
 
+    def check(self, x, xp, *axes):
+        return sum([self.check_one_axis(x, xp, a) for a in axes], ())
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
-    def test_all_reduce(self, xp, dtype):
+    def test_general(self, xp, dtype):
         x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
-        return self.check(x, xp, None)
+        return self.check(x, xp, None, (0, 1, 2), 0, 1, 2, (0, 1))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
-    def test_all_reduce_2(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
-        return self.check(x, xp, (0, 1, 2))
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_reduce_all_zero(self, xp, dtype):
+    def test_all_zero(self, xp, dtype):
         x = xp.zeros((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, None)
+        return self.check(x, xp, None, (0, 1, 2), 0, 1, 2, (0, 1))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
-    def test_all_reduce_all_zero_2(self, xp, dtype):
-        x = xp.zeros((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, (0, 1, 2))
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_reduce_all_one(self, xp, dtype):
+    def test_all_one(self, xp, dtype):
         x = xp.ones((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, None)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_reduce_all_one_2(self, xp, dtype):
-        x = xp.ones((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, (0, 1, 2))
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
-        return self.check(x, xp, 0)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_2(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
-        return self.check(x, xp, 1)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_3(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
-        return self.check(x, xp, 2)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_4(self, xp, dtype):
-        x = testing.shaped_arange((2, 3, 4), xp, dtype) - 10
-        return self.check(x, xp, (0, 1))
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_all_zero(self, xp, dtype):
-        x = xp.zeros((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, 0)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_2_all_zero(self, xp, dtype):
-        x = xp.zeros((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, 1)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_3_all_zero(self, xp, dtype):
-        x = xp.zeros((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, 2)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_4_all_zero(self, xp, dtype):
-        x = xp.zeros((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, (0, 1))
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_all_one(self, xp, dtype):
-        x = xp.ones((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, 0)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_2_all_one(self, xp, dtype):
-        x = xp.ones((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, 1)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_3_all_one(self, xp, dtype):
-        x = xp.ones((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, 2)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_all_partial_reduce_4_all_one(self, xp, dtype):
-        x = xp.ones((2, 3, 4), dtype=dtype)
-        return self.check(x, xp, (0, 1))
+        return self.check(x, xp, None, (0, 1, 2), 0, 1, 2, (0, 1))
 
 
 @testing.gpu

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -1,7 +1,29 @@
 import unittest
 
+import numpy
+import six
+
 import cupy
 from cupy import testing
+
+
+def calc_out_shape(shape, axis, keepdims):
+    if axis is None:
+        axis = list(six.moves.range(len(shape)))
+    elif isinstance(axis, int):
+        axis = [axis]
+    else:
+        axis = list(axis)
+
+    shape = numpy.array(shape)
+
+    if keepdims:
+        shape[axis] = 1
+    else:
+        shape[axis] = -1
+        shape = filter(lambda x: x != -1 , shape)
+    return tuple(shape)
+
 
 @testing.gpu
 class TestAll(unittest.TestCase):
@@ -9,19 +31,62 @@ class TestAll(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        self.x = cupy.arange(10) % 2 == 1
+        self.f = 'all'
 
-    def test_simple(self):
-        self.assertFalse(cupy.all(self.x))
+    def check(self, x, xp, axis):
+        a = xp.all(x, axis)
+
+        out_shape = calc_out_shape(x.shape, axis, False)
+        b = xp.empty(out_shape, dtype=x.dtype)
+        getattr(xp, self.f)(x, axis, out=b)
+
+        c = xp.all(x, axis, keepdims=True)
+
+        out_shape2 = calc_out_shape(x.shape, axis, True)
+        d = xp.empty(out_shape2, dtype=x.dtype)
+        xp.all(x, axis, out=d, keepdims=True)
+        return (a, b, c, d)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_reduce(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return self.check(x, xp, None)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_reduce_2(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return self.check(x, xp, (0, 1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return self.check(x, xp, 0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_2(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return self.check(x, xp, 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_3(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return self.check(x, xp, 2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_all_partial_reduce_4(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return self.check(x, xp, (0, 1))
+
 
 @testing.gpu
-class TestAny(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
+class TestAny(TestAll):
 
     def setUp(self):
-        self.x = cupy.arange(10) % 2 == 1
-
-    def test_simple(self):
-        self.assertTrue(cupy.any(self.x))
-
+        super(TestAny, self).setUp()
+        self.f = 'any'

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -7,13 +7,6 @@ import six
 from cupy import testing
 
 
-def _product(parameter):
-    keys = sorted(parameter)
-    values = [parameter[key] for key in keys]
-    values_product = itertools.product(*values)
-    return [dict(zip(keys, vals)) for vals in values_product]
-
-
 def _calc_out_shape(shape, axis, keepdims):
     if axis is None:
         axis = list(six.moves.range(len(shape)))
@@ -33,12 +26,13 @@ def _calc_out_shape(shape, axis, keepdims):
 
 
 @testing.parameterize(
-    *_product({'f': ['all', 'any'],
-               'x': [numpy.arange(24).reshape(2, 3, 4) - 10,
-                     numpy.zeros((2, 3, 4)),
-                     numpy.ones((2, 3, 4))],
-               'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
-               'keepdims': [False, True]}))
+    *testing.product(
+        {'f': ['all', 'any'],
+         'x': [numpy.arange(24).reshape(2, 3, 4) - 10,
+               numpy.zeros((2, 3, 4)),
+               numpy.ones((2, 3, 4))],
+         'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
+         'keepdims': [False, True]}))
 @testing.gpu
 class TestAllAny(unittest.TestCase):
 
@@ -61,13 +55,14 @@ class TestAllAny(unittest.TestCase):
 
 
 @testing.parameterize(
-    *_product({'f': ['all', 'any'],
-               'x': [numpy.array([[[numpy.nan]]]),
-                     numpy.array([[[numpy.nan, 0]]]),
-                     numpy.array([[[numpy.nan, 1]]]),
-                     numpy.array([[[numpy.nan, 0, 1]]])],
-               'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
-               'keepdims': [False, True]}))
+    *testing.product(
+        {'f': ['all', 'any'],
+         'x': [numpy.array([[[numpy.nan]]]),
+               numpy.array([[[numpy.nan, 0]]]),
+               numpy.array([[[numpy.nan, 1]]]),
+               numpy.array([[[numpy.nan, 0, 1]]])],
+         'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
+         'keepdims': [False, True]}))
 @testing.gpu
 class TestAllAnyWithNaN(unittest.TestCase):
 

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -1,9 +1,27 @@
 import unittest
 
+import cupy
 from cupy import testing
 
-
 @testing.gpu
-class TestTruth(unittest.TestCase):
+class TestAll(unittest.TestCase):
 
     _multiprocess_can_split_ = True
+
+    def setUp(self):
+        self.x = cupy.arange(10) % 2 == 1
+
+    def test_simple(self):
+        self.assertFalse(cupy.all(self.x))
+
+@testing.gpu
+class TestAny(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        self.x = cupy.arange(10) % 2 == 1
+
+    def test_simple(self):
+        self.assertTrue(cupy.any(self.x))
+

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -6,7 +6,7 @@ import six
 from cupy import testing
 
 
-def calc_out_shape(shape, axis, keepdims):
+def _calc_out_shape(shape, axis, keepdims):
     if axis is None:
         axis = list(six.moves.range(len(shape)))
     elif isinstance(axis, int):
@@ -35,13 +35,13 @@ class TestAll(unittest.TestCase):
     def check_one_axis(self, x, xp, axis):
         a = getattr(xp, self.f)(x, axis)
 
-        out_shape = calc_out_shape(x.shape, axis, False)
+        out_shape = _calc_out_shape(x.shape, axis, False)
         b = xp.empty(out_shape, dtype=x.dtype)
         getattr(xp, self.f)(x, axis, out=b)
 
         c = getattr(xp, self.f)(x, axis, keepdims=True)
 
-        out_shape2 = calc_out_shape(x.shape, axis, True)
+        out_shape2 = _calc_out_shape(x.shape, axis, True)
         d = xp.empty(out_shape2, dtype=x.dtype)
         getattr(xp, self.f)(x, axis, out=d, keepdims=True)
         return (a, b, c, d)


### PR DESCRIPTION
This PR implements cupy.all and cupy.any. It also implements corresponding `ndarray`'s methods (`ndarray.all` and `ndarray.any`). 

This PR fixes #409.