### PR TITLE
Fix transpose() when called with no "axes"

### DIFF
--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -7,8 +7,10 @@ from chainer.utils import type_check
 class Transpose(function.Function):
     """Permute the dimensions of an array."""
 
-    def __init__(self, axes):
-        self.axes = tuple(ax % len(axes) for ax in axes)
+    def __init__(self, axes=None):
+        self.axes = axes
+        if axes:
+            self.axes = tuple(ax % len(axes) for ax in axes)
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1,)
@@ -19,6 +21,8 @@ class Transpose(function.Function):
 
     def forward(self, inputs):
         x = inputs[0]
+        if not self.axes:
+            self.axes = list(range(len(x.data.shape)))[::-1]
         y = x.transpose(self.axes)
         return y,
 
@@ -41,5 +45,4 @@ def transpose(x, axes=None):
         ~chainer.Variable: Variable whose axes are permuted.
 
     """
-    axes = axes or list(range(len(x.data.shape)))[::-1]
     return Transpose(axes)(x)

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -9,8 +9,6 @@ class Transpose(function.Function):
 
     def __init__(self, axes=None):
         self.axes = axes
-        if axes:
-            self.axes = tuple(ax % len(axes) for ax in axes)
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1,)
@@ -21,14 +19,15 @@ class Transpose(function.Function):
 
     def forward(self, inputs):
         x = inputs[0]
-        if not self.axes:
-            self.axes = list(range(len(x.data.shape)))[::-1]
         y = x.transpose(self.axes)
         return y,
 
     def backward(self, inputs, grad_outputs):
         gy = grad_outputs[0]
-        inv_axes = tuple(numpy.argsort(self.axes))
+        inv_axes = self.axes
+        if self.axes:
+            axes = tuple(ax % len(self.axes) for ax in self.axes)
+            inv_axes = tuple(numpy.argsort(axes)) 
         gx = gy.transpose(inv_axes)
         return gx,
 

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -41,4 +41,5 @@ def transpose(x, axes=None):
         ~chainer.Variable: Variable whose axes are permuted.
 
     """
+    axes = axes or list(range(len(x.data.shape)))[::-1]
     return Transpose(axes)(x)

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -27,7 +27,7 @@ class Transpose(function.Function):
         inv_axes = self.axes
         if self.axes:
             axes = tuple(ax % len(self.axes) for ax in self.axes)
-            inv_axes = tuple(numpy.argsort(axes)) 
+            inv_axes = tuple(numpy.argsort(axes))
         gx = gy.transpose(inv_axes)
         return gx,
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
@@ -52,4 +52,12 @@ class TestTranspose(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
+class TestTransposeNoneAxes(TestTranspose):
+    axes = None
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (4, 3, 2))
+        self.gy = numpy.random.uniform(-1, 1, (2, 3, 4))
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
transpose() causes error when argument “axes” is None because Transpose.\_\_init\_\_()  assumes that the “axes” is iterable.

I added a line to fix it (the default behavior of “axes” is to reverse the dimension of input x).