### PR TITLE
Add gradient_check.check_backward to check.rst

### DIFF
--- a/docs/source/reference/check.rst
+++ b/docs/source/reference/check.rst
@@ -34,4 +34,5 @@ Gradient checking utilities
 .. automodule:: chainer.gradient_check
 
 .. autofunction:: assert_allclose
+.. autofunction:: check_backward
 .. autofunction:: numerical_grad


### PR DESCRIPTION
`gradient_check.check_backward` is missing in the reference manual.