### PR TITLE
Remove h5py from install_requires on Read the Docs.

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -1,8 +1,16 @@
-import h5py
+import os
+
 import numpy
 
 from chainer import cuda
 from chainer import serializer
+
+
+try:
+    import h5py
+except ImportError:
+    if not os.environ.get('READTHEDOCS', None) == 'True':
+        raise
 
 
 class HDF5Serializer(serializer.Serializer):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
+import os
+
 from setuptools import setup
+
+
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+install_requires = [
+    'filelock',
+    'nose',
+    'numpy>=1.9.0',
+    'protobuf',
+    'six>=1.9.0']
+
+if not on_rtd:
+    install_requires.append('h5py>=2.5.0')
 
 setup(
     name='chainer',
@@ -48,12 +63,7 @@ setup(
     package_data={
         'cupy': ['carray.cuh'],
     },
-    install_requires=['filelock',
-                      'h5py>=2.5.0',
-                      'nose',
-                      'numpy>=1.9.0',
-                      'protobuf',
-                      'six>=1.9.0'],
+    install_requires=install_requires,
     # Cython is required to setup h5py, not for chainer itself.
     # This line is required for h5py-2.5.0, as `setup_requires` is missing in
     # its `setup.py` and you cannot install h5py directly.


### PR DESCRIPTION
The h5py is reguired hdf5.h.
But, there is no way to install the hdf5.h on Read the Docs.