### PR TITLE
Fix test for debug_print

### DIFF
--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -406,8 +406,8 @@ class TestDebugPrint(unittest.TestCase):
         self.assertIn('device: CPU', result)
         self.assertIn('numpy.ndarray', result)
 
-        self.check_debug_print(v, mean=np.mean(self.arr),
-                               std=np.std(self.arr))
+        self.check_debug_print(v, mean=float(np.mean(v.data)),
+                               std=float(np.std(v.data)))
 
     @attr.gpu
     def test_debug_print_gpu(self):
@@ -418,8 +418,8 @@ class TestDebugPrint(unittest.TestCase):
         self.assertIn('device: <CUDA Device 0>', result)
         self.assertIn('cupy.core.core.ndarray', result)
 
-        self.check_debug_print(v, mean=cuda.cupy.mean(self.arr),
-                               std=cuda.cupy.std(self.arr))
+        self.check_debug_print(v, mean=float(cuda.cupy.mean(v.data)),
+                               std=float(cuda.cupy.std(v.data)))
 
 
 class TestVariableSetCreator(unittest.TestCase):


### PR DESCRIPTION
The current test for debug_print cannot be passed on py3. I fixed the test.