### PR TITLE
Fix bug with unclosed resources in serializers

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -56,9 +56,9 @@ def save_hdf5(filename, obj, compression=4):
         compression (int): Gzip compression level.
 
     """
-    f = h5py.File(filename, 'w')
-    s = HDF5Serializer(f, compression=compression)
-    s.save(obj)
+    with h5py.File(filename, 'w') as f:
+        s = HDF5Serializer(f, compression=compression)
+        s.save(obj)
 
 
 class HDF5Deserializer(serializer.Deserializer):
@@ -102,6 +102,6 @@ def load_hdf5(filename, obj):
         obj: Object to be deserialized. It must support serialization protocol.
 
     """
-    f = h5py.File(filename, 'r')
-    d = HDF5Deserializer(f)
-    d.load(obj)
+    with h5py.File(filename, 'r') as f:
+        d = HDF5Deserializer(f)
+        d.load(obj)


### PR DESCRIPTION
h5py file open and load do not close / flush their buffers, causing resource leak and causes intermittent bugs depending on program behavior.