### PR TITLE
Add ignore_label into sigmoid_cross_entropy

### DIFF
--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -10,8 +10,11 @@ class SigmoidCrossEntropy(function.Function):
 
     """Sigmoid activation followed by a sigmoid cross entropy loss."""
 
-    def __init__(self, use_cudnn=True):
+    ignore_label = -1
+
+    def __init__(self, use_cudnn=True, normalize=True):
         self.use_cudnn = use_cudnn
+        self.normalize = normalize
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -23,48 +26,44 @@ class SigmoidCrossEntropy(function.Function):
             x_type.shape == t_type.shape
         )
 
-    def forward_cpu(self, inputs):
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
         x, t = inputs
-        self.y, = sigmoid.Sigmoid().forward_cpu((x,))
+        self.ignore_mask = (t != self.ignore_label)
+        if self.normalize:
+            count = int(self.ignore_mask.sum())
+        else:
+            count = x.shape[0]
+        self.count = count
         # stable computation of the cross entropy.
-        loss = -numpy.sum(
-            x * (t - (x >= 0)) - numpy.log1p(numpy.exp(-numpy.abs(x))))
-        return numpy.array(loss / t.shape[0], dtype=x.dtype),
+        loss = -xp.sum(
+            self.ignore_mask * (x * (t - (x >= 0)) -
+                                xp.log1p(xp.exp(-xp.abs(x)))))
+        return xp.array(loss / self.count, dtype=x.dtype),
 
-    def forward_gpu(self, inputs):
+    def backward(self, inputs, grad_outputs):
         x, t = inputs
-        self.y, = sigmoid.Sigmoid(self.use_cudnn).forward_gpu((x,))
-        loss = cuda.reduce(
-            'T x, S t, T inv_cnt', 'T out',
-            'x * (t - (x >= 0)) - log1p(exp(-fabs(x)))',
-            'a + b', 'out = a * inv_cnt', 0,
-            'sigmoid_crossent_fwd')(x, t, -1.0 / t.shape[0])
-        return loss,
-
-    def backward_cpu(self, inputs, grad_outputs):
-        t, gloss = inputs[1], grad_outputs[0]
-        dtype = self.y.dtype
-        gx = gloss * (self.y - t.astype(dtype)) / dtype.type(t.shape[0])
-        return gx, None
-
-    def backward_gpu(self, inputs, grad_outputs):
-        t, gloss = inputs[1], grad_outputs[0]
-        gx = cuda.elementwise(
-            'T y, S t, raw T gloss, T inv_cnt', 'T gx',
-            'gx = gloss[0] * inv_cnt * (y - t)',
-            'sigmoid_crossent_bwd')(self.y, t, gloss, 1.0 / t.shape[0])
+        gloss = grad_outputs[0]
+        y, = sigmoid.Sigmoid().forward((x,))
+        dtype = y.dtype
+        gx = (gloss * self.ignore_mask * (y - t.astype(dtype)) /
+              dtype.type(self.count))
         return gx, None
 
 
-def sigmoid_cross_entropy(x, t, use_cudnn=True):
+def sigmoid_cross_entropy(x, t, use_cudnn=True, normalize=True):
     """Computes cross entropy loss for sigmoid activations.
 
     Args:
         x (Variable): A variable object holding a matrix whose (i, j)-th
             element indicates the unnormalized log probability of the j-th unit
             at the i-th example.
-        t (Variable): A variable object holding an int32 vector of groundtruth
-            binary labels.
+        t (Variable): Variable holding an int32 vector of groundtruth labels.
+            If ``t[i] == -1``, correspondig ``x[i]`` is ignored.
+        normalize (Variable): Variable holding a boolean value which
+            determines the normalization constant. If true, this function
+            normalizes the cross entropy loss across all instances. If else,
+            it only normalizes along a batch size.
 
     Returns:
         Variable: A variable object holding a scalar array of the cross entropy
@@ -75,4 +74,4 @@ def sigmoid_cross_entropy(x, t, use_cudnn=True):
        This function is differentiable only by ``x``.
 
     """
-    return SigmoidCrossEntropy(use_cudnn)(x, t)
+    return SigmoidCrossEntropy(use_cudnn, normalize)(x, t)

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -60,6 +60,7 @@ def sigmoid_cross_entropy(x, t, use_cudnn=True, normalize=True):
             at the i-th example.
         t (Variable): Variable holding an int32 vector of groundtruth labels.
             If ``t[i] == -1``, correspondig ``x[i]`` is ignored.
+            Loss becomes to zero if all groundtruth labels are ``-1``.
         normalize (bool): Variable holding a boolean value which
             determines the normalization constant. If true, this function
             normalizes the cross entropy loss across all instances. If else,

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -60,7 +60,7 @@ def sigmoid_cross_entropy(x, t, use_cudnn=True, normalize=True):
             at the i-th example.
         t (Variable): Variable holding an int32 vector of groundtruth labels.
             If ``t[i] == -1``, correspondig ``x[i]`` is ignored.
-            Loss becomes to zero if all groundtruth labels are ``-1``.
+            Loss is zero if all groundtruth labels are ``-1``.
         normalize (bool): Variable holding a boolean value which
             determines the normalization constant. If true, this function
             normalizes the cross entropy loss across all instances. If else,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -24,10 +24,9 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
