### PR TITLE
Add functions and links to TOC

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -23,95 +23,291 @@ functions, which users should use.
 
    KEEP EACH LIST IN LEXICOGRAPHICAL ORDER.
 
+
 Activation functions
 --------------------
+
+clipped_relu
+~~~~~~~~~~~~
 .. autofunction:: clipped_relu
+
+elu
+~~~
 .. autofunction:: elu
+
+leaky_relu
+~~~~~~~~~~
 .. autofunction:: leaky_relu
+
+log_softmax
+~~~~~~~~~~~
 .. autofunction:: log_softmax
+
+lstm
+~~~~
 .. autofunction:: lstm
+
+maxout
+~~~~~~
 .. autofunction:: maxout
+
+prelu
+~~~~~
 .. autofunction:: prelu
+
+relu
+~~~~
 .. autofunction:: relu
+
+sigmoid
+~~~~~~~
 .. autofunction:: sigmoid
+
+slstm
+~~~~~
 .. autofunction:: slstm
+
+softmax
+~~~~~~~
 .. autofunction:: softmax
+
+softplus
+~~~~~~~~
 .. autofunction:: softplus
+
+tanh
+~~~~
 .. autofunction:: tanh
+
 
 Array manipulations
 -------------------
+
+broadcast
+~~~~~~~~~
 .. autofunction:: broadcast
+
+broadcast_to
+~~~~~~~~~~~~
 .. autofunction:: broadcast_to
+
+concat
+~~~~~~
 .. autofunction:: concat
+
+copy
+~~~~
 .. autofunction:: copy
+
+expand_dims
+~~~~~~~~~~~
 .. autofunction:: expand_dims
+
+reshape
+~~~~~~~
 .. autofunction:: reshape
+
+select_item
+~~~~~~~~~~~
 .. autofunction:: select_item
+
+split_axis
+~~~~~~~~~~
 .. autofunction:: split_axis
+
+swapaxes
+~~~~~~~~
 .. autofunction:: swapaxes
+
+transpose
+~~~~~~~~~
 .. autofunction:: transpose
+
+where
+~~~~~
 .. autofunction:: where
+
 
 Neural network connections
 --------------------------
+
+bilinear
+~~~~~~~~
 .. autofunction:: bilinear
+
+convolution_2d
+~~~~~~~~~~~~~~
 .. autofunction:: convolution_2d
+
+deconvolution_2d
+~~~~~~~~~~~~~~~~
 .. autofunction:: deconvolution_2d
+
+embed_id
+~~~~~~~~
 .. autofunction:: embed_id
+
+linear
+~~~~~~
 .. autofunction:: linear
+
 
 Evaluation functions
 --------------------
+
+accuracy
+~~~~~~~~
 .. autofunction:: accuracy
+
 
 Loss functions
 --------------
+
+bernoulli_nll
+~~~~~~~~~~~~~
+.. autofunction:: bernoulli_nll
+
+connectionist_temporal_classification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: connectionist_temporal_classification
+
+contrastive
+~~~~~~~~~~~
 .. autofunction:: contrastive
+
+cross_covariance
+~~~~~~~~~~~~~~~~
 .. autofunction:: cross_covariance
-.. autofunction:: mean_squared_error
-.. autofunction:: negative_sampling
-.. autofunction:: sigmoid_cross_entropy
-.. autofunction:: softmax_cross_entropy
+
+gaussian_kl_divergence
+~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: gaussian_kl_divergence
+
+gaussian_nll
+~~~~~~~~~~~~
+.. autofunction:: gaussian_nll
+
+hinge
+~~~~~
 .. autofunction:: hinge
 
-Loss functions for VAE
-~~~~~~~~~~~~~~~~~~~~~~
-.. autofunction:: bernoulli_nll
-.. autofunction:: gaussian_kl_divergence
-.. autofunction:: gaussian_nll
+mean_squared_error
+~~~~~~~~~~~~~~~~~~
+.. autofunction:: mean_squared_error
+
+negative_sampling
+~~~~~~~~~~~~~~~~~
+.. autofunction:: negative_sampling
+
+sigmoid_cross_entropy
+~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: sigmoid_cross_entropy
+
+softmax_cross_entropy
+~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: softmax_cross_entropy
+
 
 Mathematical functions
 ----------------------
+
+batch_inv
+~~~~~~~~~
 .. autofunction:: batch_inv
