### PR TITLE
Fix Maxout and make it Chain

### DIFF
--- a/chainer/functions/activation/maxout.py
+++ b/chainer/functions/activation/maxout.py
@@ -3,35 +3,36 @@ from chainer.functions.math import minmax
 
 
 def maxout(x, pool_size, axis=1):
-    """Maxout activation function
+    """Maxout activation function.
 
     It accepts an input tensor ``x``, reshapes the ``axis`` dimension
-    (say the size being ``M * pool_size``) into two dimensional tensor
-    ``(M, pool_size)`` and takes maximum along the ``axis`` dimension
+    (say the size being ``M * pool_size``) into two dimensions
+    ``(M, pool_size)``, and takes maximum along the ``axis`` dimension.
     The output of this function is same as ``x`` except that ``axis`` dimension
     is transformed from ``M * pool_size`` to ``M``.
 
-    Typically, ``x`` is the output of Linear Layer or Convolution Layer.
+    Typically, ``x`` is the output of a linear layer or a convolution layer.
     The following is the example where we use :func:`maxout` in combination
-    with Linear Link.
+    with a Linear link.
 
     >>> l = L.Linear(in_size, out_size * pool_size)
     ... x = Variable(...)  # prepare data
-    ... x = linear(x)
+    ... x = l(x)
     ... y = maxout(x, pool_size)
 
     Args:
        x (~chainer.Variable): Input variable. Its first dimension is assumed
             to be the *minibatch dimension*. The other dimensions are treated
-            as concatenated one dimension.
+            as one concatenated dimension.
     Returns:
-        ~chainer.Variable: Variable holding :math:`Y`.
+        ~chainer.Variable: Output variable.
 
     .. seealso:: :class:`~chainer.links.Maxout`
     """
 
-    assert (x.data.shape[axis] % pool_size == 0,
-            'channel dimension must be divided by num_channel')
+    msg = 'channel dimension must be divided by num_channel'
+    assert x.data.shape[axis] % pool_size == 0, msg
+
     shape = (x.data.shape[:axis] +
              (x.data.shape[axis] // pool_size, pool_size) +
              x.data.shape[axis + 1:])

--- a/chainer/functions/activation/maxout.py
+++ b/chainer/functions/activation/maxout.py
@@ -1,108 +1,39 @@
-import numpy
-
-from chainer import cuda
-from chainer import function
-from chainer.utils import type_check
+from chainer.functions.array import reshape
+from chainer.functions.math import minmax
 
 
-def _as_mat(x):
-    if x.ndim == 2:
-        return x
-    return x.reshape(len(x), -1)
+def maxout(x, num_channel, axis=1):
+    """Maxout activation function
 
+    It accepts an input tensor ``x``, reshapes the ``axis`` dimension
+    (say the size being ``M * num_channel``) into two dimensional tensor
+    ``(M, num_channel)`` and takes maximum along the third dimension.
+    The output of this function is same as ``x`` except that ``axis`` dimension
+    is transformed from ``M * channel`` to ``M``.
 
-class MaxoutFunction(function.Function):
+    Typically, ``x`` is the output of Linear Layer or Convolution Layer.
+    The following is the example where we use :func:`maxout` in combination
+    with Linear Link.
 
