### PR TITLE
Fix installation method for cudnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Requirements for some features:
   - CUDA 6.5+
   - Cython 0.23+
   - filelock
-- CuDNN support
-  - CuDNN v2
+- cuDNN support
+  - cuDNN v2
 - Caffe model support
   - Python 2.7+ (Py3 is not supported)
   - Protocol Buffers (pip install protobuf)
@@ -46,7 +46,7 @@ In this case, you have to add the following line to `.bashrc` or `.zshrc` (choos
 export PATH=/usr/local/cuda/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 ```
-If you want to enable CuDNN, add a path containing `cudnn.h` to `CPATH`, and add a directory containing `libcudnn.so` to `LIBRARY_PATH` and `LD_LIBRARY_PATH`:
+If you want to enable cuDNN, add a path containing `cudnn.h` to `CPATH`, and add a directory containing `libcudnn.so` to `LIBRARY_PATH` and `LD_LIBRARY_PATH`:
 ```
 export CPATH=/path/to/cudnn/include:$CPATH
 export LIBRARY_PATH=/path/to/cudnn/lib:$LIBRARY_PATH

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this case, you have to add the following line to `.bashrc` or `.zshrc` (choos
 export PATH=/usr/local/cuda/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 ```
-If you want to enable cuDNN, add a path containing `cudnn.h` to `CPATH`, and add a directory containing `libcudnn.so` to `LIBRARY_PATH` and `LD_LIBRARY_PATH`:
+If you want to enable cuDNN, add a directory containing `cudnn.h` to `CPATH`, and add a directory containing `libcudnn.so` to `LIBRARY_PATH` and `LD_LIBRARY_PATH`:
 ```
 export CPATH=/path/to/cudnn/include:$CPATH
 export LIBRARY_PATH=/path/to/cudnn/lib:$LIBRARY_PATH

--- a/README.md
+++ b/README.md
@@ -46,8 +46,14 @@ In this case, you have to add the following line to `.bashrc` or `.zshrc` (choos
 export PATH=/usr/local/cuda/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 ```
-Do not forget to restart your terminal session (or `source` it) to enable this change.
-It automatically enables the CUDA support.
+If you want to enable cudnn, add a path containing `cudnn.h` to `CPATH`, and add a path containing `libcudnn.so` to `LIBRARY_PATH` and `LD_LIBRARY_PATH`:
+```
+export CPATH=/path/to/cudnn/include:$CPATH
+export LIBRARY_PATH=/path/to/cudnn/lib:$LIBRARY_PATH
+export LD_LIBRARY_PATH=/path/to/cudnn/lib:$LD_LIBRARY_PATH
+```
+Do not forget to restart your terminal session (or `source` it) to enable these changes.
+And then, reinstall Chainer.
 
 ## More information
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this case, you have to add the following line to `.bashrc` or `.zshrc` (choos
 export PATH=/usr/local/cuda/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 ```
-If you want to enable cudnn, add a path containing `cudnn.h` to `CPATH`, and add a path containing `libcudnn.so` to `LIBRARY_PATH` and `LD_LIBRARY_PATH`:
+If you want to enable CuDNN, add a path containing `cudnn.h` to `CPATH`, and add a directory containing `libcudnn.so` to `LIBRARY_PATH` and `LD_LIBRARY_PATH`:
 ```
 export CPATH=/path/to/cudnn/include:$CPATH
 export LIBRARY_PATH=/path/to/cudnn/lib:$LIBRARY_PATH


### PR DESCRIPTION
Users need to set environment variables to build chainer with cudnn in the next version.