### PR TITLE
Implement chainer.testing.product and , cupy.testing.product

### DIFF
--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -3,6 +3,7 @@ import nose
 from chainer.testing import parameterized
 
 parameterize = parameterized.parameterize
+product = parameterized.product
 
 
 def run_module(name, file):

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -1,3 +1,4 @@
+import itertools
 import sys
 import unittest
 

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -29,3 +29,10 @@ def parameterize(*params):
         # Remove original base class
         return None
     return f
+
+
+def product(parameter):
+    keys = sorted(parameter)
+    values = [parameter[key] for key in keys]
+    values_product = itertools.product(*values)
+    return [dict(zip(keys, vals)) for vals in values_product]

--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -28,6 +28,7 @@ for_unsigned_dtypes = helper.for_unsigned_dtypes
 for_int_dtypes = helper.for_int_dtypes
 
 parameterize = parameterized.parameterize
+product = parameterized.product
 
 shaped_arange = helper.shaped_arange
 shaped_reverse_arange = helper.shaped_reverse_arange

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -1,3 +1,4 @@
+import itertools
 import sys
 import unittest
 

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -29,3 +29,10 @@ def parameterize(*params):
         # Remove original base class
         return None
     return f
+
+
+def product(parameter):
+    keys = sorted(parameter)
+    values = [parameter[key] for key in keys]
+    values_product = itertools.product(*values)
+    return [dict(zip(keys, vals)) for vals in values_product]

--- a/tests/chainer_tests/testing_tests/test_parameterized.py
+++ b/tests/chainer_tests/testing_tests/test_parameterized.py
@@ -1,0 +1,17 @@
+import unittest
+
+from chainer import testing
+
+
+@testing.parameterize(
+    {'actual': {'a': [1, 2], 'b': [3, 4, 5]},
+     'expect': [{'a': 1, 'b': 3}, {'a': 1, 'b': 4}, {'a': 1, 'b': 5},
+                {'a': 2, 'b': 3}, {'a': 2, 'b': 4}, {'a': 2, 'b': 5}]},
+    {'actual': {'a': [1, 2]}, 'expect': [{'a': 1}, {'a': 2}]},
+    {'actual': {'a': [1, 2], 'b': []}, 'expect': []},
+    {'actual': {'a': []}, 'expect': []},
+    {'actual': {}, 'expect': [{}]})
+class ProductTest(unittest.TestCase):
+
+    def test_product(self):
+        self.assertListEqual(testing.product(self.actual), self.expect)

--- a/tests/chainer_tests/testing_tests/test_parameterized.py
+++ b/tests/chainer_tests/testing_tests/test_parameterized.py
@@ -15,3 +15,6 @@ class ProductTest(unittest.TestCase):
 
     def test_product(self):
         self.assertListEqual(testing.product(self.actual), self.expect)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/cupy_tests/testing_tests/test_parameterized.py
+++ b/tests/cupy_tests/testing_tests/test_parameterized.py
@@ -1,0 +1,17 @@
+import unittest
+
+from cupy import testing
+
+
+@testing.parameterize(
+    {'actual': {'a': [1, 2], 'b': [3, 4, 5]},
+     'expect': [{'a': 1, 'b': 3}, {'a': 1, 'b': 4}, {'a': 1, 'b': 5},
+                {'a': 2, 'b': 3}, {'a': 2, 'b': 4}, {'a': 2, 'b': 5}]},
+    {'actual': {'a': [1, 2]}, 'expect': [{'a': 1}, {'a': 2}]},
+    {'actual': {'a': [1, 2], 'b': []}, 'expect': []},
+    {'actual': {'a': []}, 'expect': []},
+    {'actual': {}, 'expect': [{}]})
+class ProductTest(unittest.TestCase):
+
+    def test_product(self):
+        self.assertListEqual(testing.product(self.actual), self.expect)


### PR DESCRIPTION
This PR implements `chainer.testing.product` and `cupy.testing.product`. Basic usage (and implementation itself) is same as that of `maflib.util.product` ([Link](https://pfi.github.io/maf/maflib.html#maflib.util.product)).