### PR TITLE
Python 3.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - os: linux
       python: "3.4"
     - os: linux
-      python: "3.5"
+      python: "3.5.1"
 
     - os: osx
       language: generic
@@ -24,7 +24,7 @@ matrix:
     - os: osx
       language: generic
       env:
-      - PYTHON_VERSION=3.5.0
+      - PYTHON_VERSION=3.5.1
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Chainer is tested on Ubuntu 14.04 and CentOS 7. We recommend them to use Chainer, though it may run on other systems as well.
 
 Minimum requirements:
-- Python 2.7.6+, 3.4.3+, 3.5.0+
+- Python 2.7.6+, 3.4.3+, 3.5.1+
 - NumPy 1.9, 1.10
 - Six 1.9
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,7 +11,7 @@ We recommend these platforms.
 * `Ubuntu <http://www.ubuntu.com/>`_ 14.04 LTS 64bit
 * `CentOS <https://www.centos.org/>`_ 7 64bit
 
-Chainer is supported on Python 2.7.6+, 3.4.3+, 3.5.0+.
+Chainer is supported on Python 2.7.6+, 3.4.3+, 3.5.1+.
 Chainer uses C++ compiler such as g++.
 You need to install it before installing Chainer.
 This is typical installation method for each platform::


### PR DESCRIPTION
We found that chainer doesn't work with Python 3.5.0, but it works with Python 3.5.1. I changed the document, readme and travis config.