### PR TITLE
Pep8 1.7.0

### DIFF
--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -83,10 +83,10 @@ class ComputationalGraph(object):
             ret += DotNode(node).label
         for edge in self.edges:
             head, tail = edge
-            assert (isinstance(head, variable.Variable)
-                    and isinstance(tail, function.Function)) or \
-                   (isinstance(head, function.Function)
-                    and isinstance(tail, variable.Variable))
+            assert (isinstance(head, variable.Variable) and
+                    isinstance(tail, function.Function)) or \
+                   (isinstance(head, function.Function) and
+                    isinstance(tail, variable.Variable))
             head_node = DotNode(head)
             tail_node = DotNode(tail)
             ret += "%s -> %s;" % (head_node.id_, tail_node.id_)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -23,8 +23,8 @@ class Dropout(function.Function):
         if xp == numpy:
             flag = xp.random.rand(*x[0].shape) >= self.dropout_ratio
         else:
-            flag = (xp.random.rand(*x[0].shape, dtype=numpy.float32)
-                    >= self.dropout_ratio)
+            flag = (xp.random.rand(*x[0].shape, dtype=numpy.float32) >=
+                    self.dropout_ratio)
         self.mask = scale * flag
         return x[0] * self.mask,
 

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -127,7 +127,7 @@ def _as_tuple(x):
 
 
 def check_backward(func, x_data, y_grad, params=(),
-                   eps=1e-3, atol=1e-5, rtol=1e-4, use_creator=False):
+                   eps=1e-3, atol=1e-5, rtol=1e-4):
     x_data = _as_tuple(x_data)
     if y_grad is not None:
         y_grad = _as_tuple(y_grad)