+
+batch_l2_norm_squared
+~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: batch_l2_norm_squared
+
+batch_matmul
+~~~~~~~~~~~~
 .. autofunction:: batch_matmul
+
+cos
+~~~
 .. autofunction:: cos
+
+exp
+~~~
 .. autofunction:: exp
+
+identity
+~~~~~~~~
 .. autofunction:: identity
+
+inv
+~~~
 .. autofunction:: inv
+
+log
+~~~
 .. autofunction:: log
+
+matmul
+~~~~~~
 .. autofunction:: matmul
+
+max
+~~~
 .. autofunction:: max
+
+min
+~~~
 .. autofunction:: min
+
+sin
+~~~
 .. autofunction:: sin
+
+sum
+~~~
 .. autofunction:: sum
+
 
 Noise injections
 ----------------
+
+dropout
+~~~~~~~
 .. autofunction:: dropout
+
+gaussian
+~~~~~~~~
 .. autofunction:: gaussian
+
 
 Normalization functions
 -----------------------
+
+batch_normalization
+~~~~~~~~~~~~~~~~~~~
 .. autofunction:: batch_normalization
+
+fixed_batch_normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: fixed_batch_normalization
+
+local_response_normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: local_response_normalization
+
 
 Spatial pooling
 ---------------
+
+average_pooling_2d
+~~~~~~~~~~~~~~~~~~
 .. autofunction:: average_pooling_2d
+
+max_pooling_2d
+~~~~~~~~~~~~~~
 .. autofunction:: max_pooling_2d
+
+spatial_pyramid_pooling_2d
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: spatial_pyramid_pooling_2d
+
+unpooling_2d
+~~~~~~~~~~~~
 .. autofunction:: unpooling_2d
+

--- a/docs/source/reference/links.rst
+++ b/docs/source/reference/links.rst
@@ -15,48 +15,102 @@ Chainer provides many :class:`~chainer.Link` implementations in the
 
 Learnable connections
 ---------------------
+
+Bilinear
+~~~~~~~~
 .. autoclass:: Bilinear
    :members:
+
+Convolution2D
+~~~~~~~~~~~~~
 .. autoclass:: Convolution2D
    :members:
+
+Deconvolution2D
+~~~~~~~~~~~~~~~
 .. autoclass:: Deconvolution2D
    :members:
+
+EmbedID
+~~~~~~~
 .. autoclass:: EmbedID
    :members:
+
+GRU
+~~~
 .. autoclass:: GRU
    :members:
+
+Inception
+~~~~~~~~~
 .. autoclass:: Inception
    :members:
+
+InceptionBN
+~~~~~~~~~~~
 .. autoclass:: InceptionBN
    :members:
+
+Linear
+~~~~~~
 .. autoclass:: Linear
    :members:
+
+LSTM
+~~~~
 .. autoclass:: LSTM
    :members:
+
+MLPConvolution2D
+~~~~~~~~~~~~~~~~
 .. autoclass:: MLPConvolution2D
    :members:
+
+StatefulGRU
+~~~~~~~~~~~
 .. autoclass:: StatefulGRU
    :members:
 
 Activation/loss/normalization functions with parameters
 -------------------------------------------------------
+
+BatchNormalization
+~~~~~~~~~~~~~~~~~~
 .. autoclass:: BatchNormalization
    :members:
+
+BinaryHierarchicalSoftmax
+~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: BinaryHierarchicalSoftmax
    :members:
+
+PReLU
+~~~~~
 .. autoclass:: PReLU
    :members:
+
+Maxout
+~~~~~~
 .. autoclass:: Maxout
    :members:
+
+NegativeSampling
+~~~~~~~~~~~~~~~~
 .. autoclass:: NegativeSampling
    :members:
 
 Machine learning models
 -----------------------
+
+Classifier
+~~~~~~~~~~
 .. autoclass:: Classifier
    :members:
 
 Deprecated links
 ----------------
+
+Parameter
+~~~~~~~~~
 .. autoclass:: Parameter
    :members:


### PR DESCRIPTION
Fix #946.

In this PR, I added a heading to each function/link in the document. It makes sphinx add these items to the side menu and users can easily look through all functions/links.

NOTE: I couldn't find a reasonable way to add arbitrary items to the side menu. This solution makes the document somewhat redundant (i.e. the name of each function/class must be written twice), though the readability is (maybe) not lowered.

The updated document can be found [here](http://docs.chainer.org/en/reference-toc-catalog/).