### PR TITLE
Add support for SMORMS3 optimizer

### DIFF
--- a/chainer/optimizers/__init__.py
+++ b/chainer/optimizers/__init__.py
@@ -6,6 +6,7 @@ from chainer.optimizers import nesterov_ag
 from chainer.optimizers import rmsprop
 from chainer.optimizers import rmsprop_graves
 from chainer.optimizers import sgd
+from chainer.optimizers import smorms3
 
 AdaDelta = ada_delta.AdaDelta
 AdaGrad = ada_grad.AdaGrad
@@ -15,3 +16,4 @@ NesterovAG = nesterov_ag.NesterovAG
 RMSprop = rmsprop.RMSprop
 RMSpropGraves = rmsprop_graves.RMSpropGraves
 SGD = sgd.SGD
+SMORMS3 = smorms3.SMORMS3

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -1,0 +1,52 @@
+import numpy
+
+from chainer import cuda
+from chainer import optimizer
+
+
+class SMORMS3(optimizer.GradientMethod):
+
+    """Simon Funk's SMORMS3.
+
+    See http://sifter.org/~simon/journal/20150420.html.
+
+    """
+
+    def __init__(self, lr=0.001, eps=1e-16):
+        self.lr = lr
+        self.eps = eps
+
+    def init_state(self, param, state):
+        xp = cuda.get_array_module(param.data)
+        state['mem'] = xp.ones_like(param.data)
+        state['g'] = xp.zeros_like(param.data)
+        state['g2'] = xp.zeros_like(param.data)
+
+    def update_one_cpu(self, param, state):
+        mem, g, g2 = state['mem'], state['g'], state['g2']
+        grad = param.grad
+
+        r = 1 / (mem + 1)
+        g = (1 - r) * g + r * grad
+        g2 = (1 - r) * g2 + r * grad * grad
+        x = g * g / (g2 + self.eps)
+        param.data -= grad * numpy.minimum(x, self.lr) \
+            / (numpy.sqrt(g2) + self.eps)
+        mem = 1 + mem * (1 - x)
+
+        state['mem'], state['g'], state['g2'] = mem, g, g2
+
+    def update_one_gpu(self, param, state):
+        cuda.elementwise(
+            'T grad, T lr, T eps',
+            'T param, T mem, T g, T g2',
+            '''T r, x;
+               r = 1 / (mem + 1);
+               g = (1 - r) * g + r * grad;
+               g2 = (1 - r) * g2 + r * grad * grad;
+               x = g * g / (g2 + eps);
+               param -= grad * min(lr, g * g / (g2 + eps)) / (sqrt(g2) + eps);
+               mem = 1 + mem * (1 - x)
+               ''',
+            'smorms3')(param.grad, self.lr, self.eps,
+                       param.data, state['mem'], state['g'], state['g2'])

--- a/docs/source/reference/optimizers.rst
+++ b/docs/source/reference/optimizers.rst
@@ -11,3 +11,4 @@ Optimizers
 .. autoclass:: RMSprop
 .. autoclass:: RMSpropGraves
 .. autoclass:: SGD
+.. autoclass:: SMORMS3

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -196,4 +196,12 @@ class TestSGD(OptimizerTestBase, unittest.TestCase):
         return optimizers.SGD(0.1)
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+}))
+class TestSMORMS3(OptimizerTestBase, unittest.TestCase):
+    def create(self):
+        return optimizers.SMORMS3(0.1)
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds support for the SMORMS3 optimizer described here:
http://sifter.org/~simon/journal/20150420.html
This optimizer yields faster convergence on certain workloads. The cost is higher memory requirements (stores 3 parameters per weight). A CUDA kernel is provided as well.