### PR TITLE
Fix README of MNIST example

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -4,5 +4,4 @@ This is a minimal example to write a feed-forward net.
 The code consists of three parts: dataset preparation, network and optimizer definition and learning loop.
 This is a common routine to write a learning process of networks with dataset that is small enough to fit into memory.
 
-This example requires scikit-learn to load the MNIST dataset.
 If you want to run this example on the N-th GPU, pass `--gpu=N` to the script.


### PR DESCRIPTION
MNIST example no longer depends on scikit-learn.