### PR TITLE
Fix broken math expressions in reference

### DIFF
--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -9,7 +9,8 @@ class ClippedReLU(function.Function):
 
     """Clipped Rectifier Unit function.
 
-    Clipped ReLU is written as :math:`ClippedReLU(x, z) = \\min(\\max(0, x), z)`,
+    Clipped ReLU is written as
+    :math:`ClippedReLU(x, z) = \\min(\\max(0, x), z)`,
     where :math:`z(>0)` is a parameter to cap return value of ReLU.
 
     """

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -9,7 +9,7 @@ class ClippedReLU(function.Function):
 
     """Clipped Rectifier Unit function.
 
-    Clipped ReLU is written as :math:`ClippedReLU(x, z) = \min(\max(0, x), z)`,
+    Clipped ReLU is written as :math:`ClippedReLU(x, z) = \\min(\\max(0, x), z)`,
     where :math:`z(>0)` is a parameter to cap return value of ReLU.
 
     """
@@ -51,7 +51,7 @@ def clipped_relu(x, z=20.0):
     """Clipped Rectifier Unit function.
 
     This function is expressed as :math:`ClippedReLU(x, z)
-    = \min(\max(0, x), z)`, where :math:`z(>0)` is a clipping value.
+    = \\min(\\max(0, x), z)`, where :math:`z(>0)` is a clipping value.
 
     Args:
         x (~chainer.Variable): Input variable.

--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -47,7 +47,7 @@ class LeakyReLU(function.Function):
 def leaky_relu(x, slope=0.2):
     """Leaky Rectified Linear Unit function.
 
