### PR TITLE
Fix errors F.det and F.batch_det raises

### DIFF
--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -72,8 +72,10 @@ class BatchDet(function.Function):
     def backward_gpu(self, x, gy):
         x, = x
         gy, = gy
-        grad = (gy[:, None, None] * self.detx[:, None, None] *
-                inv._inv_gpu(x.transpose((0, 2, 1))))
+        inv_x, info = inv._inv_gpu(x.transpose((0, 2, 1)))
+        if cuda.cupy.any(info != 0):
+            raise numpy.linalg.LinAlgError('Singular Matrix')
+        grad = gy[:, None, None] * self.detx[:, None, None] * inv_x
         return utils.force_array(grad),
 
 

--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -67,7 +67,7 @@ class BatchDet(function.Function):
         gy, = gy
         try:
             inv_x = numpy.linalg.inv(x.transpose((0, 2, 1)))
-        except numpy.linalg.LinAlgError as e:
+        except numpy.linalg.LinAlgError:
             raise ValueError('Input has singular matrices.')
         grad = gy[:, None, None] * self.detx[:, None, None] * inv_x
         return utils.force_array(grad),

--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -22,11 +22,11 @@ def _det_gpu(b):
     # Output array
     # These arrays hold information on the execution success
     # or if the matrix was singular.
-    info1 = cuda.cupy.zeros(n_matrices, dtype=numpy.intp)
+    info = cuda.cupy.zeros(n_matrices, dtype=numpy.intp)
     ap = matmul._mat_ptrs(a)
     _, lda = matmul._get_ld(a)
     cuda.cublas.sgetrfBatched(cuda.Device().cublas_handle, n, ap.data.ptr, lda,
-                              p.data.ptr, info1.data.ptr, n_matrices)
+                              p.data.ptr, info.data.ptr, n_matrices)
     det = cuda.cupy.prod(a.diagonal(axis1=1, axis2=2), axis=1)
     # The determinant is equal to the product of the diagonal entries
     # of `a` where the sign of `a` is flipped depending on whether
@@ -34,8 +34,7 @@ def _det_gpu(b):
     rng = cuda.cupy.arange(1, n + 1, dtype='int32')
     parity = cuda.cupy.sum(p != rng, axis=1) % 2
     sign = 1. - 2. * parity.astype('float32')
-    success = cuda.cupy.all(info1 == 0)
-    return det * sign, success
+    return det * sign, info
 
 
 class BatchDet(function.Function):
@@ -60,9 +59,7 @@ class BatchDet(function.Function):
         return self.detx,
 
     def forward_gpu(self, x):
-        self.detx, success = _det_gpu(x[0])
-        if not success:
-            raise ValueError('Singular Matrix')
+        self.detx, _ = _det_gpu(x[0])
         return self.detx,
 
     def backward_cpu(self, x, gy):

--- a/chainer/functions/math/inv.py
+++ b/chainer/functions/math/inv.py
@@ -32,7 +32,7 @@ def _inv_gpu(b):
     cuda.cublas.sgetriBatched(
         handle, n, ap.data.ptr, lda, p.data.ptr, cp.data.ptr, ldc,
         info.data.ptr, n_matrices)
-    return c
+    return c, info
 
 
 class Inv(function.Function):
@@ -52,7 +52,7 @@ class Inv(function.Function):
 
     def forward_gpu(self, x):
         shape = x[0].shape
-        self.invx = _inv_gpu(x[0].reshape(1, *shape)).reshape(shape)
+        self.invx = _inv_gpu(x[0].reshape(1, *shape))[0].reshape(shape)
         return self.invx,
 
     def backward(self, x, gy):
@@ -80,7 +80,7 @@ class BatchInv(function.Function):
         return self.invx,
 
     def forward_gpu(self, x):
-        self.invx = _inv_gpu(x[0])
+        self.invx, _ = _inv_gpu(x[0])
         return self.invx,
 
     def backward_cpu(self, x, gy):

--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -161,6 +161,7 @@ class DetFunctionTest(unittest.TestCase):
         else:
             x[...] = 0.0
         x = chainer.Variable(x)
+        # it checks no errors are raised
         self.det(x)
 
     def test_singular_matrix_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -146,6 +146,7 @@ class DetFunctionTestBase(object):
     def test_singular_matrix_cpu(self):
         self.check_singular_matrix(self.x)
 
+    @attr.gpu
     def test_singular_matrix_gpu(self):
         self.check_singular_matrix(cuda.to_gpu(self.x))
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -141,7 +141,7 @@ class DetFunctionTestBase(object):
             x_data[0, :, :] = 0.0
         else:
             x_data[:, :] = 0.0
-        with self.assertRaises(numpy.linalg.LinAlgError):
+        with self.assertRaises(ValueError):
             gradient_check.check_backward(self.det, x_data, y_grad)
 
     @attr.gpu
@@ -152,7 +152,7 @@ class DetFunctionTestBase(object):
             x_data[0, :, :] = 0.0
         else:
             x_data[:, :] = 0.0
-        with self.assertRaises(numpy.linalg.LinAlgError):
+        with self.assertRaises(ValueError):
             gradient_check.check_backward(self.det, x_data, y_grad)
 
     def test_answer_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -152,7 +152,7 @@ class DetFunctionTestBase(object):
             x_data[0, :, :] = 0.0
         else:
             x_data[:, :] = 0.0
-        with self.assertRaises(ValueError):
+        with self.assertRaises(numpy.linalg.LinAlgError):
             gradient_check.check_backward(self.det, x_data, y_grad)
 
     def test_answer_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -135,6 +135,20 @@ class DetFunctionTestBase(object):
         y = F.det(x)
         self.assertEqual(y.data.ndim, 1)
 
+    def check_singular_matrix(self, x):
+        if self.batched:
+            x[0, ...] = 0.0
+        else:
+            x[...] = 0.0
+        x = chainer.Variable(x)
+        self.det(x)
+
+    def test_singular_matrix_cpu(self):
+        self.check_singular_matrix(self.x)
+
+    def test_singular_matrix_gpu(self):
+        self.check_singular_matrix(cuda.to_gpu(self.x))
+
     def test_zero_det_cpu(self):
         x_data, y_grad = self.x, self.gy
         if x_data.ndim == 3:


### PR DESCRIPTION
* Add `info` vector to the return value of `_inv_gpu`.
* Change `success` with `info` in the return value of `_det_gpu`
* `F.det` and `F.batch_det` does not raise `ValueError` even if some input matrices are singular.
* `F.det` and `F.batch_det` raise `numpy.LinAlgError`when input matrices are singular.

Fix #986 

Please merge #988 before this PR.