### PR TITLE
enabled Chain to take dict

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -411,9 +411,11 @@ class Chain(Link):
             also set to the links.
 
     """
-    def __init__(self, **links):
+    def __init__(self, *args, **kwargs):
         super(Chain, self).__init__()
         self._children = []
+
+        links = args[0] if args and len(args) > 0 and isinstance(args[0], dict) else kwargs
 
         for name, link in six.iteritems(links):
             self.add_link(name, link)


### PR DESCRIPTION
## Abstract
By this p-r, `chainer.Chain` can take dict not only named args.
So we can create `Chain` object with dynamic parameters, e.g. muti-layered RNN.

## Example

before:

```
    def __init__(self, n_in, n_units, n_out):
        super(MnistMLP, self).__init__(
            l1=L.Linear(n_in, n_units),
            l2=L.Linear(n_units, n_units),
            l3=L.Linear(n_units, n_out),
        )
        super(MnistMLP, self).__init__(args)
```

after:

```
    def __init__(self, n_in, n_units, n_out):
        args = {
            "l1": L.Linear(n_in, n_units),
            "l2": L.Linear(n_units, n_units),
            "l3": L.Linear(n_units, n_out)
        }
        super(MnistMLP, self).__init__(args)
```