### PR TITLE
Function hook

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -1,6 +1,6 @@
 import collections
-import threading
 import pkg_resources
+import threading
 
 from chainer import flag
 from chainer import function

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -1,5 +1,5 @@
-import pkg_resources
 import collections
+import pkg_resources
 
 from chainer import flag
 from chainer import function

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -1,4 +1,5 @@
 import collections
+import threading
 import pkg_resources
 
 from chainer import flag
@@ -30,6 +31,21 @@ ON = flag.ON
 OFF = flag.OFF
 AUTO = flag.AUTO
 
-global_function_hooks = collections.OrderedDict()
+
+class ThreadSafeOrderedDict(collections.OrderedDict):
+
+    def __init__(self, *args, **kwargs):
+        super(ThreadSafeOrderedDict, self).__init__(*args, **kwargs)
+        self._lock = threading.Lock()
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self._lock.release()
+
+
+global_function_hooks = ThreadSafeOrderedDict()
 
 basic_math.install_variable_arithmetics()

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -1,4 +1,5 @@
 import pkg_resources
+import collections
 
 from chainer import flag
 from chainer import function
@@ -28,5 +29,7 @@ Variable = variable.Variable
 ON = flag.ON
 OFF = flag.OFF
 AUTO = flag.AUTO
+
+global_function_hooks = collections.OrderedDict()
 
 basic_math.install_variable_arithmetics()

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -31,9 +31,14 @@ ON = flag.ON
 OFF = flag.OFF
 AUTO = flag.AUTO
 
-thread_local_objects = threading.local()
-thread_local_objects.registered_function_hooks = collections.OrderedDict()
-registered_function_hooks = thread_local_objects.registered_function_hooks
+
+thread_local = threading.local()
+
+
+def get_function_hooks():
+    if not hasattr(thread_local, 'function_hooks'):
+        thread_local.function_hooks = collections.OrderedDict()
+    return thread_local.function_hooks
 
 _debug = False
 

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -31,21 +31,8 @@ ON = flag.ON
 OFF = flag.OFF
 AUTO = flag.AUTO
 
-
-class ThreadSafeOrderedDict(collections.OrderedDict):
-
-    def __init__(self, *args, **kwargs):
-        super(ThreadSafeOrderedDict, self).__init__(*args, **kwargs)
-        self._lock = threading.Lock()
-
-    def __enter__(self):
-        self._lock.acquire()
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self._lock.release()
-
-
-global_function_hooks = ThreadSafeOrderedDict()
+thread_local_objects = threading.local()
+thread_local_objects.registered_function_hooks = collections.OrderedDict()
+registered_function_hooks = thread_local_objects.registered_function_hooks
 
 basic_math.install_variable_arithmetics()

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -369,7 +369,7 @@ class FunctionHook(object):
 
     Function hooks that derive :class:`FunctionHook` are required
     to implement four functions:
-    :meth:`~chainer.function.FunctionHook.forward_preprocess`, 
+    :meth:`~chainer.function.FunctionHook.forward_preprocess`,
     :meth:`~chainer.function.FunctionHook.forward_postprocess`,
     :meth:`~chainer.function.FunctionHook.backward_preprocess`, and
     :meth:`~chainer.function.FunctionHook.backward_postprocess`.

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -1,6 +1,8 @@
+import collections
 import os
 import weakref
 
+import chainer
 from chainer import cuda
 from chainer import flag
 from chainer.utils import type_check
