### PR TITLE
Fix dtype of argument in _inv_gpu

### DIFF
--- a/chainer/functions/math/inv.py
+++ b/chainer/functions/math/inv.py
@@ -16,12 +16,12 @@ def _inv_gpu(b):
     n = a.shape[1]
     n_matrices = len(a)
     # Pivot array
-    p = cuda.cupy.empty((n, n_matrices), dtype='int32')
+    p = cuda.cupy.empty((n, n_matrices), dtype=numpy.int32)
     # Output array
     c = cuda.cupy.empty_like(a)
     # These arrays hold information on the execution success
     # or if the matrix was singular
-    info = cuda.cupy.empty(n_matrices, dtype=numpy.intp)
+    info = cuda.cupy.empty(n_matrices, dtype=numpy.int32)
     ap = matmul._mat_ptrs(a)
     cp = matmul._mat_ptrs(c)
     _, lda = matmul._get_ld(a)


### PR DESCRIPTION
The type of `info` is required integer array.

```c
cublasStatus_t cublasSgetrfBatched(
    cublasHandle_t handle, int n, float *Aarray[], int lda,
    int *PivotArray, int *infoArray, int batchSize);
cublasStatus_t cublasSgetriBatched(
    cublasHandle_t handle, int n, float *Aarray[], int lda,
    int *PivotArray, float *Carray[], int ldc,
    int *infoArray, int batchSize);
```