### PR TITLE
Add Cython files to the chainer package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+recursive-include cupy *.pyx *.pxd *.pxi *.h
 include chainer_setup_build.py


### PR DESCRIPTION
pyx, pxd, pxi, and header files must be included in the dist.