### PR TITLE
Make GRU stateful

### DIFF
--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -25,6 +25,7 @@ Convolution2D = convolution_2d.Convolution2D
 Deconvolution2D = deconvolution_2d.Deconvolution2D
 EmbedID = embed_id.EmbedID
 GRU = gru.GRU
+StatefulGRU = gru.StatefulGRU
 Inception = inception.Inception
 InceptionBN = inceptionbn.InceptionBN
 Linear = linear.Linear

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -120,11 +120,13 @@ class StatefulGRU(GRUBase):
             self.h.to_gpu(device)
 
     def set_state(self, h):
+        assert isinstance(h, chainer.Variable)
+        h_ = h
         if self.xp == numpy:
-            h = chainer.cuda.to_cpu(h)
+            h_.to_cpu()
         else:
-            h = chainer.cuda.to_gpu(h)
-        self.h = chainer.Variable(h, volatile='auto')
+            h_.to_gpu()
+        self.h = h_
 
     def reset_state(self):
         self.h = None

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -98,9 +98,8 @@ class StatefulGRU(GRUBase):
     Use :class:`~chainer.links.GRU` as a stateless version of GRU.
 
     Args:
-        n_units(int): Dimension of hidden vector :math:`h`.
-        n_inputs(int): Dimension of input vector :math:`x`. If ``None``,
-        it is set to the same value as ``n_units``.
+        in_size(int): Dimension of input vector :math:`x`.
+        out_size(int): Dimension of hidden vector :math:`h`.
 
     Attributes:
         h(~chainer.Variable): Hidden vector that indicates the state of
@@ -109,9 +108,9 @@ class StatefulGRU(GRUBase):
     .. seealso:: :class:`~chainer.functions.GRU`
     """
 
-    def __init__(self, n_units, n_inputs=None):
-        super(StatefulGRU, self).__init__(n_units, n_inputs)
-        self.state_size = n_units
+    def __init__(self, in_size, out_size):
+        super(StatefulGRU, self).__init__(out_size, in_size)
+        self.state_size = out_size
         self.reset_state()
 
     def to_cpu(self):

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -124,7 +124,7 @@ class StatefulGRU(GRUBase):
             h = chainer.cuda.to_cpu(h)
         else:
             h = chainer.cuda.to_gpu(h)
-        self.h = chainer.Variable(h)
+        self.h = chainer.Variable(h, volatile='auto')
 
     def reset_state(self):
         self.h = None

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -130,12 +130,10 @@ class StatefulGRU(GRUBase):
         self.h = None
 
     def __call__(self, x):
-        r = self.W_r(x)
         z = self.W_z(x)
         if self.h is not None:
-            r += self.U_r(self.h)
+            r = sigmoid.sigmoid(self.W_r(x) + self.U_r(self.h))
             z += self.U_z(self.h)
-        r = sigmoid.sigmoid(r)
         z = sigmoid.sigmoid(z)
 
         h_bar = self.W(x)

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -9,13 +9,15 @@ from chainer.links.connection import linear
 
 class GRUBase(link.Chain):
 
-    def __init__(self, n_units):
+    def __init__(self, n_units, n_inputs=None):
+        if n_inputs is None:
+            n_inputs = n_units
         super(GRUBase, self).__init__(
-            W_r=linear.Linear(n_units, n_units),
+            W_r=linear.Linear(n_inputs, n_units),
             U_r=linear.Linear(n_units, n_units),
-            W_z=linear.Linear(n_units, n_units),
+            W_z=linear.Linear(n_inputs, n_units),
             U_z=linear.Linear(n_units, n_units),
-            W=linear.Linear(n_units, n_units),
+            W=linear.Linear(n_inputs, n_units),
             U=linear.Linear(n_units, n_units),
         )
 
@@ -104,8 +106,8 @@ class StatefulGRU(GRUBase):
     .. seealso:: :class:`~chainer.functions.GRU`
     """
 
-    def __init__(self, n_units):
-        super(StatefulGRU, self).__init__(n_units)
+    def __init__(self, n_units, n_inputs=None):
+        super(StatefulGRU, self).__init__(n_units, n_inputs)
         self.state_size = n_units
         self.reset_state()
 

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -49,8 +49,9 @@ class GRU(GRUBase):
     Use :class:`~chainer.links.StatefulGRU` as a *stateful* GRU.
 
     Args:
