### PR TITLE
Improve batch_normalization performance

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -154,9 +154,7 @@ class BatchNormalization(function.Function):
 
         if cuda.get_array_module(*x_orig) == numpy:
             coeff = self.gamma / self.std
-            gbeta *= inv_m
-            ggamma *= inv_m
-            gx = coeff * (gy - self.x_hat * ggamma - gbeta)
+            gx = coeff * (gy - (self.x_hat * ggamma + gbeta) * inv_m)
         else:
             gx = cuda.elementwise(
                 'T gy, T gbeta, T ggamma, T x_hat, T gamma, T std, T inv_m',


### PR DESCRIPTION
Speeding up from 1.6 to 1.8 times in the following test case .
It's tested in branch which PR #548 is merged.

before
0:00:00.312393 0:00:00.204991
0:00:00.321782 0:00:00.205670
after 
0:00:00.167545 0:00:00.124970
0:00:00.175646 0:00:00.125602

```python
import datetime

import chainer
import chainer.functions as F

def testbn(shape):
    bn = F.BatchNormalization(shape[0])
    bn.to_gpu()
    x_org = chainer.Variable(chainer.cuda.zeros(shape), volatile=False)
    x = x_org
    t1 = datetime.datetime.now()
    for i in range(200):
        x = bn(x)
    y = F.sum(x)
    y.data.get()
    t2 = datetime.datetime.now()
    y.backward()
    t3 = datetime.datetime.now()
    print(t2 - t1, t3 - t2)

#for memory allocation
testbn((10, 10, 10))
testbn((100, 100, 100))

#for performance test
testbn((10, 10, 10))
testbn((100, 100, 100))
```
