### PR TITLE
Improve word2vec

### DIFF
--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -64,7 +64,7 @@ class ContinuousBoW(chainer.Chain):
 
     def __call__(self, x, context):
         e = model.embed(context)
-        h = F.sum(e, axis=0) * (1. / context.data.shape[0])
+        h = F.sum(e, axis=0) * (1. / len(context.data))
         return self.loss_func(h, x)
 
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -182,8 +182,8 @@ for epoch in range(args.epoch):
             now = time.time()
             duration = now - cur_at
             throuput = 100000. / (now - cur_at)
-            print('{} words, {:.2f} sec, {:.2f} words/sec'.format(
-                word_count, duration, throuput))
+            print('{} words, {:.2f} sec, {:.2f} Kwords/sec'.format(
+                word_count, duration, throuput / 1000.))
             next_count += 100000
             cur_at = now
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -23,9 +23,9 @@ parser.add_argument('--unit', '-u', default=100, type=int,
                     help='number of units')
 parser.add_argument('--window', '-w', default=5, type=int,
                     help='window size')
-parser.add_argument('--batchsize', '-b', type=int, default=100,
+parser.add_argument('--batchsize', '-b', type=int, default=1000,
                     help='learning minibatch size')
-parser.add_argument('--epoch', '-e', default=10, type=int,
+parser.add_argument('--epoch', '-e', default=20, type=int,
                     help='number of epochs to learn')
 parser.add_argument('--model', '-m', choices=['skipgram', 'cbow'],
                     default='skipgram',

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -102,7 +102,7 @@ def calculate_loss(model, dataset, position):
     pos = [position + o for o in range(-w, w + 1) if o != 0]
     d = xp.asarray(np.take(dataset, pos))
     context = chainer.Variable(d)
-    x_data = xp.asarray(dataset[position])
+    x_data = xp.asarray(np.take(dataset, position))
     x = chainer.Variable(x_data)
     return model(x, context)
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -62,7 +62,7 @@ class ContinuousBoW(chainer.Chain):
 
     def __call__(self, x, context):
         e = model.embed(context)
-        h = F.sum(e, axis=0)
+        h = F.sum(e, axis=0) * (1. / context.data.shape[0])
         return self.loss_func(h, x)
 
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -88,12 +88,12 @@ class SkipGram(chainer.Chain):
 class SoftmaxCrossEntropyLoss(chainer.Chain):
     def __init__(self, n_in, n_out):
         super(SoftmaxCrossEntropyLoss, self).__init__(
-            W=L.Linear(n_in, n_out),
+            out=L.Linear(n_in, n_out),
         )
-        self.W.W.data[...] = 0
+        self.out.W.data[...] = 0
 
     def __call__(self, x, t):
-        return F.softmax_cross_entropy(self.W(x), t)
+        return F.softmax_cross_entropy(self.out(x), t)
 
 
 def calculate_loss(model, dataset, position):

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -200,7 +200,7 @@ for epoch in range(args.epoch):
 
 with open('word2vec.model', 'w') as f:
     f.write('%d %d\n' % (len(index2word), args.unit))
-    w = model.embed.W.data
+    w = cuda.to_cpu(model.embed.W.data)
     for i in range(w.shape[0]):
-        v = ' '.join(['%f' % v for v in w[i]])
+        v = ' '.join(map(str, w[i]))
         f.write('%s %s\n' % (index2word[i], v))

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -141,7 +141,7 @@ if args.out_type == 'hsm':
     loss_func.W.data[...] = 0
 elif args.out_type == 'ns':
     cs = [counts[w] for w in range(len(counts))]
-    loss_func = L.NegativeSampling(args.unit, cs, 20)
+    loss_func = L.NegativeSampling(args.unit, cs, 5)
     loss_func.W.data[...] = 0
 elif args.out_type == 'original':
     loss_func = SoftmaxCrossEntropyLoss(args.unit, n_vocab)

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -31,7 +31,7 @@ parser.add_argument('--model', '-m', choices=['skipgram', 'cbow'],
                     default='skipgram',
                     help='model type ("skipgram", "cbow")')
 parser.add_argument('--negative-size', default=5, type=int,
-                    help='number of negative samples (used when --out-type==ns)')
+                    help='number of negative samples')
 parser.add_argument('--out-type', '-o', choices=['hsm', 'ns', 'original'],
                     default='hsm',
                     help='output model type ("hsm": hierarchical softmax, '

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -79,9 +79,7 @@ class SkipGram(chainer.Chain):
     def __call__(self, x, context):
         e = model.embed(context)
         shape = e.data.shape
-        dummy = chainer.Variable(
-            xp.empty((shape[0], shape[1])))
-        x, _ = F.broadcast(x, dummy)
+        x = F.broadcast_to(x, (shape[0], shape[1]))
         e = F.reshape(e, (shape[0] * shape[1], shape[2]))
         x = F.reshape(x, (shape[0] * shape[1],))
         return self.loss_func(e, x)

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -30,6 +30,8 @@ parser.add_argument('--epoch', '-e', default=20, type=int,
 parser.add_argument('--model', '-m', choices=['skipgram', 'cbow'],
                     default='skipgram',
                     help='model type ("skipgram", "cbow")')
+parser.add_argument('--negative-size', default=5, type=int,
+                    help='number of negative samples (used when --out-type==ns)')
 parser.add_argument('--out-type', '-o', choices=['hsm', 'ns', 'original'],
                     default='hsm',
                     help='output model type ("hsm": hierarchical softmax, '
@@ -141,7 +143,7 @@ if args.out_type == 'hsm':
     loss_func.W.data[...] = 0
 elif args.out_type == 'ns':
     cs = [counts[w] for w in range(len(counts))]
-    loss_func = L.NegativeSampling(args.unit, cs, 5)
+    loss_func = L.NegativeSampling(args.unit, cs, args.negative_size)
     loss_func.W.data[...] = 0
 elif args.out_type == 'original':
     loss_func = SoftmaxCrossEntropyLoss(args.unit, n_vocab)

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -206,6 +206,6 @@ for epoch in range(args.epoch):
 with open('word2vec.model', 'w') as f:
     f.write('%d %d\n' % (len(index2word), args.unit))
     w = cuda.to_cpu(model.embed.W.data)
-    for i in range(w.shape[0]):
-        v = ' '.join(map(str, w[i]))
+    for i, wi in enumerate(w):
+        v = ' '.join(map(str, wi))
         f.write('%s %s\n' % (index2word[i], v))


### PR DESCRIPTION
- Use multi dimensional embed ID
- Fix initial parameter
- Fix default minibatch size
- Merge kernels in negative sampling
- Fix default negative sampling size (=5)

With my GTX 970, its performance is about 300Kwords/sec with minbatch-size=5000, n_units=400, window=5, HSM and CBOW model. Negative sampling is slower than HSM because its implementation is not tuned.