### PR TITLE
Use indexing instead of choose

### DIFF
--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -24,7 +24,9 @@ class SelectItem(function.Function):
 
     def forward_cpu(self, inputs):
         x, t = inputs
-        return t.choose(x.T),
+        # This code is equivalent to `t.choose(x.T)`, but `numpy.choose`
+        # does not work when `x.shape[1] > 32`.
+        return x[six.moves.range(t.size), t],
 
     def forward_gpu(self, inputs):
         x, t = inputs

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -10,9 +10,12 @@ from chainer import testing
 from chainer.testing import attr
 
 
+@testing.parameterize(
+    {'in_shape': (10, 5), 'out_shape': (10,)},
+    {'in_shape': (0, 5),  'out_shape': (0,)},
+    {'in_shape': (1, 33), 'out_shape': (1,)},
+)
 class TestSelectItem(unittest.TestCase):
-    in_shape = (10, 5)
-    out_shape = (10,)
 
     def setUp(self):
         self.x_data = numpy.random.uniform(
@@ -51,11 +54,6 @@ class TestSelectItem(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x_data),
                             cuda.to_gpu(self.t_data),
                             cuda.to_gpu(self.gy_data))
-
-
-class TestSelectItemZeroSize(unittest.TestCase):
-    in_shape = (0, 5)
-    out_shape = (0,)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
`numpy.choose` does not work when `x.shape[1] > 32`. I replaced `choose` with indexing.

fix #875 