### PR TITLE
Deduplicate Chain.to_cpu/to_gpu

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -192,9 +192,9 @@ class Link(object):
         """
         if self._cpu:
             return self
-        for param in self.params():
-            param.to_cpu()
         d = self.__dict__
+        for name in self._params:
+            d[name].to_cpu()
         for name in self._persistent:
             value = d[name]
             if isinstance(value, cuda.ndarray):
@@ -219,10 +219,10 @@ class Link(object):
         cuda.check_cuda_available()
         if not self._cpu:
             return self
+        d = self.__dict__
         with cuda.get_device(device):
-            for param in self.params():
-                param.to_gpu()
-            d = self.__dict__
+            for name in self._params:
+                d[name].to_gpu()
             for name in self._persistent:
                 value = d[name]
                 if isinstance(value, numpy.ndarray):


### PR DESCRIPTION
to_cpu/to_gpu methods of Chain/ChainList call these methods of their children recursively, while it also calls Link.to_cpu/to_gpu which call these methods of all parameter variables in the hierarchy. It results in duplicated call of to_cpu/to_gpu of parameters in the hierarchy. I fixed this duplication in this PR by only calling to_cpu/to_gpu of parameters directly belonging to the link.