### PR TITLE
Fix the order of dimentsions of Maxout's weight tensor and bias vector.

### DIFF
--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -19,9 +19,9 @@ class Maxout(link.Link):
 
     Attributes:
         W (~chainer.Variable): Weight tensor with shape
-            ``(in_size, num_channel, out_size)``.
+            ``(in_size, out_size, num_channel)``.
         b (~chainer.Variable): Bias vector with shape
-            ``(num_channel, out_size)``.
+            ``(out_size, num_channel)``.
 
     .. seealso:: :func:`~chainer.functions.maxout`
 
@@ -35,14 +35,14 @@ class Maxout(link.Link):
 
     def __init__(self, in_size, num_channel, out_size,
                  wscale=1, initialW=None, initial_bias=0):
-        super(Maxout, self).__init__(W=(in_size, num_channel, out_size))
+        super(Maxout, self).__init__(W=(in_size, out_size, num_channel))
         if initialW is None:
             initialW = numpy.random.normal(
                 0, wscale * numpy.sqrt(1. / in_size), self.W.data.shape)
         self.W.data[...] = initialW
 
         if initial_bias is not None:
-            self.add_param('b', (num_channel, out_size))
+            self.add_param('b', (out_size, num_channel))
             self.b.data[...] = initial_bias
         else:
             self.b = None

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -47,7 +47,7 @@ class TestNonparameterizedMaxout(unittest.TestCase):
             self.b = None
 
         self.x = numpy.random.uniform(
-            -0.01, 0.01, self.x_shape).astype(numpy.float32)
+            -0.01, 0.01, self.x_shape).astype(numpy.float32) + 1
 
         self.y = _maxout(self.x, self.W, self.b)
         self.gy = numpy.random.uniform(

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -22,7 +22,7 @@ def _maxout(x, W, b):
     y = numpy.tensordot(_as_mat(x), W, axes=1)
     if b is not None:
         y += b
-    return numpy.max(y, axis=1)
+    return numpy.max(y, axis=2)
 
 
 @testing.parameterize(
@@ -35,10 +35,10 @@ class TestNonparameterizedMaxout(unittest.TestCase):
     def setUp(self):
         self.W = numpy.random.uniform(
             -0.01, 0.01, self.W_shape).astype(numpy.float32)
-        for c in six.moves.range(self.W.shape[1]):
+        for o in six.moves.range(self.W.shape[1]):
             w = numpy.arange(self.W.shape[0], dtype=numpy.float32) + 1
-            for o in six.moves.range(self.W.shape[2]):
-                self.W[:, c, o] += w * o
+            for c in six.moves.range(self.W.shape[2]):
+                self.W[:, o, c] += w * c
 
         if self.b_shape is not None:
             self.b = numpy.random.uniform(

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -23,7 +23,7 @@ def _maxout(x, W, b):
     y = numpy.tensordot(_as_mat(x), W, axes=1)
     if b is not None:
         y += b
-    return numpy.max(y, axis=1)
+    return numpy.max(y, axis=2)
 
 
 @testing.parameterize(
@@ -52,17 +52,17 @@ class TestMaxout(unittest.TestCase):
 
         in_size = numpy.prod(self.in_shape)
         initialW = numpy.random.uniform(
-            -0.05, 0.05, (in_size, self.num_channel, self.out_size)
+            -0.05, 0.05, (in_size, self.out_size, self.num_channel)
         ).astype(numpy.float32)
-        for c in six.moves.range(self.num_channel):
+        for o in six.moves.range(self.out_size):
             w = numpy.arange(in_size, dtype=numpy.float32) + 1
-            for o in six.moves.range(self.out_size):
-                initialW[:, c, o] += w * o
+            for c in six.moves.range(self.num_channel):
+                initialW[:, o, c] += w * c
 
         initial_bias = None
         if self.initial_bias == 'random':
             initial_bias = numpy.random.uniform(
-                -0.05, 0.05, (self.num_channel, self.out_size))
+                -0.05, 0.05, (self.out_size, self.num_channel))
 
         self.link = links.Maxout(in_size, self.num_channel, self.out_size,
                                  self.wscale, initialW, initial_bias)
@@ -139,9 +139,9 @@ class TestInitialization(unittest.TestCase):
 
     def setUp(self):
         self.initialW = numpy.random.uniform(
-            -1, 1, (2, 3, 4)).astype(numpy.float32)
+            -1, 1, (2, 4, 3)).astype(numpy.float32)
         self.initial_bias = numpy.random.uniform(
-            -1, 1, (3, 4)).astype(numpy.float32)
+            -1, 1, (4, 3)).astype(numpy.float32)
         self.link = links.Maxout(
             2, 3, 4, initialW=self.initialW,
             initial_bias=self.initial_bias)


### PR DESCRIPTION
Fix #849 

I am wondering we should change the order of argument of `chainer.links.Maxout.__init__` from `(self, in_size, num_channels, out_size, ...)` to `(self, in_size, out_size, num_channels, ...)`.