@@ -146,13 +146,10 @@ def check_backward(func, x_data, y_grad, params=(),
     y[0].backward()
 
     def f():
-        if use_creator:
-            return y[0].creator.forward(x_data)
-        else:
-            ys = func(*xs)
-            if not isinstance(ys, tuple):
-                ys = (ys,)
-            return tuple(y.data for y in ys)
+        ys = func(*xs)
+        if not isinstance(ys, tuple):
+            ys = (ys,)
+        return tuple(y.data for y in ys)
 
     for x in xs:
         if x.data.dtype.kind == 'f':

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -227,8 +227,7 @@ def check_backward(func, x_data, y_grad, params=(),
 
     xs = [variable.Variable(x) for x in x_data]
     y = func(*xs)
-    if isinstance(y, variable.Variable):
-        y = (y,)
+    y = _as_tuple(y)
 
     if y_grad is not None:
         assert len(y) == len(y_grad)
@@ -244,8 +243,7 @@ def check_backward(func, x_data, y_grad, params=(),
 
     def f():
         ys = func(*xs)
-        if not isinstance(ys, tuple):
-            ys = (ys,)
+        ys = _as_tuple(ys)
         return tuple(y.data for y in ys)
 
     for x in xs:

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -228,6 +228,9 @@ def check_backward(func, x_data, y_grad, params=(),
     else:
         assert len(y) == 1
         y_grad = (1,)
+
+    # We only need to call `backward` for one result `Variable`.
+    # `Variable.backward` method calls `Function.backward` of its creator.
     y[0].backward()
 
     def f():

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -145,31 +145,33 @@ def check_backward(func, x_data, y_grad, params=(),
     This method creates :class:`~chainer.Variable` objects with ``x_data``
     and calls ``func`` with the :class:`~chainer.Variable`s to get its result
     as :class:`~chainer.Variable`.
-    Then, it sets ``y_grad`` arrays to ``grad`` attributed of the result and
+    Then, it sets ``y_grad`` array to ``grad`` attribute of the result and
     calls ``backward`` method to get gradients of the inputs.
     To check correctness of the gradients, the function calls
-    :func:`numerical_grad` and compares them with :func:`assert_allclose`.
-    If an input object represents integer variable, its gradient is ignored.
+    :func:`numerical_grad` to calculate numerically the gradients and compares
+    the types of gradients with :func:`assert_allclose`.
+    If input objects (``x1_data`` or/and ``x2_data`` in this example) represent
+    integer variables, their gradients are ignored.
 
     You can simplify a test when ``MyFunc`` gets only one argument::
 
     >>   check_backward(func, x1_data, gy_data)
 
-    If ``MyFunc`` is a loss function which returns zero-dimensional
+    If ``MyFunc`` is a loss function which returns a zero-dimensional
     array, pass ``None`` to ``gy_data``. In this case, it sets ``1`` to
     ``grad`` attribute of the result::
 
     >>   check_backward(my_loss_func, (x1_data, x2_data), None)
 
-    It ``MyFunc`` returns multiple outputs, pass all gradients for outputs
-    as tuple::
+    If ``MyFunc`` returns multiple outputs, pass all gradients for outputs
+    as a tuple::
 
     >>   gy1_data = xp.array(...)
     >>   gy2_data = xp.array(...)
     >>   check_backward(func, x1_data, (gy1_data, gy2_data))
 
     You can also test a :class:`~chainer.Link`.
-    To check gradients of parameters of the link, set tuple of the parameters
+    To check gradients of parameters of the link, set a tuple of the parameters
     to ``params`` arguments::
 
     >>   check_backward(my_link, (x1_data, x2_data), gy_data,

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -161,6 +161,13 @@ def check_backward(func, x_data, y_grad, params=(),
 
     >>   check_backward(my_loss_func, (x1_data, x2_data), None)
 
+    It ``MyFunc`` returns multiple outputs, pass all gradients for outputs
+    as tuple::
+
+    >>   gy1_data = xp.array(...)
+    >>   gy2_data = xp.array(...)
+    >>   check_backward(func, x1_data, (gy1_data, gy2_data))
+
     You can also test a :class:`~chainer.Link`.
     To check gradients of parameters of the link, set tuple of the parameters
     to ``params`` arguments::

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -230,11 +230,16 @@ def check_backward(func, x_data, y_grad, params=(),
     y = _as_tuple(y)
 
     if y_grad is not None:
-        assert len(y) == len(y_grad)
+        if len(y) != len(y_grad):
+            raise ValueError(
+                '`y_grad` must have the same length of output values')
         for iy, igy in zip(y, y_grad):
             iy.grad = igy
     else:
-        assert len(y) == 1
+        if len(y) != 1:
+            raise ValueError(
+                'When `y_grad` is `None`, the function must return a'
+                'zero-dimentional array')
         y_grad = (1,)
 
     # We only need to call `backward` for one result `Variable`.

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -127,7 +127,7 @@ def _as_tuple(x):
 
 
 def check_backward(func, x_data, y_grad, params=(),
-                   eps=1e-3, atol=1e-5, rtol=1e-4):
+                   eps=1e-3, atol=1e-5, rtol=1e-4, use_creator=False):
     x_data = _as_tuple(x_data)
     if y_grad is not None:
         y_grad = _as_tuple(y_grad)
@@ -146,8 +146,13 @@ def check_backward(func, x_data, y_grad, params=(),
     y[0].backward()
 
     def f():
-        y = func(*xs)
-        return y.data,
+        if use_creator:
+            return y[0].creator.forward(x_data)
+        else:
+            ys = func(*xs)
+            if not isinstance(ys, tuple):
+                ys = (ys,)
+            return tuple(y.data for y in ys)
 
     for x in xs:
         if x.data.dtype.kind == 'f':

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -221,9 +221,11 @@ def check_backward(func, x_data, y_grad, params=(),
         y = (y,)
 
     if y_grad is not None:
+        assert len(y) == len(y_grad)
         for iy, igy in zip(y, y_grad):
             iy.grad = igy
     else:
+        assert len(y) == 1
         y_grad = (1,)
     y[0].backward()
 

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -156,7 +156,8 @@ def check_backward(func, x_data, y_grad, params=(),
     >>   check_backward(func, x1_data, gy_data)
 
     If ``MyFunc`` is a loss function which returns zero-dimensional
-    array, pass ``None`` to ``gy_data``::
+    array, pass ``None`` to ``gy_data``. In this case, it sets ``1`` to
+    ``grad`` attribute of the result::
 
     >>   check_backward(my_loss_func, (x1_data, x2_data), None)
 

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -130,7 +130,7 @@ def check_backward(func, x_data, y_grad, params=(),
                    eps=1e-3, atol=1e-5, rtol=1e-4):
     """Test backward procedure of a given function.
 
-    This function automatically check backward-process of a given function.
+    This function automatically check backward-process of given function.
     For example, when you have a :class:`~chainer.Function` class ``MyFunc``,
     that gets two arguments and returns one value, you can make its test like
     this::
@@ -142,11 +142,11 @@ def check_backward(func, x_data, y_grad, params=(),
     >>   gy_data = xp.array(...)
     >>   check_backward(func, (x1_data, x2_data), gy_data)
 
-    This method creates :class:`~chainer.Variable` objects with ``x_data``,
-    and call ``func`` with the :class:`~chainer.Variable`s to get its result
-    :class:`~chainer.Variable`.
-    And then, set ``grad`` of the results with ``y_grad`` arrays and call
-    ``backward`` method to get gradients of the inputs.
+    This method creates :class:`~chainer.Variable` objects with ``x_data``
+    and calls ``func`` with the :class:`~chainer.Variable`s to get its result
+    as :class:`~chainer.Variable`.
+    Then, it sets ``y_grad`` arrays to ``grad`` attributed of the result and
+    calls ``backward`` method to get gradients of the inputs.
     To check correctness of the gradients, the function calls
     :func:`numerical_grad` and compares them with :func:`assert_allclose`.
     If an input object represents integer variable, its gradient is ignored.
@@ -161,21 +161,18 @@ def check_backward(func, x_data, y_grad, params=(),
     >>   check_backward(my_loss_func, (x1_data, x2_data), None)
 
     You can also test a :class:`~chainer.Link`.
-    To check gradients of parameters of the link, set ``params`` arguments
-    with a tuple of parameters::
+    To check gradients of parameters of the link, set tuple of the parameters
+    to ``params`` arguments::
 
     >>   check_backward(my_link, (x1_data, x2_data), gy_data,
     >>                  (my_link.W, my_link.b))
 
     Note that ``params`` are not ``ndarray``s, but ``~chainer.Variables``s.
 
-    A function object is acceptable for ``func`` argument::
+    Function objects are acceptable as ``func`` argument::
 
     >>   check_backward(lambda x1, x2: f(x1, x2),
     >>                  (x1_data, x2_data), gy_data)
-
-    ``func`` must returns one :class:`~chainer.Variable` or a tuple of
-    `~chainer.Variable`s.
 
     .. note::
 
@@ -191,19 +188,24 @@ def check_backward(func, x_data, y_grad, params=(),
             :class:`~chainer.Variable`. You can use :class:`~chainer.Function`
             object, :class:`~chainer.Link` object or a function satisfying the
             condition.
-        x_data (ndarray or tuple of ndarrays): A set of ``ndarray``s to pass
-            ``func``. If ``x_data`` is one ``ndarray`` object, it is treated
-            as ``(x_data,)``.
+        x_data (ndarray or tuple of ndarrays): A set of ``ndarray``s to be
+            passed to ``func``. If ``x_data`` is one ``ndarray`` object, it is
+            treated as ``(x_data,)``.
         y_grad (ndarray or tuple of ndarrays or None):
             A set of ``ndarray``s representing gradinents of return-values of
-            ``func``. If ``func`` is a loss-function, set ``y_grad = None``.
+            ``func``. If ``y_grad`` is one ``ndarray`` object, it is
+            treated as ``(y_grad,)``. If ``func`` is a loss-function, set
+            ``y_grad = None``.
         params (~chainer.Variable or tuple of ~chainder.Variable):
             A set of :class:`~chainer.Variable`s whose gradients are checked.
             When ``func`` is a ``~chainer.Link`` object, set its parameters
-            as ``params``.
-        eps (float): Epsilon value to pass :func:`numerical_grad`.
-        atol (float): Absolute tolerance to pass :func:`assert_allclose`.
-        rtol (float): Relative tolerance to pass :func:`assert_allclose`.
+            as ``params``. If ``params`` is one ~chainer.Variable object, it is
+            treated as ``(params,)``.
+        eps (float): Epsilon value to be passed to :func:`numerical_grad`.
+        atol (float): Absolute tolerance to be passed to
+            :func:`assert_allclose`.
+        rtol (float): Relative tolerance to be passed to
+            :func:`assert_allclose`.
 
     See:
        :func:`numerical_grad`

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -34,11 +34,9 @@ def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
     if cupy_error is None and numpy_error is None:
         self.fail('Both cupy and numpy are expected to raise errors, but not')
     elif cupy_error is None:
-        self.fail('Only numpy raises error\n\n'
-                  + numpy_tb)
+        self.fail('Only numpy raises error\n\n' + numpy_tb)
     elif numpy_error is None:
-        self.fail('Only cupy raises error\n\n'
-                  + cupy_tb)
+        self.fail('Only cupy raises error\n\n' + cupy_tb)
     elif type(cupy_error) is not type(numpy_error):
         msg = '''Differnet types of errors occurred
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -44,8 +44,7 @@ class TestClippedReLU(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.clipped_relu(x, self.z),
-            x_data, y_grad)
+            functions.ClippedReLU(self.z), x_data, y_grad)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -43,17 +43,9 @@ class TestClippedReLU(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.clipped_relu(x, self.z)
-        self.assertEqual(y.data.dtype, numpy.float32)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.clipped_relu(x, self.z),
+            x_data, y_grad)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
@@ -45,16 +45,9 @@ class TestELU(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.elu(x, alpha=self.alpha)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.elu(x, alpha=self.alpha),
+            x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
@@ -46,8 +46,7 @@ class TestELU(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.elu(x, alpha=self.alpha),
-            x_data, y_grad)
+            functions.ELU(self.alpha), x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
@@ -45,16 +45,9 @@ class TestLeakyReLU(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.leaky_relu(x, slope=self.slope)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.leaky_relu(x, slope=self.slope),
+            x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
@@ -46,8 +46,7 @@ class TestLeakyReLU(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.leaky_relu(x, slope=self.slope),
-            x_data, y_grad)
+            functions.LeakyReLU(self.slope), x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_lstm.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_lstm.py
@@ -72,20 +72,8 @@ class TestLSTM(unittest.TestCase):
         self.test_forward_gpu()
 
     def check_backward(self, c_prev_data, x_data, c_grad, h_grad):
-        c_prev = chainer.Variable(c_prev_data)
-        x = chainer.Variable(x_data)
-        c, h = functions.lstm(c_prev, x)
-        c.grad = c_grad
-        h.grad = h_grad
-        c.backward()
-
-        func = c.creator
-        f = lambda: func.forward((c_prev.data, x.data))
-        gc_prev, gx = gradient_check.numerical_grad(
-            f, (c_prev.data, x.data), (c_grad, h_grad), eps=1e-2)
-
-        gradient_check.assert_allclose(gc_prev, c_prev.grad)
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            functions.lstm, (c_prev_data, x_data), (c_grad, h_grad), eps=1e-2)
 
     @condition.retry(3)
     def test_full_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_lstm.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_lstm.py
@@ -73,7 +73,8 @@ class TestLSTM(unittest.TestCase):
 
     def check_backward(self, c_prev_data, x_data, c_grad, h_grad):
         gradient_check.check_backward(
-            functions.lstm, (c_prev_data, x_data), (c_grad, h_grad), eps=1e-2)
+            functions.LSTM(),
+            (c_prev_data, x_data), (c_grad, h_grad), eps=1e-2)
 
     @condition.retry(3)
     def test_full_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -79,31 +79,14 @@ class TestNonparameterizedMaxout(unittest.TestCase):
             b, cuda.to_gpu(self.y))
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
-        x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
         if b_data is None:
-            y = functions.maxout(x, W)
+            gradient_check.check_backward(
+                functions.maxout, (x_data, W_data), y_grad,
+                eps=1e-2, atol=1e-2)
         else:
-            b = chainer.Variable(b_data)
-            y = functions.maxout(x, W, b)
-
-        y.grad = y_grad
-        y.backward()
-        func = y.creator
-
-        if b_data is None:
-            f = lambda: func.forward((x.data, W.data))
-            gx, gW = gradient_check.numerical_grad(
-                f, (x.data, W.data), (y.grad, ), eps=1e-2)
-        else:
-            f = lambda: func.forward((x.data, W.data, b.data))
-            gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, W.data, b.data), (y.grad, ), eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-2)
-        gradient_check.assert_allclose(gW, W.grad, atol=1e-2)
-        if b_data is not None:
-            gradient_check.assert_allclose(gb, b.grad, atol=1e-2)
+            gradient_check.check_backward(
+                functions.maxout, (x_data, W_data, b_data), y_grad,
+                eps=1e-2, atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -6,6 +6,7 @@ import six
 import chainer
 from chainer import cuda
 from chainer import functions
+from chainer.functions.activation import maxout
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
@@ -84,7 +85,7 @@ class TestNonparameterizedMaxout(unittest.TestCase):
             args = args + (b_data,)
 
         gradient_check.check_backward(
-            functions.MaxoutFunction(), args, y_grad,
+            maxout.MaxoutFunction(), args, y_grad,
             eps=1e-2, atol=1e-2)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -79,14 +79,13 @@ class TestNonparameterizedMaxout(unittest.TestCase):
             b, cuda.to_gpu(self.y))
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
-        if b_data is None:
-            gradient_check.check_backward(
-                functions.maxout, (x_data, W_data), y_grad,
-                eps=1e-2, atol=1e-2)
-        else:
-            gradient_check.check_backward(
-                functions.maxout, (x_data, W_data, b_data), y_grad,
-                eps=1e-2, atol=1e-2)
+        args = (x_data, W_data)
+        if b_data is not None:
+            args = args + (b_data,)
+
+        gradient_check.check_backward(
+            functions.MaxOut(), args, y_grad,
+            eps=1e-2, atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -84,7 +84,7 @@ class TestNonparameterizedMaxout(unittest.TestCase):
             args = args + (b_data,)
 
         gradient_check.check_backward(
-            functions.MaxOut(), args, y_grad,
+            functions.MaxoutFunction(), args, y_grad,
             eps=1e-2, atol=1e-2)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -22,8 +22,7 @@ class TestReLU(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
         gradient_check.check_backward(
-            lambda x: functions.relu(x, use_cudnn=use_cudnn),
-            x_data, y_grad)
+            functions.ReLU(use_cudnn), x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy
 
-import chainer
 from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
@@ -22,17 +21,9 @@ class TestReLU(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        y = functions.relu(x, use_cudnn=use_cudnn)
-        self.assertEqual(y.data.dtype, numpy.float32)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.relu(x, use_cudnn=use_cudnn),
+            x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -39,7 +39,8 @@ class TestSigmoid(unittest.TestCase):
         y.backward()
 
         func = y.creator
-        f = lambda: func.forward((x.data,))
+
+        def f(): return func.forward((x.data,))
         gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
 
         gradient_check.assert_allclose(gx, x.grad)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -33,17 +33,8 @@ class TestSigmoid(unittest.TestCase):
         self.test_forward_gpu(False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        y = functions.sigmoid(x, use_cudnn=use_cudnn)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-
-        def f(): return func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            functions.Sigmoid(use_cudnn), x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -47,16 +47,9 @@ class TestSoftmax(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, gy_data, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        y = functions.softmax(x, use_cudnn)
-        y.grad = gy_data
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.softmax(x, use_cudnn),
+            x_data, gy_data, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -48,8 +48,7 @@ class TestSoftmax(unittest.TestCase):
 
     def check_backward(self, x_data, gy_data, use_cudnn=True):
         gradient_check.check_backward(
-            lambda x: functions.softmax(x, use_cudnn),
-            x_data, gy_data, eps=1e-2)
+            functions.Softmax(use_cudnn), x_data, gy_data, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
@@ -26,17 +26,8 @@ class TestSoftplus(unittest.TestCase):
         gradient_check.assert_allclose(y_exp, y.data)
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.softplus(x, beta=self.beta)
-        self.assertEqual(y.data.dtype, numpy.float32)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.softplus(x, beta=self.beta), x_data, y_grad)
 
     @condition.retry(3)
     def test_forward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
@@ -27,7 +27,7 @@ class TestSoftplus(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.softplus(x, beta=self.beta), x_data, y_grad)
+            functions.Softplus(beta=self.beta), x_data, y_grad)
 
     @condition.retry(3)
     def test_forward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -32,15 +32,8 @@ class TestTanh(unittest.TestCase):
         self.test_forward_gpu(False)
 
     def check_backward(self, x_data, gy_data, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        y = functions.tanh(x, use_cudnn=use_cudnn)
-        y.grad = gy_data
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.tanh(x, use_cudnn=use_cudnn), x_data, gy_data)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -33,7 +33,7 @@ class TestTanh(unittest.TestCase):
 
     def check_backward(self, x_data, gy_data, use_cudnn=True):
         gradient_check.check_backward(
-            lambda x: functions.tanh(x, use_cudnn=use_cudnn), x_data, gy_data)
+            functions.Tanh(use_cudnn), x_data, gy_data)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
@@ -51,22 +51,8 @@ class TestBroadcast(unittest.TestCase):
         self.check_forward([cuda.to_gpu(x) for x in self.data])
 
     def check_backward(self, data, grads):
-        xs = [chainer.Variable(x) for x in data]
-        bxs = functions.broadcast(*xs)
-
-        # When len(xs) == 1, function returns a Variable object
-        if isinstance(bxs, chainer.Variable):
-            bxs = (bxs,)
-
-        func = bxs[0].creator
-        f = lambda: func.forward(data)
-
-        for i, (bx, grad) in enumerate(zip(bxs, grads)):
-            bx.grad = grad
-            bx.backward()
-            gxs = gradient_check.numerical_grad(
-                f, data, tuple(bx.grad for bx in bxs))
-            gradient_check.assert_allclose(gxs[i], xs[i].grad)
+        gradient_check.check_backward(
+            functions.broadcast, data, grads)
 
     def test_backward_cpu(self):
         self.check_backward(self.data, self.grads)

--- a/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
@@ -114,16 +114,8 @@ class TestBroadcastTo(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.data))
 
     def check_backward(self, data, grad):
-        x = chainer.Variable(data)
-        bx = functions.broadcast_to(x, self.out_shape)
-
-        func = bx.creator
-        f = lambda: func.forward((data,))
-
-        bx.grad = grad
-        bx.backward()
-        gx, = gradient_check.numerical_grad(f, (data,), (bx.grad,))
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            functions.BroadcastTo(self.out_shape), data, grad)
 
     def test_backward_cpu(self):
         self.check_backward(self.data, self.grad)

--- a/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
@@ -52,7 +52,7 @@ class TestBroadcast(unittest.TestCase):
 
     def check_backward(self, data, grads):
         gradient_check.check_backward(
-            functions.broadcast, data, grads)
+            functions.Broadcast(), data, grads)
 
     def test_backward_cpu(self):
         self.check_backward(self.data, self.grads)

--- a/tests/chainer_tests/functions_tests/array_tests/test_expand_dims.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_expand_dims.py
@@ -35,16 +35,9 @@ class TestExpandDims(unittest.TestCase):
         numpy.testing.assert_array_equal(cuda.to_cpu(y.data), y_expect)
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.expand_dims(x, self.axis)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x_data,))
-        gx, = gradient_check.numerical_grad(f, (x_data,), (y_grad,))
-        gradient_check.assert_allclose(cuda.to_cpu(x.grad),
-                                       cuda.to_cpu(gx))
+        gradient_check.check_backward(
+            lambda x: functions.expand_dims(x, self.axis),
+            x_data, y_grad)
 
     def test_forward_cpu(self):
         self.check_forward(self.x)

--- a/tests/chainer_tests/functions_tests/array_tests/test_expand_dims.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_expand_dims.py
@@ -36,8 +36,7 @@ class TestExpandDims(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.expand_dims(x, self.axis),
-            x_data, y_grad)
+            functions.ExpandDims(self.axis), x_data, y_grad)
 
     def test_forward_cpu(self):
         self.check_forward(self.x)

--- a/tests/chainer_tests/functions_tests/array_tests/test_reshape.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_reshape.py
@@ -5,6 +5,7 @@ import numpy
 import chainer
 from chainer import cuda
 from chainer import functions
+from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 
@@ -31,13 +32,9 @@ class TestReshape(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.reshape(x, self.gy.shape)
-        y.grad = y_grad
-        y.backward()
-
-        shape = self.x.shepe
-        self.assertTrue((self.gy.reshape(shape) == cuda.to_cpu(x.grad)).all())
+        gradient_check.check_backward(
+            lambda x: functions.reshape(x, self.gy.shape),
+            x_data, y_grad)
 
 
 class TestReshapeUnknownDimension(TestReshape):

--- a/tests/chainer_tests/functions_tests/array_tests/test_reshape.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_reshape.py
@@ -33,8 +33,7 @@ class TestReshape(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.reshape(x, self.gy.shape),
-            x_data, y_grad)
+            functions.Reshape(self.gy.shape), x_data, y_grad)
 
 
 class TestReshapeUnknownDimension(TestReshape):

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -40,7 +40,7 @@ class TestSelectItem(unittest.TestCase):
 
     def check_backward(self, x_data, t_data, gy_data):
         gradient_check.check_backward(
-            functions.select_item,
+            functions.SelectItem(),
             (x_data, t_data), gy_data, eps=0.01)
 
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -39,18 +39,9 @@ class TestSelectItem(unittest.TestCase):
                            cuda.to_gpu(self.t_data))
 
     def check_backward(self, x_data, t_data, gy_data):
-        x = chainer.Variable(x_data)
-        t = chainer.Variable(t_data)
-        y = functions.select_item(x, t)
-        y.grad = gy_data
-        y.backward()
-        self.assertEqual(None, t.grad)
-
-        func = y.creator
-        f = lambda: func.forward((x.data, t.data))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (gy_data,), eps=0.01)
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            functions.select_item,
+            (x_data, t_data), gy_data, eps=0.01)
 
     def test_backward_cpu(self):
         self.check_backward(self.x_data, self.t_data, self.gy_data)

--- a/tests/chainer_tests/functions_tests/array_tests/test_swapaxes.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_swapaxes.py
@@ -34,16 +34,9 @@ class TestSwapaxes(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.swapaxes(x, self.axis1, self.axis2)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data.copy(),))
-
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1e-5)
-        gradient_check.assert_allclose(gx, x.grad, rtol=1e-5)
+        gradient_check.check_backward(
+            lambda x: functions.swapaxes(x, self.axis1, self.axis2),
+            x_data, y_grad, eps=1e-5, rtol=1e-5)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/array_tests/test_swapaxes.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_swapaxes.py
@@ -35,7 +35,7 @@ class TestSwapaxes(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.swapaxes(x, self.axis1, self.axis2),
+            functions.Swapaxes(self.axis1, self.axis2),
             x_data, y_grad, eps=1e-5, rtol=1e-5)
 
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
@@ -33,7 +33,7 @@ class TestTranspose(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.transpose(x, self.axes),
+            functions.Transpose(self.axes),
             x_data, y_grad, eps=1e-5, rtol=1e-5)
 
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
@@ -32,17 +32,9 @@ class TestTranspose(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.transpose(x, self.axes)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data.copy(),))
-
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1e-5)
-
-        gradient_check.assert_allclose(gx, x.grad, rtol=1e-5)
+        gradient_check.check_backward(
+            lambda x: functions.transpose(x, self.axes),
+            x_data, y_grad, eps=1e-5, rtol=1e-5)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/array_tests/test_where.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_where.py
@@ -50,7 +50,7 @@ class TestWhere(unittest.TestCase):
 
     def check_backward(self, c_data, x_data, y_data, g_data):
         gradient_check.check_backward(
-            F.where, (c_data, x_data, y_data), g_data)
+            F.Where(), (c_data, x_data, y_data), g_data)
 
     def test_backward_cpu(self):
         self.check_backward(self.c_data, self.x_data, self.y_data, self.g_data)

--- a/tests/chainer_tests/functions_tests/array_tests/test_where.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_where.py
@@ -49,22 +49,8 @@ class TestWhere(unittest.TestCase):
                            cuda.to_gpu(self.y_data))
 
     def check_backward(self, c_data, x_data, y_data, g_data):
-        c = chainer.Variable(c_data)
-        x = chainer.Variable(x_data)
-        y = chainer.Variable(y_data)
-
-        z = F.where(c, x, y)
-        z.grad = g_data
-
-        z.backward()
-
-        func = z.creator
-        f = lambda: func.forward((c.data, x.data, y.data))
-
-        gx, gy = gradient_check.numerical_grad(f, (x_data, y.data), (g_data,))
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gy, y.grad)
-        self.assertIs(c.grad, None)
+        gradient_check.check_backward(
+            F.where, (c_data, x_data, y_data), g_data)
 
     def test_backward_cpu(self):
         self.check_backward(self.c_data, self.x_data, self.y_data, self.g_data)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -60,30 +60,18 @@ class TestConvolution2DFunction(unittest.TestCase):
         self.test_forward_consistency(nobias=True)
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
-        x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
-        b = None if b_data is None else chainer.Variable(b_data)
-        y = functions.convolution_2d(
-            x, W, b, stride=self.stride, pad=self.pad,
-            use_cudnn=self.use_cudnn)
-
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        if b is None:
-            f = lambda: func.forward((x.data, W.data))
-            gx, gW = gradient_check.numerical_grad(
-                f, (x.data, W.data), (y.grad,), eps=1e-2)
+        if b_data is None:
+            gradient_check.check_backward(
+                lambda x, W: functions.convolution_2d(
+                    x, W, None, stride=self.stride, pad=self.pad,
+                    use_cudnn=self.use_cudnn),
+                (x_data, W_data), y_grad, eps=1e-2)
         else:
-            f = lambda: func.forward((x.data, W.data, b.data))
-            gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, W.data, b.data), (y.grad,), eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gW, W.grad)
-        if b is not None:
-            gradient_check.assert_allclose(gb, b.grad)
+            gradient_check.check_backward(
+                lambda x, W, b: functions.convolution_2d(
+                    x, W, b, stride=self.stride, pad=self.pad,
+                    use_cudnn=self.use_cudnn),
+                (x_data, W_data, b_data), y_grad, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -79,29 +79,18 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         self.test_forward_consistency()
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
-        x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
-        b = None if b_data is None else chainer.Variable(b_data)
-        y = F.deconvolution_2d(x, W, b, stride=self.stride, pad=self.pad,
-                               use_cudnn=self.use_cudnn)
-
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        if b is None:
-            f = lambda: func.forward((x.data, W.data))
-            gx, gW = gradient_check.numerical_grad(
-                f, (x.data, W.data), (y.grad,), eps=1e-2)
+        if b_data is None:
+            gradient_check.check_backward(
+                lambda x, W: F.deconvolution_2d(
+                    x, W, None, stride=self.stride, pad=self.pad,
+                    use_cudnn=self.use_cudnn),
+                (x_data, W_data), y_grad, eps=1e-2)
         else:
-            f = lambda: func.forward((x.data, W.data, b.data))
-            gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, W.data, b.data), (y.grad,), eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gW, W.grad)
-        if b is not None:
-            gradient_check.assert_allclose(gb, b.grad)
+            gradient_check.check_backward(
+                lambda x, W, b: F.deconvolution_2d(
+                    x, W, b, stride=self.stride, pad=self.pad,
+                    use_cudnn=self.use_cudnn),
+                (x_data, W_data, b_data), y_grad, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -5,6 +5,7 @@ import numpy
 import chainer
 from chainer import cuda
 import chainer.functions as F
+from chainer.functions.connection import deconvolution_2d
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
@@ -79,18 +80,14 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         self.test_forward_consistency()
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
-        if b_data is None:
-            gradient_check.check_backward(
-                lambda x, W: F.deconvolution_2d(
-                    x, W, None, stride=self.stride, pad=self.pad,
-                    use_cudnn=self.use_cudnn),
-                (x_data, W_data), y_grad, eps=1e-2)
-        else:
-            gradient_check.check_backward(
-                lambda x, W, b: F.deconvolution_2d(
-                    x, W, b, stride=self.stride, pad=self.pad,
-                    use_cudnn=self.use_cudnn),
-                (x_data, W_data, b_data), y_grad, eps=1e-2)
+        args = (x_data, W_data)
+        if b_data is not None:
+            args = args + (b_data,)
+
+        gradient_check.check_backward(
+            deconvolution_2d.Deconvolution2DFunction(
+                self.stride, self.pad, self.outsize, self.use_cudnn),
+            args, y_grad, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
@@ -57,27 +57,13 @@ class TestNonparameterizedLinear(unittest.TestCase):
             cuda.to_gpu(self.x.dot(self.W.T)))
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
-        x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
-        b = None if b_data is None else chainer.Variable(b_data)
-        y = functions.linear(x, W, b)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
         if b_data is None:
-            f = lambda: func.forward((x.data, W.data))
-            gx, gW = gradient_check.numerical_grad(
-                f, (x.data, W.data), (y.grad,), eps=1e-2)
+            gradient_check.check_backward(
+                lambda x, W: functions.linear(x, W, None),
+                (x_data, W_data), y_grad, eps=1e-2)
         else:
-            f = lambda: func.forward((x.data, W.data, b.data))
-            gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, W.data, b.data), (y.grad,), eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gW, W.grad)
-        if b_data is not None:
-            gradient_check.assert_allclose(gb, b.grad)
+            gradient_check.check_backward(
+                functions.linear, (x_data, W_data, b_data), y_grad, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
@@ -5,6 +5,7 @@ import numpy
 import chainer
 from chainer import cuda
 from chainer import functions
+from chainer.functions.connection import linear
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
@@ -57,13 +58,12 @@ class TestNonparameterizedLinear(unittest.TestCase):
             cuda.to_gpu(self.x.dot(self.W.T)))
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
-        if b_data is None:
-            gradient_check.check_backward(
-                lambda x, W: functions.linear(x, W, None),
-                (x_data, W_data), y_grad, eps=1e-2)
-        else:
-            gradient_check.check_backward(
-                functions.linear, (x_data, W_data, b_data), y_grad, eps=1e-2)
+        args = (x_data, W_data)
+        if b_data is not None:
+            args = args + (b_data,)
+
+        gradient_check.check_backward(
+            linear.LinearFunction(), args, y_grad, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -66,20 +66,9 @@ class TestContrastive(unittest.TestCase):
                            cuda.to_gpu(self.t))
 
     def check_backward(self, x0_data, x1_data, t_data):
-        x0 = chainer.Variable(x0_data)
-        x1 = chainer.Variable(x1_data)
-        t = chainer.Variable(t_data)
-        loss = functions.contrastive(x0, x1, t, self.margin)
-        loss.backward()
-        self.assertEqual(None, t.grad)
-
-        func = loss.creator
-        f = lambda: func.forward((x0.data, x1.data, t.data))
-        gx0, = gradient_check.numerical_grad(f, (x0.data,), (1,))
-        gx1, = gradient_check.numerical_grad(f, (x1.data,), (1,))
-
-        gradient_check.assert_allclose(gx0, x0.grad, rtol=1e-4, atol=1e-4)
-        gradient_check.assert_allclose(gx1, x1.grad, rtol=1e-4, atol=1e-4)
+        gradient_check.check_backward(
+            lambda x0, x1, t: functions.contrastive(x0, x1, t, self.margin),
+            (x0_data, x1_data, t_data), None, rtol=1e-4, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -67,7 +67,7 @@ class TestContrastive(unittest.TestCase):
 
     def check_backward(self, x0_data, x1_data, t_data):
         gradient_check.check_backward(
-            lambda x0, x1, t: functions.contrastive(x0, x1, t, self.margin),
+            functions.Contrastive(self.margin),
             (x0_data, x1_data, t_data), None, rtol=1e-4, atol=1e-4)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
@@ -55,7 +55,7 @@ class TestCrossCovariance(unittest.TestCase):
 
     def check_backward(self, y_data, z_data):
         gradient_check.check_backward(
-            functions.cross_covariance, (y_data, z_data), None, eps=0.02)
+            functions.CrossCovariance(), (y_data, z_data), None, eps=0.02)
 
     def check_type(self, y_data, z_data):
         y = chainer.Variable(y_data)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
@@ -54,19 +54,8 @@ class TestCrossCovariance(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.y), cuda.to_gpu(self.z))
 
     def check_backward(self, y_data, z_data):
-        y = chainer.Variable(y_data)
-        z = chainer.Variable(z_data)
-        loss = functions.cross_covariance(y, z)
-        scaled_loss = 0.5 * loss
-        scaled_loss.backward()
-
-        func = loss.creator
-        f = lambda: func.forward((y.data, z.data))
-        gy, gz = gradient_check.numerical_grad(f, (y.data, z.data),
-                                               (0.5,), eps=0.02)
-
-        gradient_check.assert_allclose(gy, y.grad)
-        gradient_check.assert_allclose(gz, z.grad)
+        gradient_check.check_backward(
+            functions.cross_covariance, (y_data, z_data), None, eps=0.02)
 
     def check_type(self, y_data, z_data):
         y = chainer.Variable(y_data)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -80,9 +80,8 @@ class TestCTC(unittest.TestCase):
     # expected value(via numerical differentiation) from t_data
     def check_backward(self, t_data, xs_data):
         gradient_check.check_backward(
-            lambda *args: functions.connectionist_temporal_classification(
-                args[:-1], args[-1], 2),
-            xs_data + (t_data,), self.g, atol=1e-4)
+            functions.ConnectionistTemporalClassification(2),
+            (t_data,) + xs_data, self.g, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -79,21 +79,10 @@ class TestCTC(unittest.TestCase):
 
     # expected value(via numerical differentiation) from t_data
     def check_backward(self, t_data, xs_data):
-        xs = tuple(chainer.Variable(x_data) for x_data in xs_data)
-        t = chainer.Variable(t_data)
-        loss = functions.connectionist_temporal_classification(xs, t, 2)
-        loss.grad = self.g
-        loss.backward()
-
-        func = loss.creator
-        xs_data = tuple(x.data for x in xs)
-        f = lambda: func.forward((t.data,) + xs_data)
-        gl_0, gx_0, gx_1, gx_2, gx_3 = gradient_check.numerical_grad(
-            f, ((t.data,) + xs_data), (self.gx,))
-        gradient_check.assert_allclose(xs[0].grad, gx_0, atol=1e-04)
-        gradient_check.assert_allclose(xs[1].grad, gx_1, atol=1e-04)
-        gradient_check.assert_allclose(xs[2].grad, gx_2, atol=1e-04)
-        gradient_check.assert_allclose(xs[3].grad, gx_3, atol=1e-04)
+        gradient_check.check_backward(
+            lambda *args: functions.connectionist_temporal_classification(
+                args[:-1], args[-1], 2),
+            xs_data + (t_data,), self.g, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -39,9 +39,9 @@ class TestCTC(unittest.TestCase):
                 (self.alpha(x, l, t-1, u-1) + self.alpha(x, l, t-1, u))
         else:
             return x[t][l[u]] * \
-                (self.alpha(x, l, t-1, u-2)
-                 + self.alpha(x, l, t-1, u-1)
-                 + self.alpha(x, l, t-1, u))
+                (self.alpha(x, l, t-1, u-2) +
+                 self.alpha(x, l, t-1, u-1) +
+                 self.alpha(x, l, t-1, u))
 
     def check_forward(self, t_data, xs_data):
         x = tuple(chainer.Variable(x_data) for x_data in xs_data)
@@ -61,11 +61,11 @@ class TestCTC(unittest.TestCase):
             loss_expect += -math.log(self.alpha(xt[b],
                                                 self.l[b],
                                                 self.x.shape[0]-1,
-                                                self.l[b].shape[0]-1)
-                                     + self.alpha(xt[b],
-                                                  self.l[b],
-                                                  self.x.shape[0]-1,
-                                                  self.l[b].shape[0]-2))
+                                                self.l[b].shape[0]-1) +
+                                     self.alpha(xt[b],
+                                                self.l[b],
+                                                self.x.shape[0]-1,
+                                                self.l[b].shape[0]-2))
         loss_expect /= batch_size
         self.assertAlmostEqual(loss_expect, loss_value, places=5)
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -62,8 +62,7 @@ class TestHinge(unittest.TestCase):
 
     def check_backward(self, x_data, t_data, norm):
         gradient_check.check_backward(
-            lambda x, t: functions.hinge(x, t, norm),
-            (x_data, t_data), None, eps=0.01, atol=1e-4)
+            functions.Hinge(norm), (x_data, t_data), None, eps=0.01, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu_l1(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -61,17 +61,9 @@ class TestHinge(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), 'L2')
 
     def check_backward(self, x_data, t_data, norm):
-        x = chainer.Variable(x_data)
-        t = chainer.Variable(t_data)
-        loss = functions.hinge(x, t, norm)
-        loss.backward()
-        self.assertEqual(None, t.grad)
-
-        func = loss.creator
-        f = lambda: func.forward((x.data, t.data))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (1,), eps=0.01)
-
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-4)
+        gradient_check.check_backward(
+            lambda x, t: functions.hinge(x, t, norm),
+            (x_data, t_data), None, eps=0.01, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu_l1(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
@@ -43,20 +43,9 @@ class TestMeanSquaredError(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
 
     def check_backward(self, x0_data, x1_data):
-        x0 = chainer.Variable(x0_data)
-        x1 = chainer.Variable(x1_data)
-        loss = functions.mean_squared_error(x0, x1)
-        loss.backward()
-
-        func = loss.creator
-        f = lambda: func.forward((x0.data, x1.data))
-        gx0, gx1 = gradient_check.numerical_grad(
-            f, (x0.data, x1.data), (1,), eps=1e-2)
-
-        gradient_check.assert_allclose(gx0, x0.grad)
-        gradient_check.assert_allclose(gx1, x1.grad)
-        self.assertEqual(x0.grad.dtype, numpy.float32)
-        self.assertEqual(x1.grad.dtype, numpy.float32)
+        gradient_check.check_backward(
+            functions.mean_squared_error,
+            (x0_data, x1_data), None, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
@@ -44,7 +44,7 @@ class TestMeanSquaredError(unittest.TestCase):
 
     def check_backward(self, x0_data, x1_data):
         gradient_check.check_backward(
-            functions.mean_squared_error,
+            functions.MeanSquaredError(),
             (x0_data, x1_data), None, eps=1e-2)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -77,7 +77,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
             return
 
         gradient_check.check_backward(
-            lambda x, t: functions.sigmoid_cross_entropy(x, t, use_cudnn),
+            functions.SigmoidCrossEntropy(use_cudnn),
             (x_data, t_data), None, eps=1e-2)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -61,17 +61,9 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)
 
     def check_backward(self, x_data, t_data, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        t = chainer.Variable(t_data)
-        loss = functions.softmax_cross_entropy(x, t, use_cudnn)
-        loss.backward()
-        self.assertEqual(None, t.grad)
-
-        func = loss.creator
-        f = lambda: func.forward((x.data, t.data))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (1,), eps=0.02)
-
-        gradient_check.assert_allclose(gx, x.grad, atol=self.backward_atol)
+        gradient_check.check_backward(
+            lambda x, t: functions.softmax_cross_entropy(x, t, use_cudnn),
+            (x_data, t_data), None, eps=0.02, atol=self.backward_atol)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -62,7 +62,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
     def check_backward(self, x_data, t_data, use_cudnn=True):
         gradient_check.check_backward(
-            lambda x, t: functions.softmax_cross_entropy(x, t, use_cudnn),
+            functions.SoftmaxCrossEntropy(use_cudnn),
             (x_data, t_data), None, eps=0.02, atol=self.backward_atol)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -20,9 +20,9 @@ class TestGaussianKLDivergence(unittest.TestCase):
         # Refer to Appendix B in the original paper
         # Auto-Encoding Variational Bayes (http://arxiv.org/abs/1312.6114)
         J = self.mean.size
-        self.expect = -(J + numpy.sum(self.ln_var)
-                        - numpy.sum(self.mean * self.mean)
-                        - numpy.sum(numpy.exp(self.ln_var))) * 0.5
+        self.expect = -(J + numpy.sum(self.ln_var) -
+                        numpy.sum(self.mean * self.mean) -
+                        numpy.sum(numpy.exp(self.ln_var))) * 0.5
 
     def check_gaussian_kl_divergence(self, mean, ln_var):
         m = chainer.Variable(mean)
@@ -50,8 +50,8 @@ class TestBernoulliNLL(unittest.TestCase):
         # Refer to Appendix C.1 in the original paper
         # Auto-Encoding Variational Bayes (http://arxiv.org/abs/1312.6114)
         p = 1 / (1 + numpy.exp(-self.y))
-        self.expect = - (numpy.sum(self.x * numpy.log(p))
-                         + numpy.sum((1 - self.x) * numpy.log(1 - p)))
+        self.expect = - (numpy.sum(self.x * numpy.log(p)) +
+                         numpy.sum((1 - self.x) * numpy.log(1 - p)))
 
     def check_bernoulli_nll(self, x_data, y_data):
         x = chainer.Variable(x_data)
@@ -83,9 +83,9 @@ class TestGaussianNLL(unittest.TestCase):
         x_d = self.x - self.mean
         var = numpy.exp(self.ln_var)
 
-        self.expect = (0.5 * D * numpy.log(2 * numpy.pi)
-                       + 0.5 * numpy.sum(self.ln_var)
-                       + numpy.sum(x_d * x_d / var) * 0.5)
+        self.expect = (0.5 * D * numpy.log(2 * numpy.pi) +
+                       0.5 * numpy.sum(self.ln_var) +
+                       numpy.sum(x_d * x_d / var) * 0.5)
 
     def check_gaussian_nll(self, x_data, mean_data, ln_var_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/math_tests/test_exponential.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_exponential.py
@@ -50,16 +50,7 @@ class UnaryFunctionsTestBase(object):
         self.check_forward_gpu(F.log, numpy.log)
 
     def check_backward(self, op, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = op(x)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(op, x_data, y_grad)
 
     def check_backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -30,18 +30,8 @@ class _TestMatMul(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
     def check_backward(self, x1_data, x2_data, y_grad, atol):
-        x1 = chainer.Variable(x1_data)
-        x2 = chainer.Variable(x2_data)
-        y = self.op(x1, x2)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x1.data, x2.data))
-        gx1, gx2 = gradient_check.numerical_grad(
-            f, (x1.data, x2.data), (y.grad,))
-        gradient_check.assert_allclose(gx1, x1.grad, atol=atol)
-        gradient_check.assert_allclose(gx2, x2.grad, atol=atol)
+        gradient_check.check_backward(
+            self.op, (x1_data, x2_data), y_grad, atol=atol)
 
     @condition.retry(3)
     def test_matmul_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
@@ -77,16 +77,9 @@ class TestMax(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), axis=(-2, 0))
 
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
-        x = chainer.Variable(x_data)
-        y = functions.max(x, axis=axis, keepdims=keepdims)
-
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data.copy(),))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1e-5)
-        gradient_check.assert_allclose(gx, x.grad, rtol=1e-3, atol=1e-3)
+        gradient_check.check_backward(
+            lambda x: functions.max(x, axis=axis, keepdims=keepdims),
+            x_data, y_grad, eps=1e-5, rtol=1e-3, atol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -249,16 +242,9 @@ class TestMin(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), axis=(-2, 0))
 
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
-        x = chainer.Variable(x_data)
-        y = functions.min(x, axis=axis, keepdims=keepdims)
-
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data.copy(),))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1e-5)
-        gradient_check.assert_allclose(gx, x.grad, rtol=1e-3, atol=1e-3)
+        gradient_check.check_backward(
+            lambda x: functions.min(x, axis=axis, keepdims=keepdims),
+            x_data, y_grad, eps=1e-4, rtol=1e-3, atol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
@@ -78,7 +78,7 @@ class TestMax(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
         gradient_check.check_backward(
-            lambda x: functions.max(x, axis=axis, keepdims=keepdims),
+            functions.Max(axis, keepdims),
             x_data, y_grad, eps=1e-5, rtol=1e-3, atol=1e-3)
 
     @condition.retry(3)
@@ -243,7 +243,7 @@ class TestMin(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
         gradient_check.check_backward(
-            lambda x: functions.min(x, axis=axis, keepdims=keepdims),
+            functions.Min(axis=axis, keepdims=keepdims),
             x_data, y_grad, eps=1e-4, rtol=1e-3, atol=1e-3)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sum.py
@@ -91,7 +91,7 @@ class TestSum(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad, axis=None):
         gradient_check.check_backward(
-            lambda x: functions.sum(x, axis=axis), x_data, y_grad)
+            functions.Sum(axis), x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_sum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sum.py
@@ -90,14 +90,8 @@ class TestSum(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), axis=(-2, 0))
 
     def check_backward(self, x_data, y_grad, axis=None):
-        x = chainer.Variable(x_data)
-        y = functions.sum(x, axis=axis)
-
-        y.grad = y_grad
-        y.backward()
-
-        gx_expect = numpy.full_like(self.x, self.gy)
-        gradient_check.assert_allclose(gx_expect, x.grad)
+        gradient_check.check_backward(
+            lambda x: functions.sum(x, axis=axis), x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
@@ -50,16 +50,7 @@ class UnaryFunctionsTestBase(object):
         self.check_forward_gpu(F.sin, numpy.sin)
 
     def check_backward(self, op, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = op(x)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(op, (x_data,), y_grad)
 
     def check_backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
@@ -50,7 +50,7 @@ class UnaryFunctionsTestBase(object):
         self.check_forward_gpu(F.sin, numpy.sin)
 
     def check_backward(self, op, x_data, y_grad):
-        gradient_check.check_backward(op, (x_data,), y_grad)
+        gradient_check.check_backward(op, x_data, y_grad)
 
     def check_backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
@@ -19,7 +19,8 @@ class TestGaussian(unittest.TestCase):
 
     def check_backward(self, m_data, v_data, y_grad):
         gradient_check.check_backward(
-            functions.gaussian, (m_data, v_data), y_grad, atol=1e-4, rtol=1e-3)
+            functions.gaussian, (m_data, v_data), y_grad,
+            atol=1e-4, rtol=1e-3, use_creator=True)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy
 
-import chainer
 from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
@@ -19,19 +18,8 @@ class TestGaussian(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
 
     def check_backward(self, m_data, v_data, y_grad):
-        m = chainer.Variable(m_data)
-        v = chainer.Variable(v_data)
-        y = functions.gaussian(m, v)
-        self.assertEqual(y.data.dtype, numpy.float32)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((m.data, v.data))
-        gm, gv = gradient_check.numerical_grad(f, (m.data, v.data), (y.grad,))
-
-        gradient_check.assert_allclose(gm, m.grad, atol=1e-4, rtol=1e-3)
-        gradient_check.assert_allclose(gv, v.grad, atol=1e-4, rtol=1e-3)
+        gradient_check.check_backward(
+            functions.gaussian, (m_data, v_data), y_grad, atol=1e-4, rtol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
@@ -19,8 +19,8 @@ class TestGaussian(unittest.TestCase):
 
     def check_backward(self, m_data, v_data, y_grad):
         gradient_check.check_backward(
-            functions.gaussian, (m_data, v_data), y_grad,
-            atol=1e-4, rtol=1e-3, use_creator=True)
+            functions.Gaussian(), (m_data, v_data), y_grad,
+            atol=1e-4, rtol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_local_response_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_local_response_normalization.py
@@ -47,16 +47,9 @@ class TestLocalResponseNormalization(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.local_response_normalization(x)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1)
-
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-3)
+        gradient_check.check_backward(
+            functions.local_response_normalization, x_data, y_grad,
+            eps=1, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_local_response_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_local_response_normalization.py
@@ -48,7 +48,7 @@ class TestLocalResponseNormalization(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            functions.local_response_normalization, x_data, y_grad,
+            functions.LocalResponseNormalization(), x_data, y_grad,
             eps=1, atol=1e-4)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -52,8 +52,7 @@ class TestAveragePooling2D(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
         gradient_check.check_backward(
-            lambda x: functions.average_pooling_2d(
-                x, 3, stride=2, pad=1, use_cudnn=use_cudnn),
+            functions.AveragePooling2D(3, 2, 1, False, use_cudnn),
             x_data, y_grad, eps=1e-2)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -51,17 +51,10 @@ class TestAveragePooling2D(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        y = functions.average_pooling_2d(x, 3, stride=2,
-                                         pad=1, use_cudnn=use_cudnn)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1e-2)
-
-        gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
+        gradient_check.check_backward(
+            lambda x: functions.average_pooling_2d(
+                x, 3, stride=2, pad=1, use_cudnn=use_cudnn),
+            x_data, y_grad, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -72,18 +72,11 @@ class TestMaxPooling2D(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        y = functions.max_pooling_2d(x, 3, stride=2, pad=1,
-                                     cover_all=self.cover_all,
-                                     use_cudnn=use_cudnn)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(cuda.to_cpu(gx), cuda.to_cpu(x.grad))
+        gradient_check.check_backward(
+            lambda x: functions.max_pooling_2d(
+                x, 3, stride=2, pad=1, cover_all=self.cover_all,
+                use_cudnn=use_cudnn),
+            x_data, y_grad)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -73,8 +73,8 @@ class TestMaxPooling2D(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
         gradient_check.check_backward(
-            lambda x: functions.max_pooling_2d(
-                x, 3, stride=2, pad=1, cover_all=self.cover_all,
+            functions.MaxPooling2D(
+                3, stride=2, pad=1, cover_all=self.cover_all,
                 use_cudnn=use_cudnn),
             x_data, y_grad)
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -73,8 +73,8 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
         gradient_check.check_backward(
-            lambda x: functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling_class,
+            functions.SpatialPyramidPooling2D(
+                x_data.shape[1:], self.pyramid_height, self.pooling_class,
                 use_cudnn=use_cudnn),
             x_data, y_grad, atol=1e-4)
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -72,20 +72,11 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         self.check_forward_ones(cuda.to_gpu(self.one), False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        x = chainer.Variable(x_data)
-        y = functions.spatial_pyramid_pooling_2d(
-            x, self.pyramid_height, self.pooling_class, use_cudnn=use_cudnn)
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-
-        gradient_check.assert_allclose(
-            cuda.to_cpu(gx),
-            cuda.to_cpu(x.grad),
-            atol=1e-04)
+        gradient_check.check_backward(
+            lambda x: functions.spatial_pyramid_pooling_2d(
+                x, self.pyramid_height, self.pooling_class,
+                use_cudnn=use_cudnn),
+            x_data, y_grad, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -100,6 +100,7 @@ class TestMaxout(unittest.TestCase):
         gradient_check.check_backward(
             self.link, x_data, y_grad, params, eps=1e-4, atol=1e-2)
 
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -92,27 +92,14 @@ class TestMaxout(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y.grad = y_grad
-        y.backward()
-
-        f = lambda: (self.link(x).data, )
         if self.initial_bias is None:
-            gx, gW = gradient_check.numerical_grad(
-                f, (x.data, self.link.W.data),
-                (y.grad, ), eps=1e-4)
+            params = (self.link.W,)
         else:
-            gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, self.link.W.data, self.link.b.data),
-                (y.grad, ), eps=1e-4)
+            params = (self.link.W, self.link.b)
 
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-2)
-        gradient_check.assert_allclose(gW, self.link.W.grad, atol=1e-2)
-        if self.initial_bias is not None:
-            gradient_check.assert_allclose(gb, self.link.b.grad, atol=1e-2)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, params, eps=1e-4, atol=1e-2)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 

--- a/tests/chainer_tests/links_tests/activation_tests/test_prelu.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_prelu.py
@@ -51,18 +51,8 @@ class TestPReLUSingle(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y.grad = y_grad
-        y.backward()
-
-        W = self.link.W
-        link = self.link
-        f = lambda: (link(x).data,)
-        gx, gW = gradient_check.numerical_grad(f, (x.data, W.data), (y.grad,))
-
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gW, W.grad, atol=1e-4)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, self.link.W, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -64,19 +64,8 @@ class TestConvolution2D(unittest.TestCase):
         self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y.grad = y_grad
-        y.backward()
-
-        f = lambda: (self.link(x).data,)
-        gx, gW, gb = gradient_check.numerical_grad(
-            f, (x.data, self.link.W.data, self.link.b.data), (y.grad,),
-            eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gW, self.link.W.grad)
-        gradient_check.assert_allclose(gb, self.link.b.grad)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, (self.link.W, self.link.b), eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -73,22 +73,12 @@ class TestDeconvolution2D(unittest.TestCase):
         self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y.grad = y_grad
-        y.backward()
-
-        f = lambda: (self.link(x).data,)
-        gx, gW = gradient_check.numerical_grad(
-            f, (x.data, self.link.W.data), (y.grad,), eps=1e-2)
+        params = [self.link.W]
         if not self.nobias:
-            gb, = gradient_check.numerical_grad(
-                f, (self.link.b.data,), (y.grad,), eps=1e-2)
+            params.append(self.link.b)
 
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gW, self.link.W.grad)
-        if not self.nobias:
-            gradient_check.assert_allclose(gb, self.link.b.grad)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, params, eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -48,14 +48,8 @@ class TestEmbedID(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y.grad = y_grad
-        y.backward()
-
-        f = lambda: (self.link(x).data,)
-        gW, = gradient_check.numerical_grad(f, (self.link.W.data,), (y.grad,))
-        gradient_check.assert_allclose(gW, self.link.W.grad)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, self.link.W)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_gru.py
@@ -93,7 +93,8 @@ class TestGRU(unittest.TestCase):
         y.grad = y_grad
         y.backward()
 
-        f = lambda: (_gru(self.link, h_data, x_data),)
+        def f():
+            return _gru(self.link, h_data, x_data),
         gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
         gradient_check.assert_allclose(gx, x.grad, atol=1e-3)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_linear.py
@@ -52,19 +52,8 @@ class TestLinear(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y.grad = y_grad
-        y.backward()
-
-        f = lambda: (self.link(x).data,)
-        gx, gW, gb = gradient_check.numerical_grad(
-            f, (x.data, self.link.W.data, self.link.b.data), (y.grad,),
-            eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad)
-        gradient_check.assert_allclose(gW, self.link.W.grad)
-        gradient_check.assert_allclose(gb, self.link.b.grad)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, (self.link.W, self.link.b), eps=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/loss_tests/test_hierarchical_softmax.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_hierarchical_softmax.py
@@ -80,18 +80,9 @@ class TestBinaryHierarchicalSoftmax(unittest.TestCase):
             cpu_loss, cuda.to_cpu(gpu_loss))
 
     def check_backward(self, x_data, t_data, y_grad):
-        x = chainer.Variable(x_data)
-        t = chainer.Variable(t_data)
-        y = self.link(x, t)
-        y.grad = y_grad
-        y.backward()
-
-        f = lambda: (self.link(x, t).data,)
-        gx, _, gW = gradient_check.numerical_grad(
-            f, (x.data, t.data, self.link.W.data), (y.grad,), eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-4)
-        gradient_check.assert_allclose(gW, self.link.W.grad, atol=1e-4)
+        gradient_check.check_backward(
+            self.link, (x_data, t_data), y_grad, self.link.W,
+            eps=1e-2, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py
@@ -31,7 +31,9 @@ class TestNegativeSampling(unittest.TestCase):
 
         # fix samples
         negative_sampling.NegativeSamplingFunction.samples = y.creator.samples
-        f = lambda: (self.link(x, t).data,)
+
+        def f():
+            return (self.link(x, t).data,)
         gx, gW = gradient_check.numerical_grad(
             f, (x.data, W.data), (y.grad,), eps=1e-2)
         del negative_sampling.NegativeSamplingFunction.samples  # clean up

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -37,19 +37,9 @@ class BatchNormalizationTestBase(object):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y.grad = y_grad
-        y.backward()
-
-        f = lambda: (self.link(x).data,)
-        gx, ggamma, gbeta = gradient_check.numerical_grad(
-            f, (x.data, self.link.gamma.data, self.link.beta.data),
-            (y.grad,), eps=1e-2)
-
-        gradient_check.assert_allclose(gx, x.grad, rtol=1e-3, atol=1e-4)
-        gradient_check.assert_allclose(ggamma, self.link.gamma.grad)
-        gradient_check.assert_allclose(gbeta, self.link.beta.grad)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, (self.link.gamma, self.link.beta),
+            eps=1e-2, rtol=1e-3, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -49,7 +49,7 @@ class NumericalGradientTest(unittest.TestCase):
         # matrix-vector multiplication of dfxs and dys
         dx_expect = tuple(map(lambda dfx: _dot(dfx, gys), dfxs))
 
-        func = lambda: f(xs)
+        def func(): return f(xs)
         dx_actual = gradient_check.numerical_grad(func, xs, gys, eps)
 
         print('eps: {}'.format(eps))
@@ -84,8 +84,9 @@ class NumericalGradientTest(unittest.TestCase):
 
 class NumericalGradientTest2(NumericalGradientTest):
 
-    f = lambda self, xs: (1,)
-    df = lambda self, xs: ((0,),)
+    def f(self, xs): return (1,)
+
+    def df(self, xs): return ((0,),)
 
 
 class NumericalGradientTest3(NumericalGradientTest):
@@ -159,7 +160,7 @@ class NumericalGradientReferenceTest(unittest.TestCase):
     def check_reference(self, x):
         # A returned value and an input refers the same memory.
         # See issue #488
-        func = lambda: (x,)
+        def func(): return (x,)
         gx, = gradient_check.numerical_grad(func, (x,), (1,))
         gradient_check.assert_allclose(cuda.to_cpu(gx), 1)
 

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -110,7 +110,8 @@ class TestBinaryOperator(unittest.TestCase):
     def setUp(self):
         x = T.Variable(1, 'x')
         y = T.Variable(1, 'y')
-        f = lambda x, y: (x, y)
+
+        def f(x, y): return (x, y)
         self.op1 = T.BinaryOperator(7, x, y, '+', f)
         self.op2 = T.BinaryOperator(8, x, y, '+', f)
         self.op3 = T.BinaryOperator(9, x, y, '+', f)
@@ -136,7 +137,8 @@ class TestUnaryOperator(unittest.TestCase):
 
     def setUp(self):
         x = T.Variable(1, 'x')
-        f = lambda x: (x,)
+
+        def f(x): return (x,)
         self.op1 = T.UnaryOperator(8, x, '-', f)
         self.op2 = T.UnaryOperator(9, x, '-', f)
 
@@ -273,7 +275,8 @@ class TestBoolBinaryOperator(unittest.TestCase):
         x = T.Variable(1, 'x')
         y = T.Variable(1, 'y')
         z = T.Variable(2, 'z')
-        f = lambda x, y: x == y
+
+        def f(x, y): return x == y
         self.op1 = T.BoolBinaryOperator(x, y, '==', '!=', f)
         self.op2 = T.BoolBinaryOperator(x, z, '==', '!=', f)
 

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -22,24 +22,24 @@ class TestArrayGet(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_contiguous_array(self, dtype):
-        contiguous_array = lambda xp: testing.shaped_arange(
-            (3,), xp=xp, dtype=dtype)
+        def contiguous_array(xp):
+            return testing.shaped_arange((3,), xp=xp, dtype=dtype)
         self.check_get(contiguous_array, None)
 
     @testing.for_all_dtypes()
     def test_non_contiguous_array(self, dtype):
-        non_contiguous_array = lambda xp: testing.shaped_arange(
-            (3,), xp=xp, dtype=dtype)[0::2]
+        def non_contiguous_array(xp):
+            return testing.shaped_arange((3,), xp=xp, dtype=dtype)[0::2]
         self.check_get(non_contiguous_array, None)
 
     @testing.for_all_dtypes()
     def test_contiguous_array_stream(self, dtype):
-        contiguous_array = lambda xp: testing.shaped_arange(
-            (3,), xp=xp, dtype=dtype)
+        def contiguous_array(xp):
+            return testing.shaped_arange((3,), xp=xp, dtype=dtype)
         self.check_get(contiguous_array, self.stream.ptr)
 
     @testing.for_all_dtypes()
     def test_non_contiguous_array_stream(self, dtype):
-        non_contiguous_array = lambda xp: testing.shaped_arange(
-            (3,), xp=xp, dtype=dtype)[0::2]
+        def non_contiguous_array(xp):
+            return testing.shaped_arange((3,), xp=xp, dtype=dtype)[0::2]
         self.check_get(non_contiguous_array, self.stream.ptr)


### PR DESCRIPTION
fix #846 

Main differences are below:
- Fix operator position (W503)
- Make a general backward-checking method and use it in test for functions and links (E731)
- Replace lambda with def (E731)