### PR TITLE
Check index to suppress invalid access

### DIFF
--- a/chainer/utils/walker_alias.py
+++ b/chainer/utils/walker_alias.py
@@ -28,7 +28,7 @@ class WalkerAlias(object):
         pairs.sort()
         for prob, i in pairs:
             p = prob * len(probs)
-            while p > 1 and ir < len(threshold):
+            while p > 1 and ir < il:
                 values[ir * 2 + 1] = i
                 p -= 1.0 - threshold[ir]
                 ir += 1


### PR DESCRIPTION
Escecially when calculation error is large, `ir` get a larget value than `il`.
So, the method access `threshold[ir]` before assigining `threshold[il]`. It causes an error.