### PR TITLE
let split_axis generate c-contigous array for cudnn.

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -42,7 +42,8 @@ class SplitAxis(function.Function):
                     raise ValueError('Not support if shape contains 0')
                 prev_i = i
         xp = cuda.get_array_module(*x)
-        return tuple(xp.split(x[0], self.indices_or_sections, self.axis))
+        ret = xp.split(x[0], self.indices_or_sections, self.axis)
+        return tuple([cuda.cupy.ascontiguousarray(xi) for xi in ret])
 
     def backward(self, x, gys):
         xp = cuda.get_array_module(*x)


### PR DESCRIPTION
When I split the last dimension (axis = 3), and use cudnn, I got an error like following:

```
bad array (1, 1, 512, 512)
Traceback (most recent call last):
  File "./main-vaegan.py", line 471, in <module>
    train_vaegan_labeled(gen, enc, dis)
  File "./main-vaegan.py", line 362, in train_vaegan_labeled
    yl_train  = dis(x_train)
  File "./main-vaegan.py", line 272, in __call__
    h = elu(self.c0(x) + self.c0s(x_signal))     # no bn because images from generator will katayotteru?
  File "/home/ubuntu/.local/lib/python2.7/site-packages/chainer/links/connection/convolution_2d.py", line 77, in __call__
    x, self.W, self.b, self.stride, self.pad, self.use_cudnn)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/chainer/functions/connection/convolution_2d.py", line 267, in convolution_2d
    return func(x, W, b)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/chainer/function.py", line 105, in __call__
    outputs = self.forward(in_data)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/chainer/function.py", line 181, in forward
    return self.forward_gpu(inputs)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/chainer/functions/connection/convolution_2d.py", line 75, in forward_gpu
    x_desc = cudnn.create_tensor_descriptor(x)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/cupy/cudnn.py", line 65, in create_tensor_descriptor
    raise ValueError('Supoorts c-contigous array only')
ValueError: Supoorts c-contigous array only
```

It seems that splitting the 3rd axis generates non c-contigous array.

This patch fixed the above error.