### PR TITLE
Fix typecheck condition of split_axis

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -19,7 +19,7 @@ class SplitAxis(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
-        type_check.expect(in_types[0].ndim >= self.axis)
+        type_check.expect(in_types[0].ndim > self.axis)
 
         if isinstance(self.indices_or_sections, collections.Iterable):
             max_index = type_check.Variable(


### PR DESCRIPTION
When `ndim == self.axis`, line 27 is not evaluated properly: https://github.com/pfnet/chainer/compare/fix-split-axis-typecheck?expand=1#diff-9e610d281c820d44c4a0cbf0ca6263fdL27