-        if hasattr(self, 'ignore_all') and self.ignore_all:
+        if getattr(self, 'ignore_all', False):
             self.t = -numpy.ones(self.shape).astype(numpy.int32)
         else:
-            self.ignore_all = False
             self.t = numpy.random.randint(-1, 2,
                                           self.shape).astype(numpy.int32)
 
@@ -42,7 +41,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         # Compute expected value
         loss_expect = 0
-        if not self.ignore_all:
+        if not getattr(self, 'ignore_all', False):
             non_ignore_count = 0
             for i in six.moves.range(self.x.shape[0]):
                 for j in six.moves.range(self.x.shape[1]):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -16,6 +16,7 @@ from chainer.testing import condition
 @testing.parameterize(
     {'shape': (8, 7), 'normalize': True},
     {'shape': (8, 7), 'normalize': False},
+    {'shape': (8, 7), 'normalize': True, 'ignore_all': True},
     # too large shape causes int32 -> float64 issue
     {'shape': (65536, 1), 'normalize': False},
 )
@@ -23,7 +24,11 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
-        self.t = numpy.random.randint(-1, 2, self.shape).astype(numpy.int32)
+        if hasattr(self, 'ignore_all') and self.ignore_all:
+            self.t = -numpy.ones(self.shape).astype(numpy.int32)
+        else:
+            self.ignore_all = False
+            self.t = numpy.random.randint(-1, 2, self.shape).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x_val = chainer.Variable(x_data)
@@ -36,19 +41,20 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         # Compute expected value
         loss_expect = 0
-        non_ignore_count = 0
-        for i in six.moves.range(self.x.shape[0]):
-            for j in six.moves.range(self.x.shape[1]):
-                xd, td = self.x[i, j], self.t[i, j]
-                if td == -1:
-                    continue
-                loss_expect -= xd * (td - (xd >= 0)) \
-                    - math.log(1 + math.exp(-numpy.abs(xd)))
-                non_ignore_count += 1
-        if self.normalize:
-            loss_expect /= non_ignore_count
-        else:
-            loss_expect /= self.t.shape[0]
+        if not self.ignore_all:
+            non_ignore_count = 0
+            for i in six.moves.range(self.x.shape[0]):
+                for j in six.moves.range(self.x.shape[1]):
+                    xd, td = self.x[i, j], self.t[i, j]
+                    if td == -1:
+                        continue
+                    loss_expect -= xd * (td - (xd >= 0)) \
+                        - math.log(1 + math.exp(-numpy.abs(xd)))
+                    non_ignore_count += 1
+            if self.normalize:
+                loss_expect /= non_ignore_count
+            else:
+                loss_expect /= self.t.shape[0]
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -14,31 +14,41 @@ from chainer.testing import condition
 
 
 @testing.parameterize(
-    {'shape': (4, 3)},
-    {'shape': (65536, 1)},  # too large shape causes int32 -> float64 issue
+    {'shape': (8, 7), 'normalize': True},
+    {'shape': (8, 7), 'normalize': False},
+    # too large shape causes int32 -> float64 issue
+    {'shape': (65536, 1), 'normalize': False},
 )
 class TestSigmoidCrossEntropy(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
-        self.t = numpy.random.randint(0, 2, self.shape).astype(numpy.int32)
+        self.t = numpy.random.randint(-1, 2, self.shape).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x_val = chainer.Variable(x_data)
         t_val = chainer.Variable(t_data)
-        loss = functions.sigmoid_cross_entropy(x_val, t_val, use_cudnn)
+        loss = functions.sigmoid_cross_entropy(x_val, t_val,
+                                               use_cudnn, self.normalize)
         self.assertEqual(loss.data.shape, ())
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = float(cuda.to_cpu(loss.data))
 
         # Compute expected value
         loss_expect = 0
+        non_ignore_count = 0
         for i in six.moves.range(self.x.shape[0]):
             for j in six.moves.range(self.x.shape[1]):
                 xd, td = self.x[i, j], self.t[i, j]
+                if td == -1:
+                    continue
                 loss_expect -= xd * (td - (xd >= 0)) \
                     - math.log(1 + math.exp(-numpy.abs(xd)))
-        loss_expect /= self.t.shape[0]
+                non_ignore_count += 1
+        if self.normalize:
+            loss_expect /= non_ignore_count
+        else:
+            loss_expect /= self.t.shape[0]
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -28,7 +28,8 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
             self.t = -numpy.ones(self.shape).astype(numpy.int32)
         else:
             self.ignore_all = False
-            self.t = numpy.random.randint(-1, 2, self.shape).astype(numpy.int32)
+            self.t = numpy.random.randint(-1, 2,
+                                          self.shape).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x_val = chainer.Variable(x_data)


### PR DESCRIPTION
I added ``ignore_label`` to ``sigmoid_cross_entropy`` as ``softmax_cross_entropy`` has.
When groundtruth label is -``1``, corresponding prediction is ignored while computing loss.

Added ``normalize`` option works same as ``softmax_cross_entropy``.