### PR TITLE
Use for-loop instead of ufunc.at as it is too slow

### DIFF
--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -33,8 +33,8 @@ class EmbedIDFunction(function.Function):
         if xp is numpy:
             # It is equivalent to `numpy.add.at(gW, x, gy)` but ufunc.at is
             # too slow.
-            for ix, igy in six.moves.zip(x.reshape((x.size,)),
-                                         gy.reshape((x.size, gy.shape[-1]))):
+            for ix, igy in six.moves.zip(x.reshape(-1),
+                                         gy.reshape((x.size, -1))):
                 gW[ix] += igy
         else:
             cuda.elementwise(

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -34,7 +34,7 @@ class EmbedIDFunction(function.Function):
             # It is equivalent to `numpy.add.at(gW, x, gy)` but ufunc.at is
             # too slow.
             for ix, igy in six.moves.zip(x.ravel(),
-                                         gy.reshape((x.size, -1))):
+                                         gy.reshape(x.size, -1)):
                 gW[ix] += igy
         else:
             cuda.elementwise(

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -33,7 +33,7 @@ class EmbedIDFunction(function.Function):
         if xp is numpy:
             # It is equivalent to `numpy.add.at(gW, x, gy)` but ufunc.at is
             # too slow.
-            for ix, igy in six.moves.zip(x.reshape(-1),
+            for ix, igy in six.moves.zip(x.ravel(),
                                          gy.reshape((x.size, -1))):
                 gW[ix] += igy
         else:

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -1,4 +1,5 @@
 import numpy
+import six
 
 from chainer import cuda
 from chainer import function
@@ -30,7 +31,11 @@ class EmbedIDFunction(function.Function):
         gW = xp.zeros_like(W)
 
         if xp is numpy:
-            numpy.add.at(gW, x, gy)
+            # It is equivalent to `numpy.add.at(gW, x, gy)` but ufunc.at is
+            # too slow.
+            for ix, igy in six.moves.zip(x.reshape((x.size,)),
+                                         gy.reshape((x.size, gy.shape[-1]))):
+                gW[ix] += igy
         else:
             cuda.elementwise(
                 'T gy, int32 x, int32 n_out', 'raw T gW',


### PR DESCRIPTION
I found that `ufunc.at` is very slow. This patch replaces `ufunc.at` with a simple for loop.

Original:
```
% time python embed_test.py
python embed_test.py  4.13s user 0.06s system 100% cpu 4.177 total
```

This patch:
```
% time python embed_test.py
python embed_test.py  0.56s user 0.07s system 100% cpu 0.625 total
```

Test code:
```
import chainer
import numpy

e = chainer.functions.EmbedID(1000, 300)
x = chainer.Variable(numpy.random.randint(0, 1000, (200)).astype(numpy.int32))
y = e(x)
y.grad = numpy.zeros((200, 300), dtype=numpy.float32)

for i in range(1000):
    y.backward()
```