### PR TITLE
Make SPP a subclass of Pooling2D

### DIFF
--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -2,7 +2,6 @@ import numpy
 import six
 
 from chainer import cuda
-from chainer import function
 from chainer.functions.array import concat
 from chainer.functions.pooling import max_pooling_2d
 from chainer.functions.pooling import pooling_2d

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -5,9 +5,10 @@ from chainer import cuda
 from chainer import function
 from chainer.functions.array import concat
 from chainer.functions.pooling import max_pooling_2d
+from chainer.functions.pooling import pooling_2d
 
 
-class SpatialPyramidPooling2D(function.Function):
+class SpatialPyramidPooling2D(pooling_2d.Pooling2D):
 
     """Spatial pyramid pooling over a set of 2d planes."""
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -9,6 +9,7 @@ from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
+from chainer.utils import type_check
 
 
 class TestSpatialPyramidPooling2D(unittest.TestCase):
@@ -99,6 +100,46 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+
+
+class TestValidDtype(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.randn(5, 3, 5, 5)
+        self.v = chainer.Variable(self.x.astype(numpy.float32))
+
+    def check_valid_dtype(self):
+        functions.spatial_pyramid_pooling_2d(
+            self.v, 3, functions.MaxPooling2D)
+
+    def test_valid_dtype_cpu(self):
+        self.check_valid_dtype()
+
+    @attr.gpu
+    def test_valid_dtype_gpu(self):
+        self.v.to_gpu()
+        self.check_valid_dtype()
+
+
+class TestInvalidDtype(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.randn(5, 3, 5, 5)
+        self.v = chainer.Variable(self.x.astype(numpy.int32))
+
+    def check_invalid_dtype(self):
+        functions.spatial_pyramid_pooling_2d(
+            self.v, 3, functions.MaxPooling2D)
+
+    def test_invalid_dtype_cpu(self):
+        with self.assertRaises(type_check.InvalidType):
+            self.check_invalid_dtype()
+
+    @attr.gpu
+    def test_invalid_dtype_gpu(self):
+        self.v.to_gpu()
+        with self.assertRaises(type_check.InvalidType):
+            self.check_invalid_dtype()
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fix #787 

Lack of `type_check_forward` in `SpatialPyramidPooling2D` caused #787's error. So the main objective of this change is to introduce type check to SPP.

The drawback of this change is to restrict the input SPP 4D array with `float32`. But this restriction is acceptable because it is same as ones other pooling functions have.