### PR TITLE
Add min and max alias for amin and amax, to mimick numpy.

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1383,7 +1383,9 @@ argmin = sorting.search.argmin
 # Statistics
 # -----------------------------------------------------------------------------
 amin = statistics.order.amin
+min = statistics.order.amin
 amax = statistics.order.amax
+max = statistics.order.amax
 
 mean = statistics.meanvar.mean
 var = statistics.meanvar.var


### PR DESCRIPTION
Numpy has np.min and np.max functions. It's true that np.min == np.amin and np.max == np.amax, so I added the same aliases to cupy.