-    def check_type_forward(self, in_types):
-        type_check.expect(
-            in_types.size() >= 2,
-            in_types.size() <= 3
-        )
-        x_type, w_type = in_types[:2]
-
-        type_check.expect(
-            x_type.dtype.kind == 'f',
-            w_type.dtype.kind == 'f',
-            x_type.ndim >= 2,
-            w_type.ndim == 3,
-            type_check.prod(x_type.shape[1:]) == w_type.shape[0]
-        )
-
-        if in_types.size().eval() == 3:
-            b_type = in_types[2]
-            type_check.expect(
-                b_type.dtype.kind == 'f',
-                b_type.ndim == 2,
-                b_type.shape == w_type.shape[1:]
-            )
-
-    def forward(self, inputs):
-        xp = cuda.get_array_module(*inputs)
-        x = _as_mat(inputs[0])
-        W = inputs[1]
-        ys = xp.tensordot(x, W, axes=1)
-        if len(inputs) == 3:
-            ys += inputs[2]
-        self.argmax = xp.argmax(ys, axis=1)
-        return xp.max(ys, axis=1),
-
-    def backward(self, inputs, grad_outputs):
-        gy = grad_outputs[0]
-        x = _as_mat(inputs[0])
-        W = inputs[1]
-
-        xp = cuda.get_array_module(*inputs)
-        # gradient of z = xW + b
-        gz = xp.zeros((gy.shape[0], W.shape[1], gy.shape[1]), x.dtype)
-        if xp == numpy:
-            idx0 = xp.arange(len(gy))[:, None]
-            idx1 = xp.arange(gy.shape[1])
-            gz[idx0, self.argmax, idx1] = gy
-        else:
-            gz_r = xp.rollaxis(gz, 1)
-            cuda.elementwise(
-                'T gy, S argmax, int32 n', 'raw T gz',
-                'gz[argmax * n + i] = gy', 'maxout_bwd'
-            )(gy, self.argmax, gz_r.size // len(gz_r), gz_r)
-        gx = xp.tensordot(gz, W, ((1, 2), (1, 2))).reshape(inputs[0].shape)
-        gW = xp.tensordot(x, gz, (0, 0))
-
-        if len(inputs) == 3:
-            gb = gz.sum(axis=0)
-            return gx, gW, gb
-        else:
-            return gx, gW
-
-
-def maxout(x, W, b=None):
-    """non parametrized Maxout activation function
-
-    It accepts two or three arguments: an input minibatch ``x``,
-    a weight tensor ``W``, and optionally a bias matrix ``b``
-    and computes
-
-    .. math::
-
-      Y_{i} = \\mathrm{max}_{j} (x^{T}W_{\\cdot ij} + b_{ij}).
-
-    Here, :math:`x` is a input vector and :math:`W_{\\cdot ij}`
-    is a sub-vector extracted from :math:`W` by fixing second
-    and third dimensions to :math:`i` and :math:`j`, respectively.
-    Minibatch dimension is omitted in the above equation.
+    >>> l = L.Linear(in_size, out_size * num_channel)
+    ... x = Variable(...)  # prepare data
+    ... x = linear(x)
+    ... y = maxout(x, num_channel)
 
     Args:
        x (~chainer.Variable): Input variable. Its first dimension is assumed
             to be the *minibatch dimension*. The other dimensions are treated
-            as concatenated one dimension whose size must be ``N``.
-       W (~chainer.Variable): Weight variable of shape ``(N, C, M)``.
-       b (~chainer.Variable): Bias variable (optional) of shape ``(C, M)``.
+            as concatenated one dimension.
     Returns:
         ~chainer.Variable: Variable holding :math:`Y`.
 
     .. seealso:: :class:`~chainer.links.Maxout`
     """
 
-    if b is None:
-        return MaxoutFunction()(x, W)
-    else:
-        return MaxoutFunction()(x, W, b)
+    assert (x.data.shape[axis] % num_channel == 0,
+            'channel dimension must be divided by num_channel')
+    shape = (x.data.shape[:axis] +
+             (x.data.shape[axis] // num_channel, num_channel) +
+             x.data.shape[axis + 1:])
+    x = reshape.reshape(x, shape)
+    return minmax.max(x, axis=axis + 1)

--- a/chainer/functions/activation/maxout.py
+++ b/chainer/functions/activation/maxout.py
@@ -1,5 +1,6 @@
 from chainer.functions.array import reshape
 from chainer.functions.math import minmax
+from chainer.utils import type_check
 
 
 def maxout(x, pool_size, axis=1):
@@ -30,8 +31,15 @@ def maxout(x, pool_size, axis=1):
     .. seealso:: :class:`~chainer.links.Maxout`
     """
 
-    msg = 'channel dimension must be divided by num_channel'
-    assert x.data.shape[axis] % pool_size == 0, msg
+    if pool_size <= 0:
+        raise ValueError('pool_size must be positive integer.')
+
+    if x.data.shape[axis] % pool_size != 0:
+        expect = 'x.data.shape[axis] % pool_size != 0'
+        actual = 'x.data.shape[axis]={}, pool_size={}'.format(
+            x.data.shape[axis], pool_size)
+        msg = 'axis dimension must be divided by pool_size'
+        raise type_check.InvalidType(expect, actual, msg)
 
     shape = (x.data.shape[:axis] +
              (x.data.shape[axis] // pool_size, pool_size) +

--- a/chainer/functions/activation/maxout.py
+++ b/chainer/functions/activation/maxout.py
@@ -2,23 +2,23 @@ from chainer.functions.array import reshape
 from chainer.functions.math import minmax
 
 
-def maxout(x, num_channel, axis=1):
+def maxout(x, pool_size, axis=1):
     """Maxout activation function
 
     It accepts an input tensor ``x``, reshapes the ``axis`` dimension
-    (say the size being ``M * num_channel``) into two dimensional tensor
-    ``(M, num_channel)`` and takes maximum along the third dimension.
+    (say the size being ``M * pool_size``) into two dimensional tensor
+    ``(M, pool_size)`` and takes maximum along the ``axis`` dimension
     The output of this function is same as ``x`` except that ``axis`` dimension
-    is transformed from ``M * channel`` to ``M``.
+    is transformed from ``M * pool_size`` to ``M``.
 
     Typically, ``x`` is the output of Linear Layer or Convolution Layer.
     The following is the example where we use :func:`maxout` in combination
     with Linear Link.
 
-    >>> l = L.Linear(in_size, out_size * num_channel)
+    >>> l = L.Linear(in_size, out_size * pool_size)
     ... x = Variable(...)  # prepare data
     ... x = linear(x)
-    ... y = maxout(x, num_channel)
+    ... y = maxout(x, pool_size)
 
     Args:
        x (~chainer.Variable): Input variable. Its first dimension is assumed
@@ -30,10 +30,10 @@ def maxout(x, num_channel, axis=1):
     .. seealso:: :class:`~chainer.links.Maxout`
     """
 
-    assert (x.data.shape[axis] % num_channel == 0,
+    assert (x.data.shape[axis] % pool_size == 0,
             'channel dimension must be divided by num_channel')
     shape = (x.data.shape[:axis] +
-             (x.data.shape[axis] // num_channel, num_channel) +
+             (x.data.shape[axis] // pool_size, pool_size) +
              x.data.shape[axis + 1:])
     x = reshape.reshape(x, shape)
     return minmax.max(x, axis=axis + 1)

--- a/chainer/functions/activation/maxout.py
+++ b/chainer/functions/activation/maxout.py
@@ -32,10 +32,10 @@ def maxout(x, pool_size, axis=1):
     """
 
     if pool_size <= 0:
-        raise ValueError('pool_size must be positive integer.')
+        raise ValueError('pool_size must be a positive integer.')
 
     if x.data.shape[axis] % pool_size != 0:
-        expect = 'x.data.shape[axis] % pool_size != 0'
+        expect = 'x.data.shape[axis] % pool_size == 0'
         actual = 'x.data.shape[axis]={}, pool_size={}'.format(
             x.data.shape[axis], pool_size)
         msg = 'axis dimension must be divided by pool_size'

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -30,7 +30,7 @@ class Maxout(link.Chain):
     Args:
         in_size (int): Dimension of input vectors.
         out_size (int): Dimension of output vectors.
-        num_channel (int): Number of channels.
+        pool_size (int): Number of channels.
         wscale (float): Scaling factor of the weight matrix.
         initialW (3-D array or None): Initial weight value.
             If ``None``, then this function uses ``wscale`` to initialize.
@@ -52,9 +52,9 @@ class Maxout(link.Chain):
          `URL <http://jmlr.org/proceedings/papers/v28/goodfellow13.html>`_
     """
 
-    def __init__(self, in_size, out_size, num_channel,
+    def __init__(self, in_size, out_size, pool_size,
                  wscale=1, initialW=None, initial_bias=0):
-        linear_out_size = out_size * num_channel
+        linear_out_size = out_size * pool_size
         if initialW is not None:
             initialW = initialW.reshape(linear_out_size, in_size)
 
@@ -74,7 +74,7 @@ class Maxout(link.Chain):
                 nobias=initial_bias is None, initialW=initialW,
                 initial_bias=initial_bias))
         self.out_size = out_size
-        self.num_channel = num_channel
+        self.pool_size = pool_size
 
     def __call__(self, x):
         """Applies the maxout layer.
@@ -86,4 +86,4 @@ class Maxout(link.Chain):
             ~chainer.Variable: Output of the maxout layer.
         """
         y = self.linear(x)
-        return maxout.maxout(y, self.num_channel)
+        return maxout.maxout(y, self.pool_size)

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -1,8 +1,7 @@
 import numpy
 
 from chainer import cuda
-from chainer.functions.array import reshape
-from chainer.functions.math import minmax
+from chainer.functions.activation import maxout
 from chainer import link
 from chainer.links.connection import linear
 
@@ -86,7 +85,5 @@ class Maxout(link.Chain):
         Returns:
             ~chainer.Variable: Output of the maxout layer.
         """
-        b = x.data.shape[0]
         y = self.linear(x)
-        y = reshape.reshape(y, (b, self.out_size, self.num_channel))
-        return minmax.max(y, axis=2)
+        return maxout.maxout(y, self.num_channel)

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -11,7 +11,7 @@ class Maxout(link.Chain):
 
     Let ``M``, ``P`` and ``N`` be an input dimension, a pool size,
     and an output dimension, respectively.
-    For input vector :math:`x` of size ``M``, it computes
+    For an input vector :math:`x` of size ``M``, it computes
 
     .. math::
 
@@ -24,8 +24,8 @@ class Maxout(link.Chain):
     :math:`i` and :math:`j`, respectively.
     Minibatch dimension is omitted in the above equation.
 
-    As for the actual implementation, this Chain has a
-    linear Link with a ``(M * P, N)`` weight matrix and
+    As for the actual implementation, this chain has a
+    Linear link with a ``(M * P, N)`` weight matrix and
     an optional ``M * P`` dimensional bias vector.
 
     Args:
@@ -40,7 +40,7 @@ class Maxout(link.Chain):
             If it is ``None``, bias is omitted.
 
     Attributes:
-        linear (~chainer.Link): The Linear Link that performs
+        linear (~chainer.Link): The Linear link that performs
         affine transformation.
 
     .. seealso:: :func:`~chainer.functions.maxout`

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -7,25 +7,26 @@ from chainer.links.connection import linear
 
 
 class Maxout(link.Chain):
-    """Maxout Networks
+    """Fully-connected maxout layer.
 
-    It has three dimensional weight tensor whose shape is ``(M, C, N)``
-    and optional bias vector whose shape is ``(M, C)`` where
-   ``M`` is an output dimension,``C`` the number of channel, and
-    ``N`` an input dimension . It computes
+    Let ``M``, ``P`` and ``N`` be an input dimension, a pool size,
+    and an output dimension, respectively.
+    For input vector :math:`x` of size ``M``, it computes
 
     .. math::
 
       Y_{i} = \\mathrm{max}_{j} (W_{ij\\cdot}x + b_{ij}).
 
-    Here, :math:`x` is a input vector and :math:`W_{ij\\cdot}`
-    is a sub-vector extracted from :math:`W` by fixing first
-    and second dimensions to :math:`i` and :math:`j`, respectively.
+    Here :math:`W` is a weight tensor of shape ``(M, P, N)``,
+    :math:`b` an  optional bias vector of shape ``(M, P)``
+    and :math:`W_{ij\\cdot}` is a sub-vector extracted from
+    :math:`W` by fixing first and second dimensions to
+    :math:`i` and :math:`j`, respectively.
     Minibatch dimension is omitted in the above equation.
 
-    As an actual implementation, this Chain has a linear Link with
-    a ``(M * C, N)`` weight vector and an optional ``M * C``
-    dimensional bias.
+    As for the actual implementation, this Chain has a
+    linear Link with a ``(M * P, N)`` weight matrix and
+    an optional ``M * P`` dimensional bias vector.
 
     Args:
         in_size (int): Dimension of input vectors.

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import six
 
 import chainer
 from chainer import cuda
@@ -12,113 +11,65 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-def _as_mat(x):
-    if x.ndim == 2:
-        return x
-    return x.reshape(len(x), -1)
-
-
-def _maxout(x, W, b):
-    y = numpy.tensordot(_as_mat(x), W, axes=1)
-    if b is not None:
-        y += b
-    return numpy.max(y, axis=1)
+def _maxout(x, num_channel, axis):
+    shape = (x.shape[:axis] + (x.shape[axis] // num_channel, num_channel) +
+             x.shape[axis + 1:])
+    x = x.reshape(shape)
+    return x.max(axis=axis + 1)
 
 
 @testing.parameterize(
-    {'W_shape': (2, 3, 4), 'b_shape': (3, 4), 'x_shape': (7, 2)},
-    {'W_shape': (10, 3, 4), 'b_shape': (3, 4), 'x_shape': (7, 2, 5)},
-    {'W_shape': (2, 3, 4), 'b_shape': None, 'x_shape': (7, 2)}
+    {'x_shape': (7, 12), 'num_channel': 2, 'axis': 1, 'y_shape': (7, 6)},
+    {'x_shape': (7, 12), 'num_channel': 12, 'axis': 1, 'y_shape': (7, 1)},
+    {'x_shape': (7, 3, 4), 'num_channel': 7, 'axis': 0, 'y_shape': (1, 3, 4)},
+    {'x_shape': (7, 3, 4), 'num_channel': 3, 'axis': 1, 'y_shape': (7, 1, 4)},
+    {'x_shape': (7, 3, 4), 'num_channel': 4, 'axis': 2, 'y_shape': (7, 3, 1)},
+    {'x_shape': (7, 2, 3, 4), 'num_channel': 2,
+     'axis': 3, 'y_shape': (7, 2, 3, 2)},
 )
 class TestNonparameterizedMaxout(unittest.TestCase):
 
     def setUp(self):
-        self.W = numpy.random.uniform(
-            -0.01, 0.01, self.W_shape).astype(numpy.float32)
-        for c in six.moves.range(self.W.shape[1]):
-            w = numpy.arange(self.W.shape[0], dtype=numpy.float32) + 1
-            for o in six.moves.range(self.W.shape[2]):
-                self.W[:, c, o] += w * o
+        x_size = numpy.prod(self.x_shape)
+        self.x = numpy.arange(x_size).reshape(
+            self.x_shape).astype(numpy.float32)
+        numpy.random.shuffle(self.x.ravel())
 
-        if self.b_shape is not None:
-            self.b = numpy.random.uniform(
-                -0.01, 0.01, self.b_shape).astype(numpy.float32)
-        else:
-            self.b = None
-
-        self.x = numpy.random.uniform(
-            -0.01, 0.01, self.x_shape).astype(numpy.float32)
-
-        self.y = _maxout(self.x, self.W, self.b)
+        self.y = _maxout(self.x, self.num_channel, self.axis)
         self.gy = numpy.random.uniform(
-            -0.01, 0.01, self.y.shape).astype(numpy.float32)
+            -1, 1, self.y.shape).astype(numpy.float32)
 
-    def check_forward(self, x_data, W_data, b_data, y_expect):
+    def check_forward(self, x_data):
         x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
-        if b_data is None:
-            y = functions.maxout(x, W)
-        else:
-            b = chainer.Variable(b_data)
-            y = functions.maxout(x, W, b)
-        gradient_check.assert_allclose(y_expect, y.data)
+        y = functions.maxout(x, self.num_channel, self.axis)
+        gradient_check.assert_allclose(self.y, y.data)
 
     @condition.retry(3)
     def test_forward_cpu(self):
-        self.check_forward(self.x, self.W, self.b, self.y)
+        self.check_forward(self.x)
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
-        b = self.b
-        if b is not None:
-            b = cuda.to_gpu(b)
+        self.check_forward(cuda.to_gpu(self.x))
 
-        self.check_forward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.W),
-            b, cuda.to_gpu(self.y))
-
-    def check_backward(self, x_data, W_data, b_data, y_grad):
+    def check_backward(self, x_data, y_grad):
         x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
