### PR TITLE
Add root option to imagenet examples

### DIFF
--- a/examples/imagenet/compute_mean.py
+++ b/examples/imagenet/compute_mean.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import os
 import sys
 
 import numpy
@@ -9,6 +10,8 @@ import six.moves.cPickle as pickle
 
 parser = argparse.ArgumentParser(description='Compute images mean array')
 parser.add_argument('dataset', help='Path to training image-label list file')
+parser.add_argument('--root', '-r', default='.',
+                    help='Root directory path of image files')
 parser.add_argument('--output', '-o', default='mean.npy',
                     help='path to output mean array')
 args = parser.parse_args()
@@ -16,7 +19,7 @@ args = parser.parse_args()
 sum_image = None
 count = 0
 for line in open(args.dataset):
-    filepath = line.strip().split()[0]
+    filepath = os.path.join(args.root, line.strip().split()[0])
     image = numpy.asarray(Image.open(filepath)).transpose(2, 0, 1)
     if sum_image is None:
         sum_image = numpy.ndarray(image.shape, dtype=numpy.float32)

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -12,6 +12,7 @@ import argparse
 import datetime
 import json
 import multiprocessing
+import os
 import random
 import sys
 import threading
@@ -46,6 +47,8 @@ parser.add_argument('--gpu', '-g', default=-1, type=int,
                     help='GPU ID (negative value indicates CPU)')
 parser.add_argument('--loaderjob', '-j', default=20, type=int,
                     help='Number of parallel data loading processes')
+parser.add_argument('--root', '-r', default='.',
+                    help='Root directory path of image files')
 parser.add_argument('--out', '-o', default='model',
                     help='Path to save model on each validation')
 args = parser.parse_args()
@@ -56,16 +59,16 @@ xp = cuda.cupy if args.gpu >= 0 else np
 assert 50000 % args.val_batchsize == 0
 
 
-def load_image_list(path):
+def load_image_list(path, root):
     tuples = []
     for line in open(path):
         pair = line.strip().split()
-        tuples.append((pair[0], np.int32(pair[1])))
+        tuples.append((os.path.join(root, pair[0]), np.int32(pair[1])))
     return tuples
 
 # Prepare dataset
-train_list = load_image_list(args.train)
-val_list = load_image_list(args.val)
+train_list = load_image_list(args.train, args.root)
+val_list = load_image_list(args.val, args.root)
 mean_image = pickle.load(open(args.mean, 'rb'))
 
 # Prepare model


### PR DESCRIPTION
I added root option, that represents path to the root directory of image files. This option is require to simplify test code for examples.
This PR is related to #508 