### PR TITLE
Support cover_all=True in Convolutional2D

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -26,10 +26,11 @@ def _pair(x):
 
 class Convolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, use_cudnn=True):
+    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.use_cudnn = use_cudnn
+        self.cover_all = cover_all
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -58,7 +59,8 @@ class Convolution2DFunction(function.Function):
         b = inputs[2] if len(inputs) == 3 else None
         kh, kw = W.shape[2:]
         self.col = conv.im2col_cpu(
-            x, kh, kw, self.sy, self.sx, self.ph, self.pw)
+            x, kh, kw, self.sy, self.sx, self.ph, self.pw,
+            cover_all=self.cover_all)
         y = numpy.tensordot(self.col, W, ((1, 2, 3), (1, 2, 3)))
         if b is not None:
             y += b
@@ -71,8 +73,10 @@ class Convolution2DFunction(function.Function):
         out_c, _, kh, kw = W.shape
         n, c, h, w = x.shape
 
-        out_h = conv.get_conv_outsize(h, kh, self.sy, self.ph)
-        out_w = conv.get_conv_outsize(w, kw, self.sx, self.pw)
+        out_h = conv.get_conv_outsize(h, kh, self.sy, self.ph,
+                                      cover_all=self.cover_all)
+        out_w = conv.get_conv_outsize(w, kw, self.sx, self.pw,
+                                      cover_all=self.cover_all)
 
         y = cuda.cupy.empty((n, out_c, out_h, out_w), dtype=x.dtype)
         if cuda.cudnn_enabled and self.use_cudnn:
@@ -116,7 +120,8 @@ class Convolution2DFunction(function.Function):
         else:
             # Implementation using im2col
             self.col = conv.im2col_gpu(
-                x, kh, kw, self.sy, self.sx, self.ph, self.pw)
+                x, kh, kw, self.sy, self.sx, self.ph, self.pw,
+                cover_all=self.cover_all)
             W_mat = W.reshape(out_c, -1)
             col_mats = self.col.reshape(n, -1, out_h * out_w)
             y_mats = y.reshape(n, out_c, -1)
@@ -233,7 +238,8 @@ class Convolution2DFunction(function.Function):
             return gx, gW, gb
 
 
-def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True):
+def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
+                   cover_all=False):
     """Two-dimensional convolution function.
 
     This is an implementation of two-dimensional convolution in ConvNets.
@@ -261,6 +267,8 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True):
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         use_cudnn (bool): If ``True``, then this function uses cuDNN if
             available.
+        cover_all (bool): If True, all spatial locations are convoluted into
+            some output pixels. It may make the output size larger.
 
 
     Returns:
@@ -291,7 +299,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True):
     .. seealso:: :class:`Convolution2D`
 
     """
-    func = Convolution2DFunction(stride, pad, use_cudnn)
+    func = Convolution2DFunction(stride, pad, use_cudnn, cover_all)
     if b is None:
         return func(x, W)
     else:

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -15,6 +15,7 @@ from chainer.testing import condition
 
 @testing.parameterize(*testing.product({
     'c_contiguous': [True, False],
+    'cover_all': [True, False],
 }))
 class TestConvolution2DFunction(unittest.TestCase):
 
@@ -33,8 +34,12 @@ class TestConvolution2DFunction(unittest.TestCase):
 
         self.x = numpy.random.uniform(-1, 1,
                                       (2, 3, 4, 3)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1,
-                                       (2, 2, 2, 2)).astype(numpy.float32)
+        if self.cover_all:
+            self.gy = numpy.random.uniform(-1, 1,
+                                           (2, 2, 3, 2)).astype(numpy.float32)
+        else:
+            self.gy = numpy.random.uniform(-1, 1,
+                                           (2, 2, 2, 2)).astype(numpy.float32)
 
     @attr.cudnn
     def test_forward_consistency(self, nobias=False):
@@ -43,14 +48,14 @@ class TestConvolution2DFunction(unittest.TestCase):
         b_cpu = None if nobias else chainer.Variable(self.b)
         y_cpu = functions.convolution_2d(
             x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
-            use_cudnn=self.use_cudnn)
+            use_cudnn=self.use_cudnn, cover_all=self.cover_all)
 
         x_gpu = chainer.Variable(cuda.to_gpu(self.x))
         W_gpu = chainer.Variable(cuda.to_gpu(self.W))
         b_gpu = None if nobias else chainer.Variable(cuda.to_gpu(self.b))
         y_gpu = functions.convolution_2d(
             x_gpu, W_gpu, b_gpu, stride=self.stride, pad=self.pad,
-            use_cudnn=self.use_cudnn)
+            use_cudnn=self.use_cudnn, cover_all=self.cover_all)
 
         gradient_check.assert_allclose(y_cpu.data, y_gpu.data.get())
 
