### PR TITLE
Fix batch_matmul to avoid ZeroDivisionError in GPU mode

### DIFF
--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -55,8 +55,8 @@ def _get_ld(a):
 
 
 def _batch_matmul_gpu(a, b, out, transa=False, transb=False, transout=False):
-    a = _as_batch_mat(a.copy())
-    b = _as_batch_mat(b.copy())
+    a = _as_batch_mat(cupy.ascontiguousarray(a))
+    b = _as_batch_mat(cupy.ascontiguousarray(b))
     trans_axis = (0, 2, 1)
     if transout:
         out = out.transpose(trans_axis)

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -55,8 +55,8 @@ def _get_ld(a):
 
 
 def _batch_matmul_gpu(a, b, out, transa=False, transb=False, transout=False):
-    a = _as_batch_mat(a)
-    b = _as_batch_mat(b)
+    a = _as_batch_mat(a.copy())
+    b = _as_batch_mat(b.copy())
     trans_axis = (0, 2, 1)
     if transout:
         out = out.transpose(trans_axis)

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -55,8 +55,8 @@ def _get_ld(a):
 
 
 def _batch_matmul_gpu(a, b, out, transa=False, transb=False, transout=False):
-    a = _as_batch_mat(cupy.ascontiguousarray(a))
-    b = _as_batch_mat(cupy.ascontiguousarray(b))
+    a = _as_batch_mat(cuda.cupy.ascontiguousarray(a))
+    b = _as_batch_mat(cuda.cupy.ascontiguousarray(b))
     trans_axis = (0, 2, 1)
     if transout:
         out = out.transpose(trans_axis)

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -217,4 +217,20 @@ class TestBatchMatMulMatrixMatrixBatchSize1(_TestMatMul):
             for i in six.moves.range(1)])
 
 
+class TestBatchMatMulBroadcastedMatrix(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, m, k)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (1, k, n)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x,
+            F.broadcast_to(y, (batch_size, k, n)))
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i], self.x2[0])
+            for i in six.moves.range(batch_size)])
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -217,7 +217,7 @@ class TestBatchMatMulMatrixMatrixBatchSize1(_TestMatMul):
             for i in six.moves.range(1)])
 
 
-class TestBatchMatMulBroadcastedMatrix(_TestMatMul):
+class TestBatchMatMulBroadcastedMatrix1(_TestMatMul):
 
     def setUp(self):
         self.x1 = numpy.random.uniform(
@@ -230,6 +230,22 @@ class TestBatchMatMulBroadcastedMatrix(_TestMatMul):
             F.broadcast_to(y, (batch_size, k, n)))
         self.forward_answer = numpy.array([
             numpy.dot(self.x1[i], self.x2[0])
+            for i in six.moves.range(batch_size)])
+
+
+class TestBatchMatMulBroadcastedMatrix2(_TestMatMul):
+
+    def setUp(self):
+        self.x1 = numpy.random.uniform(
+            .5, 1, (batch_size, m, k)).astype(numpy.float32)
+        self.x2 = numpy.random.uniform(
+            .5, 1, (k, n)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_size, m, n)).astype(numpy.float32)
+        self.op = lambda x, y: F.batch_matmul(x,
+            F.broadcast_to(F.expand_dims(y, 0), (batch_size, k, n)))
+        self.forward_answer = numpy.array([
+            numpy.dot(self.x1[i], self.x2)
             for i in six.moves.range(batch_size)])
 
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -226,8 +226,8 @@ class TestBatchMatMulBroadcastedMatrix1(_TestMatMul):
             .5, 1, (1, k, n)).astype(numpy.float32)
         self.gy = numpy.random.uniform(
             -1, 1, (batch_size, m, n)).astype(numpy.float32)
-        self.op = lambda x, y: F.batch_matmul(x,
-            F.broadcast_to(y, (batch_size, k, n)))
+        self.op = lambda x, y: F.batch_matmul(
+            x, F.broadcast_to(y, (batch_size, k, n)))
         self.forward_answer = numpy.array([
             numpy.dot(self.x1[i], self.x2[0])
             for i in six.moves.range(batch_size)])
@@ -242,8 +242,8 @@ class TestBatchMatMulBroadcastedMatrix2(_TestMatMul):
             .5, 1, (k, n)).astype(numpy.float32)
         self.gy = numpy.random.uniform(
             -1, 1, (batch_size, m, n)).astype(numpy.float32)
-        self.op = lambda x, y: F.batch_matmul(x,
-            F.broadcast_to(F.expand_dims(y, 0), (batch_size, k, n)))
+        self.op = lambda x, y: F.batch_matmul(
+            x, F.broadcast_to(F.expand_dims(y, 0), (batch_size, k, n)))
         self.forward_answer = numpy.array([
             numpy.dot(self.x1[i], self.x2)
             for i in six.moves.range(batch_size)])


### PR DESCRIPTION
The `batch_matmul` (in GPU mode) uses  `strides[0]` of an input array as a divisor in `_mat_ptrs` (i.e. the third argument of `cuda.cupy.arange`).
https://github.com/pfnet/chainer/blob/master/chainer/functions/math/matmul.py#L23 

And strides of ndarray will be 0 when it is a broadcasted array because of rule 4 of the ufunc’s broadcasting rules.
http://docs.scipy.org/doc/numpy-1.10.0/reference/ufuncs.html

So, ZeroDivisionError will happen.
```python
A = chainer.Variable(xp.random.random((3, 2, 4), dtype=np.float32))
B = chainer.Variable(xp.random.random((4, 6), dtype=np.float32))
B = F.expand_dims(B, 0)
B = F.broadcast_to(B, (3, 4, 6))
print(B.data.shape, B.data.strides)     # —> (3, 4, 6) (0, 48, 8)

C = F.batch_metmul(A, B)  # ZeroDivisionError (only on GPU mode)
```

We can fix the strides by simply copying the ndarray.

```python
b = xp.random.random((4, 6))
b = xp.expand_dims(b, 0)
b = xp.broadcast_to(b, (3,4,6))
print(b.shape, b.strides)   # —> (3, 4, 6) (0, 48, 8) 
_b = b.copy()
print(_b.shape, _b.strides) # —> (3, 4, 6) (192, 48, 8) 
```
