### PR TITLE
Add AlexNet to Imagenet example

### DIFF
--- a/examples/imagenet/alex.py
+++ b/examples/imagenet/alex.py
@@ -4,7 +4,7 @@ import chainer.functions as F
 
 class Alex(chainer.FunctionSet):
 
-    """Single-GPU AlexNet.
+    """Single-GPU AlexNet without partition toward the channel axis.
 
     """
 

--- a/examples/imagenet/alex.py
+++ b/examples/imagenet/alex.py
@@ -1,0 +1,39 @@
+import chainer
+import chainer.functions as F
+
+
+class Alex(chainer.FunctionSet):
+
+    """Single-GPU AlexNet.
+
+    """
+
+    insize = 227
+
+    def __init__(self):
+        super(Alex, self).__init__(
+            conv1=F.Convolution2D(3,  96, 11, stride=4),
+            conv2=F.Convolution2D(96, 256,  5, pad=2),
+            conv3=F.Convolution2D(256, 384,  3, pad=1),
+            conv4=F.Convolution2D(384, 384,  3, pad=1),
+            conv5=F.Convolution2D(384, 256,  3, pad=1),
+            fc6=F.Linear(9216, 4096),
+            fc7=F.Linear(4096, 4096),
+            fc8=F.Linear(4096, 1000),
+        )
+
+    def forward(self, x_data, y_data, train=True):
+        x = chainer.Variable(x_data, volatile=not train)
+        t = chainer.Variable(y_data, volatile=not train)
+
+        h = F.max_pooling_2d(F.relu(
+            F.local_response_normalization(self.conv1(x))), 3, stride=2)
+        h = F.max_pooling_2d(F.relu(
+            F.local_response_normalization(self.conv2(h))), 3, stride=2)
+        h = F.relu(self.conv3(h))
+        h = F.relu(self.conv4(h))
+        h = F.max_pooling_2d(F.relu(self.conv5(h)), 3, stride=2)
+        h = F.dropout(F.relu(self.fc6(h)))
+        h = F.dropout(F.relu(self.fc7(h)))
+        h = self.fc8(h)
+        return F.softmax_cross_entropy(h, t), F.accuracy(h, t)

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -35,7 +35,7 @@ parser.add_argument('--mean', '-m', default='mean.npy',
                     help='Path to the mean file (computed by compute_mean.py)')
 parser.add_argument('--arch', '-a', default='nin',
                     help='Convnet architecture \
-                    (nin, alexbn, googlenet, googlenetbn)')
+                    (nin, alex, alexbn, googlenet, googlenetbn)')
 parser.add_argument('--batchsize', '-B', type=int, default=32,
                     help='Learning minibatch size')
 parser.add_argument('--val_batchsize', '-b', type=int, default=250,
@@ -72,6 +72,9 @@ mean_image = pickle.load(open(args.mean, 'rb'))
 if args.arch == 'nin':
     import nin
     model = nin.NIN()
+elif args.arch == 'alex':
+    import alex
+    model = alex.Alex()
 elif args.arch == 'alexbn':
     import alexbn
     model = alexbn.AlexBN()


### PR DESCRIPTION
AlexNet used in `imagenet` example is different from original one in that Local Response Normalization(LRN) layers are replaced with Batch Normalizations(BN) (so, the architecture name is `alexbn` rather than `alex`). The reason for this change is that LRN was not implemented at the time the example is made. This PR implements original AlexNet and adds it to `imagenet` example.