### PR TITLE
Skip cudnn test when cudnn v2 is installed

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -218,7 +218,7 @@ class TestSoftmaxCrossEntropyCudnnCall(unittest.TestCase):
         t = chainer.Variable(self.t)
         return functions.softmax_cross_entropy(x, t, self.use_cudnn)
 
-    @unittest.skipIf(cuda.cudnn.cudnn.getVersion() < 3000,
+    @unittest.skipIf(cuda.available and cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports softmax-log')
     def test_call_cudnn_forward(self):
         with mock.patch('cupy.cudnn.cudnn.softmaxForward') as func:

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -218,6 +218,8 @@ class TestSoftmaxCrossEntropyCudnnCall(unittest.TestCase):
         t = chainer.Variable(self.t)
         return functions.softmax_cross_entropy(x, t, self.use_cudnn)
 
+    @unittest.skipIf(cuda.cudnn.cudnn.getVersion() < 3000,
+                     'Only cudnn ver>=3 supports softmax-log')
     def test_call_cudnn_forward(self):
         with mock.patch('cupy.cudnn.cudnn.softmaxForward') as func:
             self.forward()


### PR DESCRIPTION
cuDNN is used only when cuDNN ver >=3 is installed on softmax cross entropy.