### PR TITLE
Fix unittests of BatchL2NormSquared

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_batch_l2_norm_squared.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_batch_l2_norm_squared.py
@@ -6,12 +6,17 @@ import six
 import chainer
 from chainer import cuda
 from chainer import functions
-from chainer.functions.math.batch_l2_norm_squared import _as_two_dim
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
 from chainer.utils import type_check
+
+
+def _as_two_dim(x):
+    if x.ndim == 2:
+        return x
+    return x.reshape((len(x), -1))
 
 
 @testing.parameterize(

--- a/tests/chainer_tests/functions_tests/math_tests/test_batch_l2_norm_squared.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_batch_l2_norm_squared.py
@@ -48,17 +48,8 @@ class TestBatchL2NormSquared(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        x = chainer.Variable(x_data)
-        y = functions.batch_l2_norm_squared(x)
-
-        y.grad = y_grad
-        y.backward()
-
-        func = y.creator
-        f = lambda: func.forward((x.data,))
-        gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,), eps=1)
-
-        gradient_check.assert_allclose(gx, x.grad)
+        gradient_check.check_backward(
+            functions.BatchL2NormSquared(), x_data, y_grad, eps=1)
 
     @condition.retry(3)
     def test_backward_cpu(self):


### PR DESCRIPTION
This PR applies changes of #848 to BatchL2NormSquared's unittest.
I also fix the minor coding style error.

Related to #828 