@@ -97,13 +99,21 @@ class Function(object):
             :class:`Variable` objects.
 
         """
+
         in_data = tuple([x.data for x in inputs])
         if self.type_check_enable:
             self._check_data_type_forward(in_data)
+
+        hooks = collections.OrderedDict(chainer.global_function_hooks)
+        hooks.update(self.local_function_hooks)
+        for hook in hooks.values():
+            hook.forward_preprocess(self, in_data)
         # Forward prop
         with cuda.get_device(*in_data):
             outputs = self.forward(in_data)
             assert type(outputs) == tuple
+        for hook in hooks.values():
+            hook.forward_postprocess(self, in_data)
 
         out_v = flag.aggregate_flags([x.volatile for x in inputs])
         ret = tuple([variable.Variable(y, volatile=out_v) for y in outputs])
@@ -122,6 +132,26 @@ class Function(object):
             return ret[0]
         else:
             return ret
+
+    @property
+    def local_function_hooks(self):
+        """Ordered Dictionary of registered function hooks.
+
+        Contrary to ``~chainer.global_function_hooks``,
+        which registers its elements to all functions,
+        Function hooks in this property is specific to this function.
+        """
+        if not hasattr(self, '_local_function_hooks'):
+            self._local_function_hooks = collections.OrderedDict()
+        return self._local_function_hooks
+
+    @local_function_hooks.setter
+    def local_function_hooks(self, val):
+        self._local_function_hooks = val
+
+    @local_function_hooks.deleter
+    def local_function_hooks(self):
+        del self._hook_history
 
     @property
     def label(self):
@@ -299,3 +329,215 @@ Invalid operation is performed in: {0} (Forward)
             if y_ref is not None:
                 y_ref.creator = None
         self.inputs = None
+
+    def add_hook(self, hook, name=None):
+        """Registers the function hook.
+
+        Args:
+            hook(~chainer.functions.FunctionHook):
+                the function hook to be registered.
+            name(str): The name of the function hook.
+                name must be unique among function hooks
+                registered to the function. If ``None``,
+                default name of the function hook is used.
+        """
+        if not isinstance(hook, FunctionHook):
+            raise TypeError('hook must be a FunctionHook')
+        if name is None:
+            name = hook.name
+        if name in self.local_function_hooks:
+            raise KeyError('hook %s already exists' % name)
+        self.local_function_hooks[name] = hook
+
+    def delete_hook(self, name):
+        """Unregisters the function hook.
+
+        Args:
+            name(str): the name of the function hook
+            to be unregistered.
+        """
+        del self.local_function_hooks[name]
+
+
+class FunctionHook(object):
+    """Base class of hooks for Functions.
+
+    :class:`~chainer.function.FunctionsHook` is an callback object
+    that is registered to :class:`~chainer.function.Function`.
+    Registered function hooks are invoked before and after
+    forward and backward operation of each function.
+
+    Specifically, when :meth:`~chainer.function.Function.__call__` is invoked,
+    all function hooks registered to this function are called
+    before and after forward propagation.
+    Before forward propagation,
+    :meth:`~chainer.function.FunctionHook.forward_preprocess` is called and
+    after forward propagation,
+    :meth:`~chainer.function.FunctionHook.forward_postprocess` is called.
+
+    Likewise, when :method:`~chainer.variable.Variable.backward` is invoked,
+    all function hooks registered to the function which holds this variable
+    as a gradient are called before and after backward propagation.
+    Before backward propagation,
+    :meth:`~chainer.function.FunctionHook.backward_preprocess` is called and
+    after backward propagation,
+    :meth:`~chainer.function.FunctionHook.backward_postprocess` is called.
+
+    So, function hooks that derive :class:`FunctionHook` are required
+    to implement these four functions.
+    In default setting, these methods does not do anything.
+
+    If we want to use same preprocessing (resp. postprocessing) method
+    for both forward and backward processing,
+    we should override :meth:`~chainer.function.FunctionHook.preprocess`
+    (resp. :meth:`~chainer.function.FunctionHook.postprocess`) method instead
+    and keep the two preprocess methods (resp. two post process methods)
+    as it is.
+
+    Further, if we want to use same method for preprocessing and
+    postprocessing, we should overwride
+    :meth:`~chainer.functioin.FunctionHook.__call__`.
+
+    There are two ways to register :class:`~chainer.function.FunctionHook`
+    objects to :class:`chainer.function.Function` objects.
+    First one is to add the :class:`~chainer.function.FunctionHook`
+    to ``chainer.global_function_hooks``.
+    Function hooks in ``chainer.global_function_hooks`` are regared
+    to be registered to all functions.
+    The other one is to register directly to
+    :class:`~chainer.function.Function` object with
+    :meth:`~chainer.functon.Function.add_hook` method.
+    Registered function hooks in this way can be removed by
+    :meth:`~chainer.function.remove_hook` method.
+
+    We can regsiter and unregister function hooks globally (i.e. to register
+    function hooks to ``~chainer.global_function_hooks``) with
+    ``with`` statement.
+    The following code is a simple example in which
+    we measure elapsed times of a part of forward propagation.
+
+    >>> class Model(chainer.Chain):
+    ...     def __call__(x):
+    ...         x = self.l(x)
+    ...         return F.exp(x)
+    ...
+    ... model1 = chainer.Model(l=L.Linear(10, 10))
+    ... model2 = chainer.Model(l=L.Linear(10, 10))
+    ... x = chainer.Variable(...)
+    ... with TimerHook():
+    ...     y = model1(x)
+    ...     y = model2(x)
+    ... model3 = chainer.Model(l=L.Linear(10, 10))
+    ... z = model3(y)
+
+    In this example, we measure the elapsed times for each forward propagation
+    of all functions in ``model1`` and ``model2`` (specifically,
+    :class:`~chainer.functions.LinearFunction` and
+    :class:`~chainer.functions.Exp` of ``model1`` and ``model2``).
+    Note that as :class:`~chainer.function_hooks.TimerHook` is unregistered
+    from ``chainer.global_hooks``, ``model3`` is not a target of measurement.
+
+    Args:
+        name(str): Name of this function hook.
+    """
+
+    name = 'FunctionHook'
+
+    def __enter__(self):
+        if self.name in chainer.global_function_hooks:
+            raise KeyError('hook %s already exists' % self.name)
+
+        chainer.global_function_hooks[self.name] = self
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        del chainer.global_function_hooks[self.name]
+
+    # unified functions
+    def __call__(self, function, in_data, out_grad=None):
+        """Unfied postprocessing function for preprocessing and postprocessing.
+
+        Args:
+            function(~chainer.function.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Arrays for input data.
+            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray or None):
+                Arrays for gradients. If this function is invoked
+                during backpropagation, this argument should be ``None``.
+        """
+        pass
+
+    def preprocess(self, function, in_data, out_grad=None):
+        """Unfied preprocessing function for forward and backward propagation.
+
+        Args:
+            function(~chainer.function.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Arrays for input data.
+            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray or None):
+                Arrays for gradients. If this function is invoked
+                during backpropagation, this argument should be ``None``.
+        """
+        self.__call__(function, in_data, out_grad)
+
+    def postprocess(self, function, in_data, out_grad=None):
+        """Unfied postprocessing function for forward and backward propagation.
+
+        Args:
+            function(~chainer.function.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Arrays for input data.
+            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray or None):
+                Arrays for gradients. If this function is invoked during
+                backpropagation, this argument should be ``None``.
+        """
+        self.__call__(function, in_data, out_grad)
+
+    # forward
+    def forward_preprocess(self, function, in_data):
+        """Callback function invoked before forward propagation.
+
+        Args:
+            function(~chainer.function.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Input of forward propagation.
+        """
+        self.preprocess(function, in_data)
+
+    def forward_postprocess(self, function, in_data):
+        """Callback function invoked after forward propagation.
+
+        Args:
+            function(~chainer.function.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Input of forward propagation.
+        """
+        self.postprocess(function, in_data)
+
+    # backward
+    def backward_preprocess(self, function, in_data, out_grad):
+        """Callback function invoked before backward propagation.
+
+        Args:
+            function(~chainer.function.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Input of forward propagation.
+        """
+        self.preprocess(function, in_data)
+
+    def backward_postprocess(self, function, in_data, out_grad):
+        """Callback function invoked after backward propagation.
+
+        Args:
+            function(~chainer.function.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Input of forward propagation.
+        """
+        self.postprocess(function, in_data)

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -156,14 +156,6 @@ class Function(object):
             self._local_function_hooks = collections.OrderedDict()
         return self._local_function_hooks
 
-    @local_function_hooks.setter
-    def local_function_hooks(self, val):
-        self._local_function_hooks = val
-
-    @local_function_hooks.deleter
-    def local_function_hooks(self):
-        del self._local_function_hooks
-
     @property
     def label(self):
         """Short text that represents the function.

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -387,17 +387,6 @@ class FunctionHook(object):
     to implement these four functions.
     In default setting, these methods does not do anything.
 
-    If we want to use same preprocessing (resp. postprocessing) method
-    for both forward and backward processing,
-    we should override :meth:`~chainer.function.FunctionHook.preprocess`
-    (resp. :meth:`~chainer.function.FunctionHook.postprocess`) method instead
-    and keep the two preprocess methods (resp. two post process methods)
-    as it is.
-
-    Further, if we want to use same method for preprocessing and
-    postprocessing, we should overwride
-    :meth:`~chainer.functioin.FunctionHook.__call__`.
-
     There are two ways to register :class:`~chainer.function.FunctionHook`
     objects to :class:`chainer.function.Function` objects.
     First one is to add the :class:`~chainer.function.FunctionHook`
@@ -453,49 +442,6 @@ class FunctionHook(object):
     def __exit__(self, exc_type, exc_value, traceback):
         del chainer.global_function_hooks[self.name]
 
-    # unified functions
-    def __call__(self, function, in_data, out_grad=None):
-        """Unfied postprocessing function for preprocessing and postprocessing.
-
-        Args:
-            function(~chainer.function.Function): Function object to which
-                the function hook is registered.
-            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Arrays for input data.
-            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray or None):
-                Arrays for gradients. If this function is invoked
-                during backpropagation, this argument should be ``None``.
-        """
-        pass
-
-    def preprocess(self, function, in_data, out_grad=None):
-        """Unfied preprocessing function for forward and backward propagation.
-
-        Args:
-            function(~chainer.function.Function): Function object to which
-                the function hook is registered.
-            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Arrays for input data.
-            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray or None):
-                Arrays for gradients. If this function is invoked
-                during backpropagation, this argument should be ``None``.
-        """
-        self.__call__(function, in_data, out_grad)
-
-    def postprocess(self, function, in_data, out_grad=None):
-        """Unfied postprocessing function for forward and backward propagation.
-
-        Args:
-            function(~chainer.function.Function): Function object to which
-                the function hook is registered.
-            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Arrays for input data.
-            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray or None):
-                Arrays for gradients. If this function is invoked during
-                backpropagation, this argument should be ``None``.
-        """
-        self.__call__(function, in_data, out_grad)
-
     # forward
     def forward_preprocess(self, function, in_data):
         """Callback function invoked before forward propagation.
@@ -506,7 +452,7 @@ class FunctionHook(object):
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input of forward propagation.
         """
-        self.preprocess(function, in_data)
+        pass
 
     def forward_postprocess(self, function, in_data):
         """Callback function invoked after forward propagation.
@@ -517,7 +463,7 @@ class FunctionHook(object):
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input of forward propagation.
         """
-        self.postprocess(function, in_data)
+        pass
 
     # backward
     def backward_preprocess(self, function, in_data, out_grad):
@@ -529,7 +475,7 @@ class FunctionHook(object):
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input of forward propagation.
         """
-        self.preprocess(function, in_data)
+        pass
 
     def backward_postprocess(self, function, in_data, out_grad):
         """Callback function invoked after backward propagation.
@@ -540,4 +486,4 @@ class FunctionHook(object):
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input of forward propagation.
         """
-        self.postprocess(function, in_data)
+        pass

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -344,7 +344,7 @@ Invalid operation is performed in: {0} (Forward)
         """Registers the function hook.
 
         Args:
-            hook(~chainer.functions.FunctionHook):
+            hook(~chainer.function.FunctionHook):
                 the function hook to be registered.
             name(str): The name of the function hook.
                 name must be unique among function hooks
@@ -352,11 +352,11 @@ Invalid operation is performed in: {0} (Forward)
                 default name of the function hook is used.
         """
         if not isinstance(hook, FunctionHook):
-            raise TypeError('hook must be a FunctionHook')
+            raise TypeError('Hook must be a FunctionHook')
         if name is None:
             name = hook.name
         if name in self.local_function_hooks:
-            raise KeyError('hook %s already exists' % name)
+            raise KeyError('Hook %s already exists' % name)
         self.local_function_hooks[name] = hook
 
     def delete_hook(self, name):

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -104,7 +104,8 @@ class Function(object):
         if self.type_check_enable:
             self._check_data_type_forward(in_data)
 
-        hooks = collections.OrderedDict(chainer.global_function_hooks)
+        with chainer.global_function_hooks:
+            hooks = collections.OrderedDict(chainer.global_function_hooks)
         hooks.update(self.local_function_hooks)
         for hook in hooks.values():
             hook.forward_preprocess(self, in_data)
@@ -436,11 +437,13 @@ class FunctionHook(object):
         if self.name in chainer.global_function_hooks:
             raise KeyError('hook %s already exists' % self.name)
 
-        chainer.global_function_hooks[self.name] = self
+        with chainer.global_function_hooks:
+            chainer.global_function_hooks[self.name] = self
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        del chainer.global_function_hooks[self.name]
+        with chainer.global_function_hooks:
+            del chainer.global_function_hooks[self.name]
 
     # forward
     def forward_preprocess(self, function, in_data):

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -372,8 +372,8 @@ Invalid operation is performed in: {0} (Forward)
 class FunctionHook(object):
     """Base class of hooks for Functions.
 
-    :class:`~chainer.function.FunctionsHook` is an callback object
-    that is registered to :class:`~chainer.function.Function`.
+    :class:`~chainer.function.FunctionHook` is an callback object
+    that is registered to :class:`~chainer.Function`.
     Registered function hooks are invoked before and after
     forward and backward operations of each function.
 
@@ -385,22 +385,22 @@ class FunctionHook(object):
     :meth:`~chainer.function.FunctionHook.backward_postprocess`.
     By default, these methods do nothing.
 
-    Specifically, when :meth:`~chainer.function.Function.__call__`
+    Specifically, when :meth:`~chainer.Function.__call__`
     method of some function is invoked,
     :meth:`~chainer.function.FunctionHook.forward_preprocess`
     (resp. :meth:`~chainer.function.FunctionHook.forward_postprocess`)
     of all function hooks registered to this function are called before
     (resp. after) forward propagation.
 
-    Likewise, when :meth:`~chainer.variable.Variable.backward` of some
-    :class:`~chainer.variable.Variable` is invoked,
+    Likewise, when :meth:`~chainer.Variable.backward` of some
+    :class:`~chainer.Variable` is invoked,
     :meth:`~chainer.function.FunctionHook.backward_preprocess`
     (resp. :meth:`~chainer.function.FunctionHook.backward_postprocess`)
     of all function hooks registered to the function which holds this variable
     as a gradient are called before (resp. after) backward propagation.
 
     There are two ways to register :class:`~chainer.function.FunctionHook`
-    objects to :class:`chainer.function.Function` objects.
+    objects to :class:`~chainer.Function` objects.
 
     First one is to use ``with`` statement. Function hooks hooked
     in this way are registered to all functions within ``with`` statement
@@ -441,12 +441,12 @@ class FunctionHook(object):
        are different depending on threads.
 
     The other one is to register directly to
-    :class:`~chainer.function.Function` object with
-    :meth:`~chainer.functon.Function.add_hook` method.
+    :class:`~chainer.Function` object with
+    :meth:`~chainer.Function.add_hook` method.
     Function hooks registered in this way can be removed by
-    :meth:`~chainer.function.remove_hook` method.
+    :meth:`~chainer.Function.delete_hook` method.
     Contrary to former registration method, function hooks are registered
-    only to the function which :meth:`~chainer.function.Function.add_hook`
+    only to the function which :meth:`~chainer.Function.add_hook`
     is called.
 
     Args:
@@ -471,7 +471,7 @@ class FunctionHook(object):
         """Callback function invoked before forward propagation.
 
         Args:
-            function(~chainer.function.Function): Function object to which
+            function(~chainer.Function): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input data of forward propagation.
@@ -482,7 +482,7 @@ class FunctionHook(object):
         """Callback function invoked after forward propagation.
 
         Args:
-            function(~chainer.function.Function): Function object to which
+            function(~chainer.Function): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input data of forward propagation.
@@ -494,7 +494,7 @@ class FunctionHook(object):
         """Callback function invoked before backward propagation.
 
         Args:
-            function(~chainer.function.Function): Function object to which
+            function(~chainer.Function): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input data of forward propagation.
@@ -507,7 +507,7 @@ class FunctionHook(object):
         """Callback function invoked after backward propagation.
 
         Args:
-            function(~chainer.function.Function): Function object to which
+            function(~chainer.Function): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input of forward propagation.

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -161,7 +161,7 @@ class Function(object):
 
     @local_function_hooks.deleter
     def local_function_hooks(self):
-        del self._hook_history
+        del self._local_function_hooks
 
     @property
     def label(self):

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -104,8 +104,7 @@ class Function(object):
         if self.type_check_enable:
             self._check_data_type_forward(in_data)
 
-        with chainer.global_function_hooks:
-            hooks = collections.OrderedDict(chainer.global_function_hooks)
+        hooks = collections.OrderedDict(chainer.registered_function_hooks)
         hooks.update(self.local_function_hooks)
         for hook in hooks.values():
             hook.forward_preprocess(self, in_data)
@@ -138,7 +137,7 @@ class Function(object):
     def local_function_hooks(self):
         """Ordered Dictionary of registered function hooks.
 
-        Contrary to ``~chainer.global_function_hooks``,
+        Contrary to ``~chainer.registered_function_hooks``,
         which registers its elements to all functions,
         Function hooks in this property is specific to this function.
         """
@@ -434,16 +433,14 @@ class FunctionHook(object):
     name = 'FunctionHook'
 
     def __enter__(self):
-        if self.name in chainer.global_function_hooks:
+        if self.name in chainer.registered_function_hooks:
             raise KeyError('hook %s already exists' % self.name)
 
-        with chainer.global_function_hooks:
-            chainer.global_function_hooks[self.name] = self
+        chainer.registered_function_hooks[self.name] = self
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        with chainer.global_function_hooks:
-            del chainer.global_function_hooks[self.name]
+        del chainer.registered_function_hooks[self.name]
 
     # forward
     def forward_preprocess(self, function, in_data):

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import six
 import traceback
 import weakref
 
@@ -110,13 +111,13 @@ class Function(object):
 
         hooks = collections.OrderedDict(chainer.get_function_hooks())
         hooks.update(self.local_function_hooks)
-        for hook in hooks.values():
+        for hook in six.itervalues(hooks):
             hook.forward_preprocess(self, in_data)
         # Forward prop
         with cuda.get_device(*in_data):
             outputs = self.forward(in_data)
             assert type(outputs) == tuple
-        for hook in hooks.values():
+        for hook in six.itervalues(hooks):
             hook.forward_postprocess(self, in_data)
 
         if chainer.is_debug():

--- a/chainer/function_hooks/__init__.py
+++ b/chainer/function_hooks/__init__.py
@@ -1,0 +1,4 @@
+from chainer.function_hooks import timer
+
+
+TimerHook = timer.TimerHook

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -1,0 +1,45 @@
+import time
+
+import numpy
+
+from chainer import cuda
+from chainer import function
+
+
+class TimerHook(function.FunctionHook):
+    """Function hook for measuring elapsed time of functions.
+
+    Attributes:
+        call_history: List of measurement results. It consists of pairs of
+            the function that calls this hook and the elapsed time.
+    """
+
+    name = 'TimerHook'
+
+    def __init__(self):
+        self.call_history = []
+
+    def preprocess(self, function, in_data, out_grad=None):
+        xp = cuda.get_array_module(*in_data)
+        if xp == numpy:
+            self.start = time.time()
+        else:
+            self.start = cuda.Event()
+            self.stop = cuda.Event()
+            self.start.record()
+
+    def postprocess(self, function, in_data, out_grad=None):
+        xp = cuda.get_array_module(*in_data)
+        if xp == numpy:
+            self.stop = time.time()
+            elapsed_time = self.stop - self.start
+        else:
+            self.stop.record()
+            self.stop.synchronize()
+            elapsed_time = cuda.cupy.cuda.get_elapsed_time(
+                self.start, self.stop)
+        self.call_history.append((function, elapsed_time))
+
+    def total_time(self):
+        """Returns total elapsed time."""
+        return sum(t for (_, t) in self.call_history)

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -11,7 +11,8 @@ class TimerHook(function.FunctionHook):
 
     Attributes:
         call_history: List of measurement results. It consists of pairs of
-            the function that calls this hook and the elapsed time.
+            the function that calls this hook and the elapsed time
+            the function consumes.
     """
 
     name = 'TimerHook'

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -43,8 +43,9 @@ class TimerHook(function.FunctionHook):
         else:
             self.stop.record()
             self.stop.synchronize()
+            # Note that `get_elapsed_time` returns result in milliseconds
             elapsed_time = cuda.cupy.cuda.get_elapsed_time(
-                self.start, self.stop)
+                self.start, self.stop) * 1000
         self.call_history.append((function, elapsed_time))
 
     def forward_postprocess(self, function, in_data):
@@ -58,5 +59,5 @@ class TimerHook(function.FunctionHook):
         self._postprocess(function)
 
     def total_time(self):
-        """Returns total elapsed time."""
+        """Returns total elapsed time in seconds."""
         return sum(t for (_, t) in self.call_history)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -326,7 +326,8 @@ class Variable(object):
 
             in_data = tuple(x.data for x in func.inputs)
             out_grad = tuple(None if y is None else y.grad for y in outputs)
-            hooks = collections.OrderedDict(chainer.global_function_hooks)
+            with chainer.global_function_hooks:
+                hooks = collections.OrderedDict(chainer.global_function_hooks)
             hooks.update(func.local_function_hooks)
             for hook in hooks.values():
                 hook.backward_preprocess(func, in_data, out_grad)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -337,7 +337,7 @@ class Variable(object):
 
             in_data = tuple(x.data for x in func.inputs)
             out_grad = tuple(None if y is None else y.grad for y in outputs)
-            hooks = collections.OrderedDict(chainer.registered_function_hooks)
+            hooks = collections.OrderedDict(chainer.get_function_hooks())
             hooks.update(func.local_function_hooks)
             for hook in hooks.values():
                 hook.backward_preprocess(func, in_data, out_grad)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -3,6 +3,7 @@ import heapq
 import traceback
 
 import numpy
+import six
 
 import chainer
 from chainer import cuda
@@ -339,12 +340,12 @@ class Variable(object):
             out_grad = tuple(None if y is None else y.grad for y in outputs)
             hooks = collections.OrderedDict(chainer.get_function_hooks())
             hooks.update(func.local_function_hooks)
-            for hook in hooks.values():
+            for hook in six.itervalues(hooks):
                 hook.backward_preprocess(func, in_data, out_grad)
             with cuda.get_device(*(in_data + out_grad)):
                 gxs = func.backward(in_data, out_grad)
             assert len(gxs) == len(in_data)
-            for hook in hooks.values():
+            for hook in six.itervalues(hooks):
                 hook.backward_postprocess(func, in_data, out_grad)
 
             if chainer.is_debug():

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -326,8 +326,7 @@ class Variable(object):
 
             in_data = tuple(x.data for x in func.inputs)
             out_grad = tuple(None if y is None else y.grad for y in outputs)
-            with chainer.global_function_hooks:
-                hooks = collections.OrderedDict(chainer.global_function_hooks)
+            hooks = collections.OrderedDict(chainer.registered_function_hooks)
             hooks.update(func.local_function_hooks)
             for hook in hooks.values():
                 hook.backward_preprocess(func, in_data, out_grad)

--- a/docs/source/reference/function_hooks.rst
+++ b/docs/source/reference/function_hooks.rst
@@ -1,0 +1,22 @@
+Function hooks
+==============
+
+
+Chainer provides a function-hook mechanism that enriches
+the behavior of forward and backward propagation of :class:`~chainer.Function`.
+
+.. module:: chainer.function
+
+Base class
+----------
+
+.. autoclass:: FunctionHook
+  :members:
+
+.. module:: chainer.function_hooks
+
+Concrete function hooks
+-----------------------
+
+.. autoclass:: TimerHook
+  :members:

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -14,5 +14,6 @@ Chainer Reference Manual
    links
    optimizers
    serializers
+   function_hooks
    caffe
    graph

--- a/tests/chainer_tests/function_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/function_hooks_tests/test_timer.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 import chainer
 from chainer import cuda
 from chainer import function_hooks
@@ -8,7 +10,6 @@ from chainer.functions.connection import linear
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
-import numpy
 
 
 def check_history(self, t, function_type, return_type):

--- a/tests/chainer_tests/function_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/function_hooks_tests/test_timer.py
@@ -1,0 +1,101 @@
+import unittest
+
+import chainer
+from chainer import cuda
+from chainer import function_hooks
+from chainer import functions
+from chainer.functions.connection import linear
+from chainer import links
+from chainer import testing
+from chainer.testing import attr
+import numpy
+
+
+def check_history(self, t, function_type, return_type):
+    self.assertIsInstance(t[0], function_type)
+    self.assertIsInstance(t[1], return_type)
+
+
+class TestTimerHookToLink(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.TimerHook()
+        self.l = links.Linear(5, 5)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    def test_name(self):
+        self.assertEqual(self.h.name, 'TimerHook')
+
+    def check_forward(self, x):
+        with self.h:
+            self.l(chainer.Variable(x))
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      linear.LinearFunction, float)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.l.to_gpu()
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x, gy):
+        x = chainer.Variable(x)
+        y = self.l(x)
+        y.grad = gy
+        with self.h:
+            y.backward()
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      linear.LinearFunction, float)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.l.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+
+class TestTimerHookToFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.TimerHook()
+        self.f = functions.Exp()
+        self.f.add_hook(self.h)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    def check_forward(self, x):
+        self.f(chainer.Variable(x))
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0], functions.Exp, float)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_fowward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x, gy):
+        x = chainer.Variable(x)
+        y = self.f(x)
+        y.grad = gy
+        y.backward()
+        self.assertEqual(2, len(self.h.call_history))
+        check_history(self, self.h.call_history[1], functions.Exp, float)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_function_hook.py
+++ b/tests/chainer_tests/test_function_hook.py
@@ -1,55 +1,28 @@
 import unittest
+
 from chainer import function
 from chainer import testing
-
-
-class MockFunctionHook(function.FunctionHook):
-
-    def __init__(self, *args, **kwargs):
-        self.call_count = 0
-        self.preprocess_count = 0
-        self.postprocess_count = 0
-        super(MockFunctionHook, self).__init__(*args, **kwargs)
-
-    def __call__(self, function, in_data, out_grad=None):
-        self.call_count += 1
-
-    def preprocess(self, function, in_data, out_grad=None):
-        self.preprocess_count += 1
-        super(MockFunctionHook, self).preprocess(function, in_data, out_grad)
-
-    def postprocess(self, function, in_data, out_grad=None):
-        self.postprocess_count += 1
-        super(MockFunctionHook, self).postprocess(function, in_data, out_grad)
 
 
 class TestFunctionHook(unittest.TestCase):
 
     def setUp(self):
-        self.h = MockFunctionHook()
+        self.h = function.FunctionHook()
 
     def test_name(self):
         self.assertEqual(self.h.name, 'FunctionHook')
 
     def test_forward_preprocess(self):
-        self.h.forward_preprocess(None, None)
-        self.assertEqual(self.h.preprocess_count, 1)
-        self.assertEqual(self.h.call_count, 1)
+        self.assertTrue(hasattr(self.h, 'forward_preprocess'))
 
     def test_forward_postprocess(self):
-        self.h.forward_postprocess(None, None)
-        self.assertEqual(self.h.postprocess_count, 1)
-        self.assertEqual(self.h.call_count, 1)
+        self.assertTrue(hasattr(self.h, 'forward_postprocess'))
 
     def test_backward_preprocess(self):
-        self.h.backward_preprocess(None, None, None)
-        self.assertEqual(self.h.preprocess_count, 1)
-        self.assertEqual(self.h.call_count, 1)
+        self.assertTrue(hasattr(self.h, 'backward_preprocess'))
 
     def test_backward_postprocess(self):
-        self.h.backward_postprocess(None, None, None)
-        self.assertEqual(self.h.postprocess_count, 1)
-        self.assertEqual(self.h.call_count, 1)
+        self.assertTrue(hasattr(self.h, 'backward_postprocess'))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_function_hook.py
+++ b/tests/chainer_tests/test_function_hook.py
@@ -1,0 +1,55 @@
+import unittest
+from chainer import function
+from chainer import testing
+
+
+class MockFunctionHook(function.FunctionHook):
+
+    def __init__(self, *args, **kwargs):
+        self.call_count = 0
+        self.preprocess_count = 0
+        self.postprocess_count = 0
+        super(MockFunctionHook, self).__init__(*args, **kwargs)
+
+    def __call__(self, function, in_data, out_grad=None):
+        self.call_count += 1
+
+    def preprocess(self, function, in_data, out_grad=None):
+        self.preprocess_count += 1
+        super(MockFunctionHook, self).preprocess(function, in_data, out_grad)
+
+    def postprocess(self, function, in_data, out_grad=None):
+        self.postprocess_count += 1
+        super(MockFunctionHook, self).postprocess(function, in_data, out_grad)
+
+
+class TestFunctionHook(unittest.TestCase):
+
+    def setUp(self):
+        self.h = MockFunctionHook()
+
+    def test_name(self):
+        self.assertEqual(self.h.name, 'FunctionHook')
+
+    def test_forward_preprocess(self):
+        self.h.forward_preprocess(None, None)
+        self.assertEqual(self.h.preprocess_count, 1)
+        self.assertEqual(self.h.call_count, 1)
+
+    def test_forward_postprocess(self):
+        self.h.forward_postprocess(None, None)
+        self.assertEqual(self.h.postprocess_count, 1)
+        self.assertEqual(self.h.call_count, 1)
+
+    def test_backward_preprocess(self):
+        self.h.backward_preprocess(None, None, None)
+        self.assertEqual(self.h.preprocess_count, 1)
+        self.assertEqual(self.h.call_count, 1)
+
+    def test_backward_postprocess(self):
+        self.h.backward_postprocess(None, None, None)
+        self.assertEqual(self.h.postprocess_count, 1)
+        self.assertEqual(self.h.call_count, 1)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
As we have not fully discussed the specification of examples of `FunctionHook`s (especially `MemoryHook`), we separate #933 into two PRs, `FunctionHook` mechanism and examples of `FunctionHook` (subclasses of `FunctionHook`s).

This PR implements the former one.

We change the implementation from #933 in two points.
* Remove `preprocess`, `postprocess`, and `__call__` methods of `FunctionHook`.
* Make `chainer.global_function_hook` thread safe.