@@ -85,7 +90,7 @@ class TestConvolution2DFunction(unittest.TestCase):
 
         gradient_check.check_backward(
             convolution_2d.Convolution2DFunction(
-                self.stride, self.pad, self.use_cudnn),
+                self.stride, self.pad, self.use_cudnn, self.cover_all),
             args, y_grad, eps=1e-2)
 
     @condition.retry(3)
@@ -123,10 +128,10 @@ class TestConvolution2DFunction(unittest.TestCase):
                             None, cuda.to_gpu(self.gy))
 
 
-@testing.parameterize(
-    {'use_cudnn': True},
-    {'use_cudnn': False},
-)
+@testing.parameterize(*testing.product({
+    'use_cudnn': [True, False],
+    'cover_all': [True, False],
+}))
 @attr.cudnn
 class TestConvolution2DCudnnCall(unittest.TestCase):
 
@@ -141,15 +146,19 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
         self.W = cuda.cupy.random.normal(
             0, numpy.sqrt(1. / (kh * kw * in_channels)),
             (out_channels, in_channels, kh, kw)).astype(numpy.float32)
-        self.gy = cuda.cupy.random.uniform(
-            -1, 1, (2, 2, 2, 2)).astype(numpy.float32)
+        if self.cover_all:
+            self.gy = cuda.cupy.random.uniform(
+                -1, 1, (2, 2, 3, 2)).astype(numpy.float32)
+        else:
+            self.gy = cuda.cupy.random.uniform(
+                -1, 1, (2, 2, 2, 2)).astype(numpy.float32)
 
     def forward(self):
         x = chainer.Variable(self.x)
         W = chainer.Variable(self.W)
         return functions.convolution_2d(
             x, W, None, stride=self.stride, pad=self.pad,
-            use_cudnn=self.use_cudnn)
+            use_cudnn=self.use_cudnn, cover_all=self.cover_all)
 
     def test_call_cudnn_forward(self):
         with mock.patch('cupy.cudnn.cudnn.convolutionForward') as func:


### PR DESCRIPTION
- [x] Fix test for cover_all=True with use_cudnn=True


Currently this has error for cudnn function:


```
======================================================================
FAIL: test_backward_gpu_nobias (test_convolution_2d.TestConvolution2DFunction_param_2)  parameter: {'c_contiguous': False, 'cover_all': True}
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/wkentaro/chainer/chainer/testing/condition.py", line 71, in wrapper
    fail()
  File "/home/wkentaro/chainer/chainer/testing/condition.py", line 51, in fail
    instance.fail(msg)
AssertionError:
Fail: 3, Success: 0

The first error message:
Traceback (most recent call last):
  File "/home/wkentaro/chainer/chainer/testing/condition.py", line 57, in <lambda>
    lambda: f(*args, **kwargs),
  File "/home/wkentaro/chainer/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py", line 122, in test_backward_gpu_nobias
    None, cuda.to_gpu(self.gy))
  File "/home/wkentaro/chainer/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py", line 102, in check_backward
    args, y_grad, eps=1e-2)
  File "/home/wkentaro/chainer/chainer/gradient_check.py", line 196, in check_backward
    y = func(*xs)
  File "/home/wkentaro/chainer/chainer/function.py", line 105, in __call__
    outputs = self.forward(in_data)
  File "/home/wkentaro/chainer/chainer/function.py", line 181, in forward
    return self.forward_gpu(inputs)
  File "/home/wkentaro/chainer/chainer/functions/connection/convolution_2d.py", line 111, in forward_gpu
    y_desc.value, y.data.ptr)
  File "cupy/cuda/cudnn.pyx", line 347, in cupy.cuda.cudnn.convolutionForward (cupy/cuda/cudnn.cpp:4771)
    cpdef convolutionForward(
  File "cupy/cuda/cudnn.pyx", line 359, in cupy.cuda.cudnn.convolutionForward (cupy/cuda/cudnn.cpp:4577)
    check_status(status)
  File "cupy/cuda/cudnn.pyx", line 167, in cupy.cuda.cudnn.check_status (cupy/cuda/cudnn.cpp:1311)
    raise CuDNNError(status)
CuDNNError: CUDNN_STATUS_BAD_PARAM: CUDNN_STATUS_BAD_PARAM
```