### PR TITLE
Set target language c++

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -102,7 +102,8 @@ def check_library(compiler, includes=(), libraries=(),
             compiler.link_shared_lib(objects,
                                      os.path.join(temp_dir, 'a'),
                                      libraries=libraries,
-                                     library_dirs=library_dirs)
+                                     library_dirs=library_dirs,
+                                     target_lang='c++')
         except (distutils.errors.LinkError, TypeError):
             return False
 

--- a/install/build.py
+++ b/install/build.py
@@ -131,7 +131,8 @@ def build_and_run(compiler, source, libraries=(),
                                      os.path.join(temp_dir, 'a'),
                                      libraries=libraries,
                                      library_dirs=library_dirs,
-                                     extra_postargs=postargs)
+                                     extra_postargs=postargs,
+                                     target_lang='c++')
         except Exception as e:
             msg = 'Cannot build a stub file.\nOriginal error: {0}'.format(e)
             raise Exception(msg)


### PR DESCRIPTION
`target_lang` is required for old gcc.