### PR TITLE
Directly manipulate os.environ to remove environment variable

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -239,7 +239,7 @@ class TestGetRandomState2(unittest.TestCase):
             os.environ['CHAINER_SEED'] = self.chainer_seed
 
     def test_get_random_state_no_chainer_seed(self):
-        os.unsetenv('CHAINER_SEED')
+        os.environ.pop('CHAINER_SEED', None)
         generator.get_random_state()
         generator.RandomState.assert_called_with(None)
 


### PR DESCRIPTION
As the [Python document](https://docs.python.org/2.7/library/os.html#os.unsetenv) indicates, it is preferable to manipulate `os.environ` directly to remove environment variable instead of using `os.unsetenv`. Actually my environment does not have bash command `unsetenv` and `os.unsetenv` does not take effect.