### PR TITLE
check ndim at cupy indexing

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -979,6 +979,8 @@ cdef class ndarray:
                     strides.push_back(self._strides[ndim - 1])
                 else:
                     strides.push_back(self.itemsize)
+            elif ndim <= j:
+                raise IndexError("too many indices for array")
             elif isinstance(s, slice):
                 s = internal.complete_slice(s, self._shape[j])
                 s_start = s.start

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -43,6 +43,9 @@ class TestArrayIndexingParameterized(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'shape': (), 'transpose': None, 'indexes': 0},
+    {'shape': (), 'transpose': None, 'indexes': (slice(0, 1, 0),)},
+    {'shape': (2, 3), 'transpose': None, 'indexes': (0, 0, 0)},
     {'shape': (2, 3, 4), 'transpose': None, 'indexes': -3},
     {'shape': (2, 3, 4), 'transpose': (2, 0, 1), 'indexes': -5},
     {'shape': (2, 3, 4), 'transpose': None, 'indexes': 3},


### PR DESCRIPTION
This PR is fixed a cupy indexig bug.
Because current cupy do not check a number of the dimension of the index, It causes memory access error.
e.g
```
In [2]: cupy.array(0)[0]
Segmentation fault (core dumped)

In [2]: cupy.array(0)[0:1]
Segmentation fault (core dumped)

In [2]: cupy.array(0)[:]
Segmentation fault (core dumped)

In [11]: cupy.arange(10)[0, 0, 0, 0]
Out[11]: array(0)

In [12]: cupy.arange(10)[0, 0, 0, 1]
Out[12]: array(360287970189639680)
```
This PR raise `IndexError`, but numpy raise `IndexError` or `ValueError`.

```
In [2]: numpy.array(0)[0]
In [5]: numpy.arange(10)[0, 0, 0, 0]
In [6]: numpy.arange(10)[0, 0, 0, 1]
=> IndexError: too many indices for array

In [3]: numpy.array(0)[0:1]
In [4]: numpy.array(0)[:]
=> ValueError: cannot slice a 0-d array
```