-    This function is expressed as :math:`f(x) = \max(x, ax)`, where :math:`a`
+    This function is expressed as :math:`f(x) = \\max(x, ax)`, where :math:`a`
     is a configurable slope value.
 
     Args:

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -77,7 +77,7 @@ def prelu(x, W):
     """Parametric ReLU function.
 
     It accepts two arguments: an input ``x`` and a weight array ``W``
-    and computes the output as :math:`PReLU(x) = \max(x, W*x)`,
+    and computes the output as :math:`PReLU(x) = \\max(x, W*x)`,
     where :math:`*` is an elementwise multiplication for each sample in the
     batch.
 

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -118,11 +118,11 @@ def bilinear(e1, e2, W, V1=None, V2=None, b=None):
     outputs one variable.
 
     To be precise, denote six input arrays mathematically by
-    :math:`e^1\in \mathbb{R}^{I\cdot J}`,
-    :math:`e^2\in \mathbb{R}^{I\cdot K}`,
-    :math:`W\in \mathbb{R}^{J \cdot K \cdot L}`,
-    :math:`V^1\in \mathbb{R}^{J \cdot L}`,
-    :math:`V^2\in \mathbb{R}^{K \cdot L}`, and :math:`b\in \mathbb{R}^{L}`.
+    :math:`e^1\\in \\mathbb{R}^{I\\cdot J}`,
+    :math:`e^2\\in \\mathbb{R}^{I\\cdot K}`,
+    :math:`W\\in \\mathbb{R}^{J \\cdot K \\cdot L}`,
+    :math:`V^1\\in \\mathbb{R}^{J \\cdot L}`,
+    :math:`V^2\\in \\mathbb{R}^{K \\cdot L}`, and :math:`b\\in \\mathbb{R}^{L}`.
     where :math:`I` is mini-batch size.
     In this document, we call :math:`V^1`, :math:`V^2`, and :math:`b` linear
     parameters.
@@ -131,8 +131,8 @@ def bilinear(e1, e2, W, V1=None, V2=None, b=None):
 
     .. math::
 
-      y_{il} = \sum_{jk} e^1_{ij} e^2_{ik} W_{jkl} + \
-        \sum_{j} e^1_{ij} V^1_{jl} + \sum_{k} e^2_{ik} V^2_{kl} + b_{l}.
+      y_{il} = \\sum_{jk} e^1_{ij} e^2_{ik} W_{jkl} + \\
+        \\sum_{j} e^1_{ij} V^1_{jl} + \\sum_{k} e^2_{ik} V^2_{kl} + b_{l}.
 
     Note that V1, V2, b are optional. If these are not given, then this
     function omits the last three terms in the above equation.

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -122,7 +122,8 @@ def bilinear(e1, e2, W, V1=None, V2=None, b=None):
     :math:`e^2\\in \\mathbb{R}^{I\\cdot K}`,
     :math:`W\\in \\mathbb{R}^{J \\cdot K \\cdot L}`,
     :math:`V^1\\in \\mathbb{R}^{J \\cdot L}`,
-    :math:`V^2\\in \\mathbb{R}^{K \\cdot L}`, and :math:`b\\in \\mathbb{R}^{L}`.
+    :math:`V^2\\in \\mathbb{R}^{K \\cdot L}`, and
+    :math:`b\\in \\mathbb{R}^{L}`,
     where :math:`I` is mini-batch size.
     In this document, we call :math:`V^1`, :math:`V^2`, and :math:`b` linear
     parameters.

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -45,8 +45,8 @@ def embed_id(x, W):
 
     This function implements so called *word embedding*. It takes two
     arguments: a set of IDs (words) ``x`` in :math:`B` dimensional integer
-    vector, and a set of all ID (word) embeddings ``W`` in :math:`V\times d`
-    float32 matrix. It outputs :math:`B \times d` matrix whose ``i``-th
+    vector, and a set of all ID (word) embeddings ``W`` in :math:`V \\times d`
+    float32 matrix. It outputs :math:`B \\times d` matrix whose ``i``-th
     column is the ``x[i]``-th column of ``W``.
 
     This function is only differentiable on the input ``W``.

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -60,7 +60,7 @@ def linear(x, W, b=None):
 
     It accepts two or three arguments: an input minibatch ``x``, a weight
     matrix ``W``, and optionally a bias vector ``b``. It computes
-    :math:`Y = xW^\top + b`.
+    :math:`Y = xW^\\top + b`.
 
     Args:
         x (~chainer.Variable): Input variable. Its first dimension is assumed

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -170,8 +170,8 @@ def negative_sampling(x, t, W, sampler, sample_size):
 
     .. math::
 
-       f(x, p) = \log\sigma(x^\\top w_p) + \\
-       k E_{i \sim P(i)}[\log\sigma(- x^\\top w_i)],
+       f(x, p) = \\log \\sigma(x^\\top w_p) + \\
+       k E_{i \\sim P(i)}[\\log \\sigma(- x^\\top w_i)],
 
     where :math:`\sigma(\cdot)` is a sigmoid function, :math:`w_i` is the
     weight vector for the word :math:`i`, and :math:`p` is a positive example.
@@ -180,8 +180,8 @@ def negative_sampling(x, t, W, sampler, sample_size):
 
     .. math::
 
-       f(x, p) \\approx \log\sigma(x^\\top w_p) + \\
-       \sum_{n \in N} \log\sigma(-x^\\top w_n).
+       f(x, p) \\approx \\log \\sigma(x^\\top w_p) + \\
+       \\sum_{n \\in N} \\log \\sigma(-x^\\top w_n).
 
     Each sample of :math:`N` is drawn from the word distribution :math:`P(w)`.
     This is calculated as :math:`P(w) = \\frac{1}{Z} c(w)^\\alpha`, where

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -39,7 +39,7 @@ class Deconvolution2D(link.Link):
     which indicate the number of the number of input channels, output channels,
     height and width of the kernels, respectively.
     The filter weight is initialized with i.i.d. Gaussian random samples, each
-    of which has zero mean and deviation :math:`\sqrt{1/(c_I k_H k_W)}` by
+    of which has zero mean and deviation :math:`\\sqrt{1/(c_I k_H k_W)}` by
     default. The deviation is scaled by ``wscale`` if specified.
 
     The bias vector is of size :math:`c_O`.

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -13,7 +13,7 @@ class Linear(link.Link):
     parameters.
 
     The weight matrix ``W`` is initialized with i.i.d. Gaussian samples, each
-    of which has zero mean and deviation :math:`\sqrt{1/\\text{in_size}}`. The
+    of which has zero mean and deviation :math:`\\sqrt{1/\\text{in_size}}`. The
     bias vector ``b`` is of size ``out_size``. Each element is initialized with
     the ``bias`` value. If ``nobias`` argument is set to True, then this link
     does not hold a bias vector.

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -261,10 +261,10 @@ class BinaryHierarchicalSoftmax(link.Link):
     corresponding to a word in a vocabulary.
     When a word :math:`x` is given, exactly one path from the root of the tree
     to the leaf of the word exists.
-    Let :math:`\\mbox{path}(x) = ((e_1, b_1), \\dots, (e_m, b_m))` be the path of
-    :math:`x`, where :math:`e_i` is an index of :math:`i`-th internal node, and
-    :math:`b_i \\in \\{-1, 1\\}` indicates direction to move at :math:`i`-th
-    internal node (-1 is left, and 1 is right).
+    Let :math:`\\mbox{path}(x) = ((e_1, b_1), \\dots, (e_m, b_m))` be the path
+    of :math:`x`, where :math:`e_i` is an index of :math:`i`-th internal node,
+    and :math:`b_i \\in \\{-1, 1\\}` indicates direction to move at
+    :math:`i`-th internal node (-1 is left, and 1 is right).
     Then, the probability of :math:`x` is given as below:
 
     .. math::

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -254,30 +254,30 @@ class BinaryHierarchicalSoftmax(link.Link):
     In natural language applications, vocabulary size is too large to use
     softmax loss.
     Instead, the hierarchical softmax uses product of sigmoid functions.
-    It costs only :math:`O(\log(n))` time where :math:`n` is the vocabulary
+    It costs only :math:`O(\\log(n))` time where :math:`n` is the vocabulary
     size in average.
 
     At first a user need to prepare a binary tree whose each leaf is
     corresponding to a word in a vocabulary.
     When a word :math:`x` is given, exactly one path from the root of the tree
     to the leaf of the word exists.
-    Let :math:`\mbox{path}(x) = ((e_1, b_1), \dots, (e_m, b_m))` be the path of
+    Let :math:`\\mbox{path}(x) = ((e_1, b_1), \\dots, (e_m, b_m))` be the path of
     :math:`x`, where :math:`e_i` is an index of :math:`i`-th internal node, and
-    :math:`b_i \in \{-1, 1\}` indicates direction to move at :math:`i`-th
+    :math:`b_i \\in \\{-1, 1\\}` indicates direction to move at :math:`i`-th
     internal node (-1 is left, and 1 is right).
     Then, the probability of :math:`x` is given as below:
 
     .. math::
 
-       P(x) &= \prod_{(e_i, b_i) \in \mbox{path}(x)}P(b_i | e_i)  \\\\
-            &= \prod_{(e_i, b_i) \in \mbox{path}(x)}\sigma(b_i x^\\top
+       P(x) &= \\prod_{(e_i, b_i) \\in \\mbox{path}(x)}P(b_i | e_i)  \\\\
+            &= \\prod_{(e_i, b_i) \\in \\mbox{path}(x)}\\sigma(b_i x^\\top
                w_{e_i}),
 
-    where :math:`\sigma(\\cdot)` is a sigmoid function, and :math:`w` is a
+    where :math:`\\sigma(\\cdot)` is a sigmoid function, and :math:`w` is a
     weight matrix.
 
-    This function costs :math:`O(\log(n))` time as an average length of paths
-    is :math:`O(\log(n))`, and :math:`O(n)` memory as the number of internal
+    This function costs :math:`O(\\log(n))` time as an average length of paths
+    is :math:`O(\\log(n))`, and :math:`O(n)` memory as the number of internal
     nodes equals :math:`n - 1`.
 
     Args:

--- a/chainer/utils/walker_alias.py
+++ b/chainer/utils/walker_alias.py
@@ -7,7 +7,7 @@ class WalkerAlias(object):
     """Implementation of Walker's alias method.
 
     This method generates a random sample from given probabilities
-    :math:`p_1, \dots, p_n` in :math:`O(1)` time.
+    :math:`p_1, \\dots, p_n` in :math:`O(1)` time.
     It is more efficient than :func:`~numpy.random.choice`.
     This class works on both CPU and GPU.
 


### PR DESCRIPTION
In the document of [`F.linear`](http://docs.chainer.org/en/stable/reference/functions.html#chainer.functions.linear) and [`F.embed_id`](http://docs.chainer.org/en/stable/reference/functions.html#chainer.functions.embed_id), math expression `\times` and `\top` are not properly rendered. To fix them, I replaced `\t` with `\\t` at the first commit.

In principle, as [Math support in Sphinx](http://sphinx-doc.org/ext/math.html) says:
> Keep in mind that when you put math markup in Python docstrings read by autodoc, you either have to double all backslashes, or use Python raw strings (r"raw").

So I further replaced single-backslash in doncstrings with double-backslashes.