### PR TITLE
Fix document of pooling and convolution functions.

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -231,9 +231,9 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True):
         W (~chainer.Variable): Weight variable of shape
             :math:`(c_O, c_I, k_H, k_W)`.
         b (~chainer.Variable): Bias variable of length :math:`c_O` (optional).
-        stride (int or (int, int)): Stride of filter applications.
+        stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
-        pad (int or (int, int)): Spatial padding width for input arrays.
+        pad (int or pair of ints): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         use_cudnn (bool): If True, then this function uses CuDNN if available.
 

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -246,9 +246,9 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
         W (~chainer.Variable): Weight variable of shape
         :math:`(c_I, c_O, k_H, k_W)`.
         b (~chainer.Variable): Bias variable of length :math:`c_O` (optional).
-        stride (int or (int, int)): Stride of filter applications.
+        stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
-        pad (int or (int, int)): Spatial padding width for input arrays.
+        pad (int or pair of ints): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         outsize (tuple): Expected output size of deconvolutional operation.
             It should be pair of height and width :math:`(out_H, out_W)`.

--- a/chainer/functions/pooling/average_pooling_2d.py
+++ b/chainer/functions/pooling/average_pooling_2d.py
@@ -116,12 +116,12 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
 
     Args:
         x (~chainer.Variable): Input variable.
-        ksize (int or (int, int)): Size of pooling window. ``ksize=k`` and
+        ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
-        stride (int or (int, int) or None): Stride of pooling applications.
+        stride (int or pair of ints or None): Stride of pooling applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent. If None is
             specified, then it uses same stride as the pooling window size.
-        pad (int or (int, int)): Spatial padding width for the input array.
+        pad (int or pair of ints): Spatial padding width for the input array.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         use_cudnn (bool): If True and CuDNN is enabled, then this function
             uses CuDNN as the core implementation.

--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -147,12 +147,12 @@ def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
 
     Args:
         x (~chainer.Variable): Input variable.
-        ksize (int or (int, int)): Size of pooling window. ``ksize=k`` and
+        ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
-        stride (int or (int, int) or None): Stride of pooling applications.
+        stride (int or pair of ints or None): Stride of pooling applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent. If None is
             specified, then it uses same stride as the pooling window size.
-        pad (int or (int, int)): Spatial padding width for the input array.
+        pad (int or pair of ints): Spatial padding width for the input array.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         cover_all (bool): If True, all spatial locations are pooled into some
             output pixels. It may make the output size larger.

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -14,11 +14,11 @@ class Convolution2D(link.Link):
     Args:
         in_channels (int): Number of channels of input arrays.
         out_channels (int): Number of channels of output arrays.
-        ksize (int or (int, int)): Size of filters (a.k.a. kernels).
+        ksize (int or pair of ints): Size of filters (a.k.a. kernels).
             ``ksize=k`` and ``ksize=(k, k)`` are equivalent.
-        stride (int or (int, int)): Stride of filter applications.
+        stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
-        pad (int or (int, int)): Spatial padding width for input arrays.
+        pad (int or pair of ints): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         wscale (float): Scaling factor of the initial weight.
         bias (float): Initial bias value.

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -16,11 +16,11 @@ class Deconvolution2D(link.Link):
     Args:
         in_channels (int): Number of channels of input arrays.
         out_channels (int): Number of channels of output arrays.
-        ksize (int or (int, int)): Size of filters (a.k.a. kernels).
+        ksize (int or pair of ints): Size of filters (a.k.a. kernels).
             ``ksize=k`` and ``ksize=(k, k)`` are equivalent.
-        stride (int or (int, int)): Stride of filter applications.
+        stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
-        pad (int or (int, int)): Spatial padding width for input arrays.
+        pad (int or pair of ints): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         wscale (float): Scaling factor of the initial weight.
         bias (float): Initial bias value.

--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -18,13 +18,13 @@ class MLPConvolution2D(link.ChainList):
         in_channels (int): Number of channels of input arrays.
         out_channels (tuple of ints): Tuple of number of channels. The i-th
             integer indicates the number of filters of the i-th convolution.
-        ksize (int or (int, int)): Size of filters (a.k.a. kernels) of the
+        ksize (int or pair of ints): Size of filters (a.k.a. kernels) of the
             first convolution layer. ``ksize=k`` and ``ksize=(k, k)`` are
             equivalent.
-        stride (int or (int, int)): Stride of filter applications at the first
+        stride (int or pair of ints): Stride of filter applications at the first
             convolution layer. ``stride=s`` and ``stride=(s, s)`` are
             equivalent.
-        pad (int or (int, int)): Spatial padding width for input arrays at the
+        pad (int or pair of ints): Spatial padding width for input arrays at the
             first convolution layer. ``pad=p`` and ``pad=(p, p)`` are
             equivalent.
         activation (function): Activation function for internal hidden units.


### PR DESCRIPTION
Use "pair of ints" instead of `(int, int)` because napoleon cannot interpret the latter.

See e.g. ksize, stride and pad argument of [max_pooling function](http://docs.chainer.org/en/stable/reference/functions.html#chainer.functions.max_pooling_2d).