### PR TITLE
Remove duplicated lines

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -47,11 +47,6 @@ Array manipulations
 .. autofunction:: transpose
 .. autofunction:: where
 
-Noise injecting functions
--------------------------
-.. autofunction:: dropout
-.. autofunction:: gaussian
-
 Neural network connections
 --------------------------
 .. autofunction:: bilinear


### PR DESCRIPTION
This PR removes duplicated lines in docs. I think `Noise injecting functions` part should be deleted.