### PR TITLE
Fix group deserializer

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -88,7 +88,8 @@ class HDF5Deserializer(serializer.Deserializer):
         self.group = group
 
     def __getitem__(self, key):
-        return HDF5Deserializer(self.group[key])
+        name = self.group.name + '/' + key
+        return HDF5Deserializer(self.group.require_group(name))
 
     def __call__(self, key, value):
         dataset = self.group[key]

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -238,6 +238,13 @@ class TestGroupHierachy(unittest.TestCase):
 
     def test_load_chain(self):
         with h5py.File(self.temp_file_path) as h5:
+            self._save(h5, self.parent, 'test')
+
+        with h5py.File(self.temp_file_path) as h5:
+            self._load(h5, self.parent, 'test')
+
+    def test_load_optimizer(self):
+        with h5py.File(self.temp_file_path) as h5:
             self._save(h5, self.optimizer, 'test')
 
         with h5py.File(self.temp_file_path) as h5:

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -197,6 +197,11 @@ class TestGroupHierachy(unittest.TestCase):
         serializer = hdf5.HDF5Serializer(group)
         serializer.save(obj)
 
+    def _load(self, h5, obj, name):
+        group = h5[name]
+        serializer = hdf5.HDF5Deserializer(group)
+        serializer.load(obj)
+
     def tearDown(self):
         if hasattr(self, 'temp_file_path'):
             os.remove(self.temp_file_path)
@@ -231,6 +236,12 @@ class TestGroupHierachy(unittest.TestCase):
         with h5py.File(self.temp_file_path) as h5:
             self._check_group(h5, ('Wp', 'epoch', 't'))
 
+    def test_load_chain(self):
+        with h5py.File(self.temp_file_path) as h5:
+            self._save(h5, self.optimizer, 'test')
+
+        with h5py.File(self.temp_file_path) as h5:
+            self._load(h5, self.optimizer, 'test')
 
 original_import = __import__
 


### PR DESCRIPTION
Hi,

Related to https://github.com/pfnet/chainer/issues/811 , we cannot load optimizer from user-specified group.
This PR fix the problem and add related tests.

You can regenerate this problem by following code:
```
import chainer
from chainer.link import Chain
from chainer.links import Linear
from chainer.optimizers import AdaDelta
from chainer.serializers import HDF5Serializer
from chainer.serializers import HDF5Deserializer
import h5py
chain = Chain(linear=Linear(100, 10))
opt = AdaDelta()
opt.setup(chain)
h5 = h5py.File("test.h5")
group = h5.create_group("test")
s = HDF5Serializer(group)
s.save(opt)
h5.close()

h5 = h5py.File("test.h5")
chain = Chain(linear=Linear(100, 10))
opt = AdaDelta()
opt.setup(chain)
group = h5['test']
d = HDF5Deserializer(group)
d.load(opt)
```

This code raises error:
```
% python test.py
Traceback (most recent call last):
  File "test.py", line 23, in <module>
    d.load(opt)
  File "/home/someone/.local/lib/python2.7/site-packages/chainer/serializer.py", line 79, in load
    obj.serialize(self)
  File "/home/someone/.local/lib/python2.7/site-packages/chainer/optimizer.py", line 253, in serialize
    s = serializer[name]
  File "/home/someone/.local/lib/python2.7/site-packages/chainer/serializers/hdf5.py", line 91, in __getitem__
    return HDF5Deserializer(self.group[key])
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/pip-build-wSlFel/h5py/h5py/_objects.c:2574)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/pip-build-wSlFel/h5py/h5py/_objects.c:2533)
  File "/home/someone/.local/lib/python2.7/site-packages/h5py/_hl/group.py", line 164, in __getitem__
    oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/pip-build-wSlFel/h5py/h5py/_objects.c:2574)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/pip-build-wSlFel/h5py/h5py/_objects.c:2533)
  File "h5py/h5o.pyx", line 190, in h5py.h5o.open (/tmp/pip-build-wSlFel/h5py/h5py/h5o.c:3546)
KeyError: 'Unable to open object (Component not found)'
```

The version I've checked is `05825ec486ae12ce13a4aceafd6760cdbe6d6245`.

Thanks,