### PR TITLE
accuracy: support ignore_label

### DIFF
--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -7,6 +7,9 @@ from chainer.utils import type_check
 
 class Accuracy(function.Function):
 
+    def __init__(self, ignore_label=None):
+        self.ignore_label = ignore_label
+
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         x_type, t_type = in_types
@@ -25,17 +28,37 @@ class Accuracy(function.Function):
         xp = cuda.get_array_module(*inputs)
         y, t = inputs
         y = y.reshape(len(y), -1)  # flatten
-        pred = y.argmax(axis=1)
-        return xp.asarray((pred == t).mean(dtype='f')),
+
+        if self.ignore_label is not None:
+            mask = (t == self.ignore_label)
+            ignore_cnt = mask.sum()
+
+            # will always be true when the true label is ignore_label
+            # TODO(henry0312)
+            #   If cupy.where returns indexes, we could make the code better.
+            #   Also, we would need Advanced Indexing.
+            pred = xp.where(mask, self.ignore_label, y.argmax(axis=1))
+            count = (pred == t).sum() - ignore_cnt
+            total = len(t) - ignore_cnt
+
+            if total == 0:
+                return xp.asarray(0.0, dtype='f'),
+            else:
+                return xp.asarray(float(count) / total, dtype='f'),
+        else:
+            pred = y.argmax(axis=1)
+            return xp.asarray((pred == t).mean(dtype='f')),
 
 
-def accuracy(y, t):
+def accuracy(y, t, ignore_label=None):
     """Computes muticlass classification accuracy of the minibatch.
 
     Args:
         y (Variable): Variable holding a matrix whose (i, j)-th element
             indicates the score of the class j at the i-th example.
         t (Variable): Variable holding an int32 vector of ground truth labels.
+        ignore_label (int or None): Skip calculating accuracy
+            if the ture label is ``ignore_label``.
 
     Returns:
         Variable: A variable holding a scalar array of the accuracy.
@@ -43,4 +66,4 @@ def accuracy(y, t):
     .. note:: This function is non-differentiable.
 
     """
-    return Accuracy()(y, t)
+    return Accuracy(ignore_label=ignore_label)(y, t)

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -11,26 +11,49 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(
+    {'x_data': numpy.random.uniform(-1, 1, (10, 3)).astype(numpy.float32),
+     't_data': numpy.random.randint(3, size=(10,)).astype(numpy.int32),
+     'ignore_label': None},
+    {'x_data': numpy.random.uniform(-1, 1, (20, 3)).astype(numpy.float32),
+     't_data': numpy.random.randint(3, size=(20,)).astype(numpy.int32),
+     'ignore_label': 0},
+    {'x_data': numpy.random.uniform(-1, 1, (20, 3)).astype(numpy.float32),
+     't_data': numpy.zeros((20,), dtype=numpy.int32),
+     'ignore_label': 0},
+)
 class TestAccuracy(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (10, 3)).astype(numpy.float32)
-        self.t = numpy.random.randint(3, size=(10,)).astype(numpy.int32)
+        self.x = self.x_data
+        self.t = self.t_data
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
-        y = chainer.functions.accuracy(x, t)
+        y = chainer.functions.accuracy(x, t, self.ignore_label)
         self.assertEqual(y.data.dtype, numpy.float32)
         self.assertEqual((), y.data.shape)
 
-        count = 0
-        for i in six.moves.range(self.t.size):
-            pred = self.x[i].argmax()
-            if pred == self.t[i]:
-                count += 1
+        if self.ignore_label is not None:
+            count = 0
+            for i in six.moves.range(self.t.size):
+                pred = self.x[i].argmax()
+                if self.t[i] != self.ignore_label and pred == self.t[i]:
+                    count += 1
+                total = (self.t != self.ignore_label).sum()
+        else:
+            count = 0
+            for i in six.moves.range(self.t.size):
+                pred = self.x[i].argmax()
+                if pred == self.t[i]:
+                    count += 1
+                total = self.t.size
 
-        expected = float(count) / self.t.size
+        if total == 0:
+            expected = 0.0
+        else:
+            expected = float(count) / total
         gradient_check.assert_allclose(expected, cuda.to_cpu(y.data))
 
     @condition.retry(3)


### PR DESCRIPTION
Some users want to calculate accuracy except a certain label.
For example, we usually don't obtain accuracy for `<EOS>` label under a task of predicting next charcters. 

Thank you.