### PR TITLE
Make test of spatial pyramid pooling stable

### DIFF
--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -51,7 +51,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
                int in_x_0 = max(0, out_x * sx - pw);
                int in_x_1 = min(w, out_x * sx + kw - pw);
 
-               float maxval = in[in_x_0 + w * (in_y_0 + h * c0)];
+               T maxval = in[in_x_0 + w * (in_y_0 + h * c0)];
                int argmax_y = in_y_0;
                int argmax_x = in_x_0;
                for (int y = in_y_0; y < in_y_1; ++y) {
@@ -112,7 +112,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
                int out_x_0 = max(0,     (x - kw + sx) / sx);
                int out_x_1 = min(out_w, (x      + sx) / sx);
 
-               float val = 0;
+               T val = 0;
                for (int out_y = out_y_0; out_y < out_y_1; ++out_y) {
                  int ky = y - out_y * sy;
                  for (int out_x = out_x_0; out_x < out_x_1; ++out_x) {

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -19,8 +19,14 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
 
     def setUp(self):
         # Avoid unstability of numerical gradient
-        self.x = numpy.random.randn(
-            self.n, self.c, self.h, self.w).astype(numpy.float32)
+        shape = (self.n, self.c, self.h, self.w)
+        size = numpy.prod(shape)
+        self.x = numpy.arange(size, dtype=numpy.float32) .reshape(shape)
+        numpy.random.shuffle(self.x)
+        self.x += numpy.random.uniform(
+            0.4, 0.6, shape).astype(numpy.float32)
+        self.x /= (self.n * self.c * self.h * self.w)
+
         self.one = numpy.ones(
             (self.n, self.c, self.h, self.w)).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, (self.n, self.output_dim, 1, 1))

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -18,7 +18,9 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     pooling_class = functions.MaxPooling2D
 
     def setUp(self):
-        # Avoid unstability of numerical gradient
+        # Spacial pyramid pooling uses max pooling in its implementation.
+        # To avoid unstability of numerical gradient, use enoufh different
+        # values.
         shape = (self.n, self.c, self.h, self.w)
         size = numpy.prod(shape)
         self.x = numpy.arange(size, dtype=numpy.float32).reshape(shape)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -21,11 +21,11 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         # Avoid unstability of numerical gradient
         shape = (self.n, self.c, self.h, self.w)
         size = numpy.prod(shape)
-        self.x = numpy.arange(size, dtype=numpy.float32) .reshape(shape)
+        self.x = numpy.arange(size, dtype=numpy.float32).reshape(shape)
         numpy.random.shuffle(self.x)
         self.x += numpy.random.uniform(
             0.4, 0.6, shape).astype(numpy.float32)
-        self.x /= (self.n * self.c * self.h * self.w)
+        self.x /= size
 
         self.one = numpy.ones(
             (self.n, self.c, self.h, self.w)).astype(numpy.float32)


### PR DESCRIPTION
I fixed arrays for test of spatial pyramid pooling to avoid unstable behavior. See also `test_max_pooling_2d`.