-        if b_data is None:
-            y = functions.maxout(x, W)
-        else:
-            b = chainer.Variable(b_data)
-            y = functions.maxout(x, W, b)
-
+        y = functions.maxout(x, self.num_channel, self.axis)
         y.grad = y_grad
         y.backward()
-        func = y.creator
-
-        if b_data is None:
-            f = lambda: func.forward((x.data, W.data))
-            gx, gW = gradient_check.numerical_grad(
-                f, (x.data, W.data), (y.grad, ), eps=1e-2)
-        else:
-            f = lambda: func.forward((x.data, W.data, b.data))
-            gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, W.data, b.data), (y.grad, ), eps=1e-2)
-
+        f = lambda: (functions.maxout(x, self.num_channel, self.axis).data,)
+        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
         gradient_check.assert_allclose(gx, x.grad, atol=1e-2)
-        gradient_check.assert_allclose(gW, W.grad, atol=1e-2)
-        if b_data is not None:
-            gradient_check.assert_allclose(gb, b.grad, atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.W, self.b, self.gy)
+        self.check_backward(self.x, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        b = self.b
-        if b is not None:
-            b = cuda.to_gpu(b)
-
-        self.check_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.W),
-            b, cuda.to_gpu(self.gy))
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -55,13 +55,9 @@ class TestNonparameterizedMaxout(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.maxout(x, self.num_channel, self.axis)
-        y.grad = y_grad
-        y.backward()
-        f = lambda: (functions.maxout(x, self.num_channel, self.axis).data,)
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-2)
+        gradient_check.check_backward(
+            lambda x: functions.maxout(x, self.num_channel, self.axis),
+            x_data, y_grad, atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -5,7 +5,6 @@ import numpy
 import chainer
 from chainer import cuda
 from chainer import functions
-from chainer.functions.activation import maxout
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -12,20 +12,20 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-def _maxout(x, num_channel, axis):
-    shape = (x.shape[:axis] + (x.shape[axis] // num_channel, num_channel) +
+def _maxout(x, pool_size, axis):
+    shape = (x.shape[:axis] + (x.shape[axis] // pool_size, pool_size) +
              x.shape[axis + 1:])
     x = x.reshape(shape)
     return x.max(axis=axis + 1)
 
 
 @testing.parameterize(
-    {'x_shape': (7, 12), 'num_channel': 2, 'axis': 1, 'y_shape': (7, 6)},
-    {'x_shape': (7, 12), 'num_channel': 12, 'axis': 1, 'y_shape': (7, 1)},
-    {'x_shape': (7, 3, 4), 'num_channel': 7, 'axis': 0, 'y_shape': (1, 3, 4)},
-    {'x_shape': (7, 3, 4), 'num_channel': 3, 'axis': 1, 'y_shape': (7, 1, 4)},
-    {'x_shape': (7, 3, 4), 'num_channel': 4, 'axis': 2, 'y_shape': (7, 3, 1)},
-    {'x_shape': (7, 2, 3, 4), 'num_channel': 2,
+    {'x_shape': (7, 12), 'pool_size': 2, 'axis': 1, 'y_shape': (7, 6)},
+    {'x_shape': (7, 12), 'pool_size': 12, 'axis': 1, 'y_shape': (7, 1)},
+    {'x_shape': (7, 3, 4), 'pool_size': 7, 'axis': 0, 'y_shape': (1, 3, 4)},
+    {'x_shape': (7, 3, 4), 'pool_size': 3, 'axis': 1, 'y_shape': (7, 1, 4)},
+    {'x_shape': (7, 3, 4), 'pool_size': 4, 'axis': 2, 'y_shape': (7, 3, 1)},
+    {'x_shape': (7, 2, 3, 4), 'pool_size': 2,
      'axis': 3, 'y_shape': (7, 2, 3, 2)},
 )
 class TestNonparameterizedMaxout(unittest.TestCase):
@@ -36,13 +36,13 @@ class TestNonparameterizedMaxout(unittest.TestCase):
             self.x_shape).astype(numpy.float32)
         numpy.random.shuffle(self.x.ravel())
 
-        self.y = _maxout(self.x, self.num_channel, self.axis)
+        self.y = _maxout(self.x, self.pool_size, self.axis)
         self.gy = numpy.random.uniform(
             -1, 1, self.y.shape).astype(numpy.float32)
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
-        y = functions.maxout(x, self.num_channel, self.axis)
+        y = functions.maxout(x, self.pool_size, self.axis)
         gradient_check.assert_allclose(self.y, y.data)
 
     @condition.retry(3)
@@ -56,7 +56,7 @@ class TestNonparameterizedMaxout(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            lambda x: functions.maxout(x, self.num_channel, self.axis),
+            lambda x: functions.maxout(x, self.pool_size, self.axis),
             x_data, y_grad, atol=1e-2)
 
     @condition.retry(3)

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -30,7 +30,7 @@ def _maxout(x, W, b):
 @testing.parameterize(
     *testing.product(
         {'in_shape': [(2, ), (2, 5)],
-         'num_channel': [3],
+         'pool_size': [3],
          'out_size': [4],
          'wscale': [1],
          'initial_bias': ['random', 'scalar', None],
@@ -53,23 +53,23 @@ class TestMaxout(unittest.TestCase):
 
         in_size = numpy.prod(self.in_shape)
         initialW = numpy.random.uniform(
-            -0.05, 0.05, (self.out_size, self.num_channel, in_size)
+            -0.05, 0.05, (self.out_size, self.pool_size, in_size)
         ).astype(numpy.float32)
         for o in six.moves.range(self.out_size):
             w = numpy.arange(in_size, dtype=numpy.float32) + 1
-            for c in six.moves.range(self.num_channel):
+            for c in six.moves.range(self.pool_size):
                 initialW[o, c, :] += w * c
 
         if self.initial_bias == 'random':
             initial_bias = numpy.random.uniform(
-                -0.05, 0.05, (self.out_size, self.num_channel))
+                -0.05, 0.05, (self.out_size, self.pool_size))
         elif self.initial_bias == 'scalar':
             initial_bias = numpy.full(
-                (self.out_size, self.num_channel), 5, dtype=numpy.float32)
+                (self.out_size, self.pool_size), 5, dtype=numpy.float32)
         elif self.initial_bias is None:
             initial_bias = None
 
-        self.link = links.Maxout(in_size, self.out_size, self.num_channel,
+        self.link = links.Maxout(in_size, self.out_size, self.pool_size,
                                  self.wscale, initialW, initial_bias)
 
         self.y = _maxout(self.x, initialW, initial_bias)
@@ -125,19 +125,19 @@ class TestInitialization(unittest.TestCase):
     def setUp(self):
         self.in_size = 2
         self.out_size = 3
-        self.num_channel = 4
+        self.pool_size = 4
         self.initialW = numpy.random.uniform(
-            -1, 1, (self.out_size, self.num_channel, self.in_size)
+            -1, 1, (self.out_size, self.pool_size, self.in_size)
         ).astype(numpy.float32)
         self.initial_bias = numpy.random.uniform(
-            -1, 1, (self.out_size, self.num_channel)
+            -1, 1, (self.out_size, self.pool_size)
         ).astype(numpy.float32)
         self.link = links.Maxout(
-            self.in_size, self.out_size, self.num_channel,
+            self.in_size, self.out_size, self.pool_size,
             initialW=self.initialW, initial_bias=self.initial_bias)
 
     def check_param(self):
-        linear_out_size = self.out_size * self.num_channel
+        linear_out_size = self.out_size * self.pool_size
         initialW = self.initialW.reshape((linear_out_size, -1))
         gradient_check.assert_allclose(initialW, self.link.linear.W.data)
         initial_bias = self.initial_bias.reshape((linear_out_size,))

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -92,20 +92,10 @@ class TestMaxout(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        if self.initial_bias is None:
-            gx, gW = gradient_check.numerical_grad(
-                f, (x.data, self.link.linear.W.data),
-                (y.grad, ), eps=1e-4)
-        else:
-            gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, self.link.linear.W.data, self.link.linear.b.data),
-                (y.grad, ), eps=1e-4)
-
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-2)
-        gradient_check.assert_allclose(gW, self.link.linear.W.grad, atol=1e-2)
+        params = [self.link.linear.W]
         if self.initial_bias is not None:
-            gradient_check.assert_allclose(
-                gb, self.link.linear.b.grad, atol=1e-2)
+            params.append(self.link.linear.b)
+        gradient_check.check_backward(self.link, x_data, y_grad, params, atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -20,10 +20,11 @@ def _as_mat(x):
 
 
 def _maxout(x, W, b):
-    y = numpy.tensordot(_as_mat(x), W, axes=1)
+    W_r = numpy.rollaxis(W, 2)
+    y = numpy.tensordot(_as_mat(x), W_r, axes=1)
     if b is not None:
         y += b
-    return numpy.max(y, axis=1)
+    return numpy.max(y, axis=2)
 
 
 @testing.parameterize(
@@ -32,7 +33,7 @@ def _maxout(x, W, b):
          'num_channel': [3],
          'out_size': [4],
          'wscale': [1],
-         'initial_bias': ['random', None],
+         'initial_bias': ['random', 'scalar', None],
          'batchsize': [7]}
     )
 )
@@ -41,7 +42,7 @@ class TestMaxout(unittest.TestCase):
     def setUp(self):
         # x, W, and b are set so that the result of forward
         # propagation gets stable, meaning that their small pertubations
-        # do not change :math:`argmax_{j} W_{\cdot ij} x + b_{ij}`.
+        # do not change :math:`argmax_{j} W_{ij\cdot} x + b_{ij}`.
 
         x_shape = (self.batchsize, ) + self.in_shape
         self.x = numpy.random.uniform(
@@ -52,27 +53,26 @@ class TestMaxout(unittest.TestCase):
 
         in_size = numpy.prod(self.in_shape)
         initialW = numpy.random.uniform(
-            -0.05, 0.05, (in_size, self.num_channel, self.out_size)
+            -0.05, 0.05, (self.out_size, self.num_channel, in_size)
         ).astype(numpy.float32)
-        for c in six.moves.range(self.num_channel):
+        for o in six.moves.range(self.out_size):
             w = numpy.arange(in_size, dtype=numpy.float32) + 1
-            for o in six.moves.range(self.out_size):
-                initialW[:, c, o] += w * o
+            for c in six.moves.range(self.num_channel):
+                initialW[o, c, :] += w * c
 
-        initial_bias = None
         if self.initial_bias == 'random':
             initial_bias = numpy.random.uniform(
-                -0.05, 0.05, (self.num_channel, self.out_size))
+                -0.05, 0.05, (self.out_size, self.num_channel))
+        elif self.initial_bias == 'scalar':
+            initial_bias = numpy.full(
+                (self.out_size, self.num_channel), 5, dtype=numpy.float32)
+        elif self.initial_bias is None:
+            initial_bias = None
 
-        self.link = links.Maxout(in_size, self.num_channel, self.out_size,
+        self.link = links.Maxout(in_size, self.out_size, self.num_channel,
                                  self.wscale, initialW, initial_bias)
 
-        W = self.link.W.data.copy()
-        b = None
-        if self.link.b is not None:
-            b = self.link.b.data.copy()
-
-        self.y = _maxout(self.x, W, b)
+        self.y = _maxout(self.x, initialW, initial_bias)
         self.link.zerograds()
 
     def check_forward(self, x_data):
@@ -100,17 +100,18 @@ class TestMaxout(unittest.TestCase):
         f = lambda: (self.link(x).data, )
         if self.initial_bias is None:
             gx, gW = gradient_check.numerical_grad(
-                f, (x.data, self.link.W.data),
+                f, (x.data, self.link.linear.W.data),
                 (y.grad, ), eps=1e-4)
         else:
             gx, gW, gb = gradient_check.numerical_grad(
-                f, (x.data, self.link.W.data, self.link.b.data),
+                f, (x.data, self.link.linear.W.data, self.link.linear.b.data),
                 (y.grad, ), eps=1e-4)
 
         gradient_check.assert_allclose(gx, x.grad, atol=1e-2)
-        gradient_check.assert_allclose(gW, self.link.W.grad, atol=1e-2)
+        gradient_check.assert_allclose(gW, self.link.linear.W.grad, atol=1e-2)
         if self.initial_bias is not None:
-            gradient_check.assert_allclose(gb, self.link.b.grad, atol=1e-2)
+            gradient_check.assert_allclose(
+                gb, self.link.linear.b.grad, atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -138,17 +139,25 @@ class TestInvalidMaxout(unittest.TestCase):
 class TestInitialization(unittest.TestCase):
 
     def setUp(self):
+        self.in_size = 2
+        self.out_size = 3
+        self.num_channel = 4
         self.initialW = numpy.random.uniform(
-            -1, 1, (2, 3, 4)).astype(numpy.float32)
+            -1, 1, (self.out_size, self.num_channel, self.in_size)
+        ).astype(numpy.float32)
         self.initial_bias = numpy.random.uniform(
-            -1, 1, (3, 4)).astype(numpy.float32)
+            -1, 1, (self.out_size, self.num_channel)
+        ).astype(numpy.float32)
         self.link = links.Maxout(
-            2, 3, 4, initialW=self.initialW,
-            initial_bias=self.initial_bias)
+            self.in_size, self.out_size, self.num_channel,
+            initialW=self.initialW, initial_bias=self.initial_bias)
 
     def check_param(self):
-        gradient_check.assert_allclose(self.initialW, self.link.W.data)
-        gradient_check.assert_allclose(self.initial_bias, self.link.b.data)
+        linear_out_size = self.out_size * self.num_channel
+        initialW = self.initialW.reshape((linear_out_size, -1))
+        gradient_check.assert_allclose(initialW, self.link.linear.W.data)
+        initial_bias = self.initial_bias.reshape((linear_out_size,))
+        gradient_check.assert_allclose(initial_bias, self.link.linear.b.data)
 
     def test_param_cpu(self):
         self.check_param()

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -95,7 +95,8 @@ class TestMaxout(unittest.TestCase):
         params = [self.link.linear.W]
         if self.initial_bias is not None:
             params.append(self.link.linear.b)
-        gradient_check.check_backward(self.link, x_data, y_grad, params, atol=1e-2)
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, params, atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):


### PR DESCRIPTION
I reimplemented Maxout with `Linear` Link. The main reasons are extensibility and simplicity.

* In the original paper, the variant of Maxout is used where linear layers are replaced with convolution layers. But we cannot reuse `MaxoutFunction` to implement it because we pass the weight tensor and bias vector of `Linear` Link to `MaxoutFunction`.
* Using `Linear` Link makes the implementation of `Maxout` Link simpler.

If this PR is merged #849 and #853 are no longer meaningful.