### PR TITLE
Show actual type at error in cuda.to_gpu

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -219,7 +219,8 @@ def to_cpu(array, stream=None):
         return array
     else:
         raise TypeError(
-            'The array sent to cpu must be numpy.ndarray or cupy.ndarray')
+            'The array sent to cpu must be numpy.ndarray or cupy.ndarray.'
+            '\nActual type: {0}.'.format(type(array)))
 
 
 def empty(shape, dtype=numpy.float32):


### PR DESCRIPTION
**before**
```
The first error message:
Traceback (most recent call last):
  File "/home/wkentaro/chainer/chainer/testing/condition.py", line 57, in <lambda>
    lambda: f(*args, **kwargs),
  File "/home/wkentaro/chainer/tests/chainer_tests/functions_tests/loss_tests/test_smooth_l1_loss.py", line 58, in test_backward_gpu
    self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
  File "/home/wkentaro/chainer/tests/chainer_tests/functions_tests/loss_tests/test_smooth_l1_loss.py", line 49, in check_backward
    (x_data, t_data), None, eps=1e-2, atol=1e-3)
  File "/home/wkentaro/chainer/chainer/gradient_check.py", line 224, in check_backward
    assert_allclose(gx, x.grad, atol=atol, rtol=rtol)
  File "/home/wkentaro/chainer/chainer/gradient_check.py", line 76, in assert_allclose
    y = cuda.to_cpu(utils.force_array(y))
  File "/home/wkentaro/chainer/chainer/cuda.py", line 222, in to_cpu
    'The array sent to cpu must be numpy.ndarray or cupy.ndarray')
TypeError: The array sent to cpu must be numpy.ndarray or cupy.ndarray
```

**after**
```
Traceback (most recent call last):
  File "/home/wkentaro/chainer/chainer/testing/condition.py", line 57, in <lambda>
    lambda: f(*args, **kwargs),
  File "/home/wkentaro/chainer/tests/chainer_tests/functions_tests/loss_tests/test_smooth_l1_loss.py", line 58, in test_backward_gpu
    self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
  File "/home/wkentaro/chainer/tests/chainer_tests/functions_tests/loss_tests/test_smooth_l1_loss.py", line 49, in check_backward
    (x_data, t_data), None, eps=1e-2, atol=1e-3)
  File "/home/wkentaro/chainer/chainer/gradient_check.py", line 224, in check_backward
    assert_allclose(gx, x.grad, atol=atol, rtol=rtol)
  File "/home/wkentaro/chainer/chainer/gradient_check.py", line 76, in assert_allclose
    y = cuda.to_cpu(utils.force_array(y))
  File "/home/wkentaro/chainer/chainer/cuda.py", line 223, in to_cpu
    '\nActual type: {0}.'.format(type(array)))
TypeError: The array sent to cpu must be numpy.ndarray or cupy.ndarray.
Actual type: <type 'NoneType'>.
```