-        n_units(int): Dimension of input vector :math:`x`, and hidden vector
-            :math:`h`.
+        n_units(int): Dimension of hidden vector :math:`h`.
+        n_inputs(int): Dimension of input vector :math:`x`. If ``None``,
+        it is set to the same value as ``n_units``.
 
     See:
         - `On the Properties of Neural Machine Translation: Encoder-Decoder
@@ -97,7 +98,9 @@ class StatefulGRU(GRUBase):
     Use :class:`~chainer.links.GRU` as a stateless version of GRU.
 
     Args:
-        n_units(int): Dimension of input vector :math:`x`, and hidden vector.
+        n_units(int): Dimension of hidden vector :math:`h`.
+        n_inputs(int): Dimension of input vector :math:`x`. If ``None``,
+        it is set to the same value as ``n_units``.
 
     Attributes:
         h(~chainer.Variable): Hidden vector that indicates the state of

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -7,9 +7,22 @@ from chainer import link
 from chainer.links.connection import linear
 
 
-class GRU(link.Chain):
+class GRUBase(link.Chain):
 
-    """Gated Recurrent Unit function (GRU).
+    def __init__(self, n_units):
+        super(GRUBase, self).__init__(
+            W_r=linear.Linear(n_units, n_units),
+            U_r=linear.Linear(n_units, n_units),
+            W_z=linear.Linear(n_units, n_units),
+            U_z=linear.Linear(n_units, n_units),
+            W=linear.Linear(n_units, n_units),
+            U=linear.Linear(n_units, n_units),
+        )
+
+
+class GRU(GRUBase):
+
+    """Stateless Gated Recurrent Unit function (GRU).
 
     GRU function has six parameters :math:`W_r`, :math:`W_z`, :math:`W`,
     :math:`U_r`, :math:`U_z`, and :math:`U`. All these parameters are
@@ -29,6 +42,10 @@ class GRU(link.Chain):
     where :math:`\\sigma` is the sigmoid function, and :math:`\\odot` is the
     element-wise product.
 
+    :class:`~chainer.links.GRU` does not hold the value of
+    hidden vector :math:`h`. So this is *stateless*.
+    Use :class:`~chainer.links.StatefulGRU` as a *stateful* GRU.
+
     Args:
         n_units(int): Dimension of input vector :math:`x`, and hidden vector
             :math:`h`.
@@ -41,27 +58,64 @@ class GRU(link.Chain):
           Modeling <http://arxiv.org/abs/1412.3555>`_
           [Chung+NIPS2014 DLWorkshop].
 
