### PR TITLE
store_forward argument for softmax cross entropy loss

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -192,6 +192,9 @@ def softmax_cross_entropy(
             determines the normalization constant. If true, this function
             normalizes the cross entropy loss across all instances. If else,
             it only normalizes along a batch size.
+        store_forward (bool): When it is ``True``, the function stores result
+            of forward computation to use it on backward computation. It reduces
+            computational cost though consumes more memories.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -193,8 +193,8 @@ def softmax_cross_entropy(
             normalizes the cross entropy loss across all instances. If else,
             it only normalizes along a batch size.
         store_forward (bool): When it is ``True``, the function stores result
-            of forward computation to use it on backward computation. It reduces
-            computational cost though consumes more memories.
+            of forward computation to use it on backward computation. It
+            reduces computational cost though consumes more memories.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -39,12 +39,12 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         count = 0
         x = numpy.rollaxis(self.x, 1, self.x.ndim).reshape(
             (self.t.size, self.x.shape[1]))
-        t = self.t.reshape(self.t.size)
-        for i in six.moves.range(x.shape[0]):
-            if t[i] == -1:
+        t = self.t.ravel()
+        for xi, ti in six.moves.zip(x, t):
+            if ti == -1:
                 continue
-            log_z = numpy.ufunc.reduce(numpy.logaddexp, x[i])
-            loss_expect -= (x[i] - log_z)[t[i]]
+            log_z = numpy.ufunc.reduce(numpy.logaddexp, xi)
+            loss_expect -= (xi - log_z)[ti]
             count += 1
 
         if count == 0:

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -17,7 +17,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
     shape = (4, 3)
     backward_atol = 1e-4
-    store_forward = True
+    cache_score = True
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
@@ -28,10 +28,10 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
         loss = functions.softmax_cross_entropy(
-            x, t, use_cudnn=use_cudnn, store_forward=self.store_forward)
+            x, t, use_cudnn=use_cudnn, cache_score=self.cache_score)
         self.assertEqual(loss.data.shape, ())
         self.assertEqual(loss.data.dtype, numpy.float32)
-        self.assertEqual(hasattr(loss.creator, 'y'), self.store_forward)
+        self.assertEqual(hasattr(loss.creator, 'y'), self.cache_score)
         loss_value = float(cuda.to_cpu(loss.data))
 
         # Compute expected value
@@ -71,7 +71,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
     def check_backward(self, x_data, t_data, use_cudnn=True):
         gradient_check.check_backward(
             functions.SoftmaxCrossEntropy(
-                use_cudnn=use_cudnn, store_forward=self.store_forward),
+                use_cudnn=use_cudnn, cache_score=self.cache_score),
             (x_data, t_data), None, eps=0.02, atol=self.backward_atol)
 
     @condition.retry(3)
@@ -91,7 +91,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
 
 class TestSoftmaxCrossEntropyRemoveForward(TestSoftmaxCrossEntropy):
 
-    store_forward = False
+    cache_score = False
 
 
 class TestSoftmaxCrossEntropyUnstable(TestSoftmaxCrossEntropy):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -32,6 +32,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             x, t, use_cudnn=use_cudnn, store_forward=self.store_forward)
         self.assertEqual(loss.data.shape, ())
         self.assertEqual(loss.data.dtype, numpy.float32)
+        self.assertEqual(hasattr(loss.creator, 'y'), self.store_forward)
         loss_value = float(cuda.to_cpu(loss.data))
 
         # Compute expected value

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -1,4 +1,3 @@
-import math
 import unittest
 
 import mock


### PR DESCRIPTION
I added an argument to change behavior of softmax cross entropy. Only when `store_forward` is True, the loss function stores forward computation result.
fix #1067 