### PR TITLE
change links __init__.py to include the caffe

### DIFF
--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -17,7 +17,7 @@ from chainer.links.loss import hierarchical_softmax
 from chainer.links.loss import negative_sampling
 from chainer.links.model import classifier
 from chainer.links.normalization import batch_normalization
-
+from chainer.links import caffe
 
 Maxout = maxout.Maxout
 PReLU = prelu.PReLU


### PR DESCRIPTION
The links `__init__.py` file didn't include reference to the caffe module and thus importing such as `from chainer import links as L` then referencing objects in the caffe module as `L.caffe.CaffeFunction` threw an error.

```
In [1]: from chainer import links as L

In [2]: L.caffe.CaffeFunction
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-cc0cfc514d8a> in <module>()
----> 1 L.caffe.CaffeFunction

AttributeError: 'module' object has no attribute 'caffe'
```

**Changed the link `__init__.py` to include `from chainer.links import caffe`**