+
+    .. seealso:: :class:`~chainer.links.StatefulGRU`
+    """
+
+    def __call__(self, h, x):
+        r = sigmoid.sigmoid(self.W_r(x) + self.U_r(h))
+        z = sigmoid.sigmoid(self.W_z(x) + self.U_z(h))
+        h_bar = tanh.tanh(self.W(x) + self.U(r * h))
+        h_new = (1 - z) * h + z * h_bar
+        return h_new
+
+
+class StatefulGRU(GRUBase):
+    """Stateful Gated Recurrent Unit function (GRU).
+
+    Stateful GRU function has six parameters :math:`W_r`, :math:`W_z`,
+    :math:`W`, :math:`U_r`, :math:`U_z`, and :math:`U`.
+    All these parameters are :math:`n \\times n` matricies,
+    where :math:`n` is the dimension of hidden vectors.
+
+    Given input vector :math:`x`, Stateful GRU returns the next
+    hidden vector :math:`h'` defined as
+
+    .. math::
+
+       r &=& \\sigma(W_r x + U_r h), \\\\
+       z &=& \\sigma(W_z x + U_z h), \\\\
+       \\bar{h} &=& \\tanh(W x + U (r \\odot h)), \\\\
+       h' &=& (1 - z) \\odot h + z \\odot \\bar{h},
+
+    where :math:`h` is current hidden vector.
+
+    As the name indicates, :class:`~chainer.links.StatefulGRU` is *stateful*,
+    meaning that it also holds the next hidden vector `h'` as a state.
+    Use :class:`~chainer.links.GRU` as a stateless version of GRU.
+
+    Args:
+        n_units(int): Dimension of input vector :math:`x`, and hidden vector.
+
+    Attributes:
+        h(~chainer.Variable): Hidden vector that indicates the state of
+        :class:`~chainer.links.StatefulGRU`.
+
+    .. seealso:: :class:`~chainer.functions.GRU`
     """
 
     def __init__(self, n_units):
-        super(GRU, self).__init__(
-            W_r=linear.Linear(n_units, n_units),
-            U_r=linear.Linear(n_units, n_units),
-            W_z=linear.Linear(n_units, n_units),
-            U_z=linear.Linear(n_units, n_units),
-            W=linear.Linear(n_units, n_units),
-            U=linear.Linear(n_units, n_units),
-        )
+        super(StatefulGRU, self).__init__(n_units)
         self.state_size = n_units
         self.reset_state()
 
     def to_cpu(self):
-        super(GRU, self).to_cpu()
+        super(StatefulGRU, self).to_cpu()
         if self.h is not None:
             self.h.to_cpu()
 
     def to_gpu(self, device=None):
-        super(GRU, self).to_gpu(device)
+        super(StatefulGRU, self).to_gpu(device)
         if self.h is not None:
             self.h.to_gpu(device)
 

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -131,14 +131,12 @@ class StatefulGRU(GRUBase):
 
     def __call__(self, x):
         z = self.W_z(x)
+        h_bar = self.W(x)
         if self.h is not None:
             r = sigmoid.sigmoid(self.W_r(x) + self.U_r(self.h))
             z += self.U_z(self.h)
-        z = sigmoid.sigmoid(z)
-
-        h_bar = self.W(x)
-        if self.h is not None:
             h_bar += self.U(r * self.h)
+        z = sigmoid.sigmoid(z)
         h_bar = tanh.tanh(h_bar)
 
         h_new = z * h_bar

--- a/docs/source/reference/links.rst
+++ b/docs/source/reference/links.rst
@@ -35,6 +35,8 @@ Learnable connections
    :members:
 .. autoclass:: MLPConvolution2D
    :members:
+.. autoclass:: StatefulGRU
+   :members:
 
 Activation/loss/normalization functions with parameters
 --------------------------------------------------------

--- a/tests/chainer_tests/links_tests/connection_tests/test_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_gru.py
@@ -32,14 +32,15 @@ class TestGRU(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
         self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+        self.link.set_state(self.h)
 
     def check_forward(self, h_data, x_data):
-        h = chainer.Variable(h_data)
         x = chainer.Variable(x_data)
-        y = self.link(h, x)
+        y = self.link(x)
         self.assertEqual(y.data.dtype, numpy.float32)
 
         y_expect = _gru(self.link, h_data, x_data)
+        gradient_check.assert_allclose(self.link.h.data, y.data)
         gradient_check.assert_allclose(y_expect, y.data)
 
     def test_forward_cpu(self):
@@ -52,17 +53,15 @@ class TestGRU(unittest.TestCase):
                            cuda.to_gpu(self.x))
 
     def check_backward(self, h_data, x_data, y_grad):
-        h = chainer.Variable(h_data)
         x = chainer.Variable(x_data)
-        y = self.link(h, x)
+        y = self.link(x)
 
         y.grad = y_grad
         y.backward()
 
-        f = lambda: (_gru(self.link, h.data, x.data),)
-        gh, gx = gradient_check.numerical_grad(f, (h.data, x.data), (y.grad,))
+        f = lambda: (_gru(self.link, h_data, x_data),)
+        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
 
-        gradient_check.assert_allclose(gh, h.grad, atol=1e-3)
         gradient_check.assert_allclose(gx, x.grad, atol=1e-3)
 
     def test_backward_cpu(self):
@@ -74,6 +73,82 @@ class TestGRU(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.h),
                             cuda.to_gpu(self.x),
                             cuda.to_gpu(self.gy))
+
+
+@testing.parameterize(
+    *testing.product({
+        'link_array_module': ['to_cpu', 'to_gpu'],
+        'state_array_module': ['to_cpu', 'to_gpu']
+    }))
+class TestGRUState(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.GRU(8)
+        self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+
+    def check_set_state(self, h):
+        self.link.set_state(h)
+        self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
+
+    def test_set_state_cpu(self):
+        self.check_set_state(self.h)
+
+    @attr.gpu
+    def test_set_state_gpu(self):
+        getattr(self.link, self.link_array_module)()
+        h = getattr(chainer.cuda, self.state_array_module)(self.h)
+        self.check_set_state(h)
+
+    def check_reset_state(self):
+        self.link.reset_state()
+        self.assertIsNone(self.link.h)
+
+    def test_reset_state_cpu(self):
+        self.check_reset_state()
+
+    @attr.gpu
+    def test_reset_state_gpu(self):
+        getattr(self.link, self.link_array_module)()
+        self.check_reset_state()
+
+
+class TestGRUToCPUToGPU(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.GRU(8)
+        self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+
+    def check_to_cpu(self, h):
+        self.link.set_state(h)
+        self.link.to_cpu()
+        self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
+        self.link.to_cpu()
+        self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
+
+    def test_to_cpu_cpu(self):
+        self.check_to_cpu(self.h)
+
+    @attr.gpu
+    def test_to_cpu_gpu(self):
+        self.check_to_cpu(chainer.cuda.to_gpu(self.h))
+
+    def check_to_cpu_to_gpu(self, h):
+        self.link.set_state(h)
+        self.link.to_gpu()
+        self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
+        self.link.to_gpu()
+        self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
+        self.link.to_cpu()
+        self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
+        self.link.to_gpu()
+        self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
+
+    def test_to_cpu_to_gpu_cpu(self):
+        self.check_to_cpu_to_gpu(self.h)
+
+    @attr.gpu
+    def test_to_cpu_to_gpu_gpu(self):
+        self.check_to_cpu_to_gpu(chainer.cuda.to_gpu(self.h))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_gru.py
@@ -26,22 +26,29 @@ def _gru(func, h, x):
 
 
 @testing.parameterize(
-    {'gru': links.GRU},
-    {'gru': links.StatefulGRU}
+    {'gru': links.GRU, 'state': 'random'},
+    {'gru': links.StatefulGRU, 'state': 'random'},
+    {'gru': links.StatefulGRU, 'state': 'zero'}
 )
 class TestStatefulGRU(unittest.TestCase):
 
     def setUp(self):
         self.link = self.gru(8)
         self.x = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
-        self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+        if self.state == 'random':
+            self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+        elif self.state == 'zero':
+            self.h = numpy.zeros((3, 8), dtype=numpy.float32)
+        else:
+            self.fail('Unsupported state initialization:{}'.format(self.state))
         self.gy = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
 
     def _forward(self, link, h, x):
         if isinstance(link, links.GRU):
             return link(h, x)
         else:
-            link.set_state(h.data)
+            if self.state != 'zero':
+                link.set_state(h.data)
             return link(x)
 
     def check_forward(self, h_data, x_data):

--- a/tests/chainer_tests/links_tests/connection_tests/test_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_gru.py
@@ -143,6 +143,7 @@ class TestGRUToCPUToGPU(unittest.TestCase):
         self.link.to_gpu()
         self.assertIsInstance(self.link.h.data, self.link.xp.ndarray)
 
+    @attr.gpu
     def test_to_cpu_to_gpu_cpu(self):
         self.check_to_cpu_to_gpu(self.h)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_gru.py
@@ -26,22 +26,32 @@ def _gru(func, h, x):
 
 
 @testing.parameterize(
-    {'gru': links.GRU, 'state': 'random'},
-    {'gru': links.StatefulGRU, 'state': 'random'},
-    {'gru': links.StatefulGRU, 'state': 'zero'}
+    {'gru': links.GRU, 'state': 'random', 'n_inputs': 4, 'n_units': 8},
+    {'gru': links.GRU, 'state': 'random', 'n_units': 8},
+    {'gru': links.StatefulGRU, 'state': 'random', 'n_inputs': 4, 'n_units': 8},
+    {'gru': links.StatefulGRU, 'state': 'random', 'n_units': 8},
+    {'gru': links.StatefulGRU, 'state': 'zero', 'n_inputs': 4, 'n_units': 8},
+    {'gru': links.StatefulGRU, 'state': 'zero', 'n_units': 8}
 )
-class TestStatefulGRU(unittest.TestCase):
+class TestGRU(unittest.TestCase):
 
     def setUp(self):
-        self.link = self.gru(8)
-        self.x = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+        if hasattr(self, 'n_inputs'):
+            self.link = self.gru(self.n_units, self.n_inputs)
+        else:
+            self.link = self.gru(self.n_units)
+            self.n_inputs = self.n_units
+        self.x = numpy.random.uniform(
+            -1, 1, (3, self.n_inputs)).astype(numpy.float32)
         if self.state == 'random':
-            self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+            self.h = numpy.random.uniform(
+                -1, 1, (3, self.n_units)).astype(numpy.float32)
         elif self.state == 'zero':
-            self.h = numpy.zeros((3, 8), dtype=numpy.float32)
+            self.h = numpy.zeros((3, self.n_units), dtype=numpy.float32)
         else:
             self.fail('Unsupported state initialization:{}'.format(self.state))
-        self.gy = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (3, self.n_units)).astype(numpy.float32)
 
     def _forward(self, link, h, x):
         if isinstance(link, links.GRU):

--- a/tests/chainer_tests/links_tests/connection_tests/test_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_gru.py
@@ -48,7 +48,7 @@ class TestStatefulGRU(unittest.TestCase):
             return link(h, x)
         else:
             if self.state != 'zero':
-                link.set_state(h.data)
+                link.set_state(h)
             return link(x)
 
     def check_forward(self, h_data, x_data):
@@ -106,7 +106,8 @@ class TestGRUState(unittest.TestCase):
 
     def setUp(self):
         self.link = links.StatefulGRU(8)
-        self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+        self.h = chainer.Variable(
+            numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32))
 
     def check_set_state(self, h):
         self.link.set_state(h)
@@ -118,8 +119,8 @@ class TestGRUState(unittest.TestCase):
     @attr.gpu
     def test_set_state_gpu(self):
         getattr(self.link, self.link_array_module)()
-        h = getattr(chainer.cuda, self.state_array_module)(self.h)
-        self.check_set_state(h)
+        getattr(self.h, self.state_array_module)()
+        self.check_set_state(self.h)
 
     def check_reset_state(self):
         self.link.reset_state()
@@ -138,7 +139,8 @@ class TestGRUToCPUToGPU(unittest.TestCase):
 
     def setUp(self):
         self.link = links.StatefulGRU(8)
-        self.h = numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32)
+        self.h = chainer.Variable(
+            numpy.random.uniform(-1, 1, (3, 8)).astype(numpy.float32))
 
     def check_to_cpu(self, h):
         self.link.set_state(h)
@@ -152,7 +154,8 @@ class TestGRUToCPUToGPU(unittest.TestCase):
 
     @attr.gpu
     def test_to_cpu_gpu(self):
-        self.check_to_cpu(chainer.cuda.to_gpu(self.h))
+        self.h.to_gpu()
+        self.check_to_cpu(self.h)
 
     def check_to_cpu_to_gpu(self, h):
         self.link.set_state(h)
@@ -171,7 +174,8 @@ class TestGRUToCPUToGPU(unittest.TestCase):
 
     @attr.gpu
     def test_to_cpu_to_gpu_gpu(self):
-        self.check_to_cpu_to_gpu(chainer.cuda.to_gpu(self.h))
+        self.h.to_gpu()
+        self.check_to_cpu_to_gpu(self.h)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fix #789 

I propose to add several APIs to `link.GRU`
* `reset_state`: This same API as `link.LSTM`
* `set_state`: The pair instance of `reset_state` (it is not existed in current `link.LSTM`)
I think we should add `set_state` to `link.LSTM`, too.

Also, we need to override `to_cpu` and `to_gpu` because when the link is moved to CPU (resp. GPU), we must move its state, too. Maybe we must override these methods of `link.LSTM`.
