### PR TITLE
Direct DtoD copy

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -124,7 +124,7 @@ cdef class MemoryPointer:
         if size > 0:
             _set_peer_access(src.device.id, self.device.id)
             runtime.memcpy(self.ptr, src.ptr, size,
-                           runtime.memcpyDeviceToDevice)
+                           runtime.memcpyDefault)
 
     cpdef copy_from_device_async(self, MemoryPointer src, size_t size, stream):
         """Copies a memory sequence from a (possibly different) device asynchronously.
@@ -138,7 +138,7 @@ cdef class MemoryPointer:
         if size > 0:
             _set_peer_access(src.device.id, self.device.id)
             runtime.memcpyAsync(self.ptr, src.ptr, size,
-                                runtime.memcpyDeviceToDevice, stream)
+                                runtime.memcpyDefault, stream)
 
     cpdef copy_from_host(self, mem, size_t size):
         """Copies a memory sequence from the host memory.

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -43,7 +43,6 @@ cdef set _peer_access = set()
 
 
 cpdef _set_peer_access(int device, int peer):
-    global _peer_access
     device_pair = device, peer
 
     if device_pair in _peer_access:

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -67,6 +67,9 @@ cpdef int getDeviceCount() except *
 cpdef setDevice(int device)
 cpdef deviceSynchronize()
 
+cpdef int deviceCanAccessPeer(int device, int peerDevice) except *
+cpdef deviceEnablePeerAccess(int peerDevice)
+
 
 ###############################################################################
 # Memory management

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -49,6 +49,10 @@ cdef extern from "cupy_cuda.h":
     int cudaSetDevice(int device) nogil
     int cudaDeviceSynchronize() nogil
 
+    int cudaDeviceCanAccessPeer(int* canAccessPeer, int device,
+                                int peerDevice) nogil
+    int cudaDeviceEnablePeerAccess(int peerDevice, unsigned int flags) nogil
+
     # Memory management
     int cudaMalloc(void** devPtr, size_t size) nogil
     int cudaFree(void* devPtr) nogil
@@ -150,6 +154,18 @@ cpdef setDevice(int device):
 cpdef deviceSynchronize():
     with nogil:
         status = cudaDeviceSynchronize()
+    check_status(status)
+
+
+cpdef int deviceCanAccessPeer(int device, int peerDevice) except *:
+    cpdef int ret
+    status = cudaDeviceCanAccessPeer(&ret, device, peerDevice)
+    check_status(status)
+    return ret
+
+
+cpdef deviceEnablePeerAccess(int peerDevice):
+    status = cudaDeviceEnablePeerAccess(peerDevice, 0)
     check_status(status)
 
 


### PR DESCRIPTION
fix #882.
This PR adds cudaDeviceEnablePeerAccess call right before the first copy between given two devices.