### PR TITLE
Use NPZ in examples

### DIFF
--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -369,7 +369,7 @@ The state of an optimizer can also be saved by the same functions:
 
 Support of the HDF5 format is enabled if the h5py package is installed.
 Serialization and deserialization with the HDF5 format are almost identical to those with the NPZ format;
-just replace ``save_npz`` and ``load_npz`` by :func:`~serializers.save_hdf5` and :func:`~serializers.load_hdf5`, respectively.
+just replace :func:`~serializers.save_npz` and :func:`~serializers.load_npz` by :func:`~serializers.save_hdf5` and :func:`~serializers.load_hdf5`, respectively.
 
 .. _mnist_mlp_example:
 

--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -334,20 +334,20 @@ Serializer is a simple interface to serialize or deserialize an object.
 :class:`Link` and :class:`Optimizer` supports serialization by serializers.
 
 Concrete serializers are defined in the :mod:`serializers` module.
-Currently, it only contains a serializer and a deserializer for HDF5 format.
+It supports NumPy NPZ and HDF5 formats.
 
-We can serialize a link object into HDF5 file by the :func:`serializers.save_hdf5` function:
-
-.. doctest::
-
-   >>> serializers.save_hdf5('my.model', model)
-
-It saves the parameters of ``model`` into the file ``'my.model'`` in HDF5 format.
-The saved model can be read by the :func:`serializers.load_hdf5` function:
+For example, we can serialize a link object into NPZ file by the :func:`serializers.save_npz` function:
 
 .. doctest::
 
-   >>> serializers.load_hdf5('my.model', model)
+   >>> serializers.save_npz('my.model', model)
+
+It saves the parameters of ``model`` into the file ``'my.model'`` in NPZ format.
+The saved model can be read by the :func:`serializers.load_npz` function:
+
+.. doctest::
+
+   >>> serializers.load_npz('my.model', model)
 
 .. note::
    Note that only the parameters and the *persistent values* are serialized by these serialization code.
@@ -359,14 +359,17 @@ The state of an optimizer can also be saved by the same functions:
 
 .. doctest::
 
-   >>> serializers.save_hdf5('my.state', optimizer)
-   >>> serializers.load_hdf5('my.state', optimizer)
+   >>> serializers.save_npz('my.state', optimizer)
+   >>> serializers.load_npz('my.state', optimizer)
 
 .. note::
    Note that serialization of optimizer only saves its internal states including number of iterations, momentum vectors of MomentumSGD, etc.
    It does not save the parameters and persistent values of the target link.
    We have to explicitly save the target link with the optimizer to resume the optimization from saved states.
 
+Support of the HDF5 format is enabled if the h5py package is installed.
+Serialization and deserialization with the HDF5 format are almost identical to those with the NPZ format;
+just replace ``save_npz`` and ``load_npz`` by :func:`~serializers.save_hdf5` and :func:`~serializers.load_hdf5`, respectively.
 
 .. _mnist_mlp_example:
 

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -110,10 +110,10 @@ optimizer.setup(model)
 # Init/Resume
 if args.initmodel:
     print('Load model from', args.initmodel)
-    serializers.load_hdf5(args.initmodel, model)
+    serializers.load_npz(args.initmodel, model)
 if args.resume:
     print('Load optimizer state from', args.resume)
-    serializers.load_hdf5(args.resume, optimizer)
+    serializers.load_npz(args.resume, optimizer)
 
 
 # ------------------------------------------------------------------------------
@@ -283,8 +283,8 @@ def train_loop():
             continue
         elif inp == 'val':  # start validation
             res_q.put('val')
-            serializers.save_hdf5(args.out, model)
-            serializers.save_hdf5(args.outstate, optimizer)
+            serializers.save_npz(args.out, model)
+            serializers.save_npz(args.outstate, optimizer)
             model.train = False
             continue
 
@@ -319,5 +319,5 @@ feeder.join()
 logger.join()
 
 # Save final model
-serializers.save_hdf5(args.out, model)
-serializers.save_hdf5(args.outstate, optimizer)
+serializers.save_npz(args.out, model)
+serializers.save_npz(args.outstate, optimizer)

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -67,10 +67,10 @@ optimizer.setup(model)
 # Init/Resume
 if args.initmodel:
     print('Load model from', args.initmodel)
-    serializers.load_hdf5(args.initmodel, model)
+    serializers.load_npz(args.initmodel, model)
 if args.resume:
     print('Load optimizer state from', args.resume)
-    serializers.load_hdf5(args.resume, optimizer)
+    serializers.load_npz(args.resume, optimizer)
 
 # Learning loop
 for epoch in six.moves.range(1, n_epoch + 1):
@@ -117,6 +117,6 @@ for epoch in six.moves.range(1, n_epoch + 1):
 
 # Save the model and the optimizer
 print('save the model')
-serializers.save_hdf5('mlp.model', model)
+serializers.save_npz('mlp.model', model)
 print('save the optimizer')
-serializers.save_hdf5('mlp.state', optimizer)
+serializers.save_npz('mlp.state', optimizer)

--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -77,10 +77,10 @@ optimizer.add_hook(chainer.optimizer.GradientClipping(grad_clip))
 # Init/Resume
 if args.initmodel:
     print('Load model from', args.initmodel)
-    serializers.load_hdf5(args.initmodel, model)
+    serializers.load_npz(args.initmodel, model)
 if args.resume:
     print('Load optimizer state from', args.resume)
-    serializers.load_hdf5(args.resume, optimizer)
+    serializers.load_npz(args.resume, optimizer)
 
 
 def evaluate(dataset):
@@ -154,6 +154,6 @@ print('test perplexity:', test_perp)
 
 # Save the model and the optimizer
 print('save the model')
-serializers.save_hdf5('rnnlm.model', model)
+serializers.save_npz('rnnlm.model', model)
 print('save the optimizer')
-serializers.save_hdf5('rnnlm.state', optimizer)
+serializers.save_npz('rnnlm.state', optimizer)


### PR DESCRIPTION
NumPy NPZ is now the standard serialization in Chainer, since it is available even if h5py is not installed. I made tutorials and examples runnable without h5py.