### PR TITLE
Fix cupy.ndarray.transpose and add test

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -431,6 +431,8 @@ class ndarray(object):
         """
         if len(axes) == 1 and isinstance(axes[0], collections.Sequence):
             axes = axes[0]
+        if axes == (None,):
+            axes = axes[0]
         return transpose(self, axes)
 
     def swapaxes(self, axis1, axis2):

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -43,3 +43,8 @@ class TestTranspose(unittest.TestCase):
     def test_external_transpose(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.transpose(a)
+
+    @testing.numpy_cupy_array_equal()
+    def test_transpose_none(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return a.transpose(None)


### PR DESCRIPTION
```x.transpose(None)``` causes error because  ```cupy.ndarray.transpose``` receives variable-length argument list ```*axes``` and thus the ```None``` become ```(None,)```.
