### PR TITLE
Restore chainer_seed in the teardown of TestGetRandomState2

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -234,8 +234,7 @@ class TestGetRandomState2(unittest.TestCase):
         generator.RandomState = self.rs_tmp
         generator._random_states = self.rs_dict
         if self.chainer_seed is None:
-            if 'CHAINER_SEED' in os.environ:
-                del os.environ['CHAINER_SEED']
+            os.environ.pop('CHAINER_SEED', None)
         else:
             os.environ['CHAINER_SEED'] = self.chainer_seed
 

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -228,10 +228,16 @@ class TestGetRandomState2(unittest.TestCase):
         generator.RandomState = mock.Mock()
         self.rs_dict = generator._random_states
         generator._random_states = {}
+        self.chainer_seed = os.getenv('CHAINER_SEED')
 
     def tearDown(self, *args):
         generator.RandomState = self.rs_tmp
         generator._random_states = self.rs_dict
+        if self.chainer_seed is None:
+            if 'CHAINER_SEED' in os.environ:
+                del os.environ['CHAINER_SEED']
+        else:
+            os.environ['CHAINER_SEED'] = self.chainer_seed
 
     def test_get_random_state_no_chainer_seed(self):
         os.unsetenv('CHAINER_SEED')


### PR DESCRIPTION
`CHAINER_SEED` is set but is not restored in the teardown of `TestGetRandomState2`. This PR fixes the problem.