### PR TITLE
Set default value for `ignore_label`

### DIFF
--- a/chainer/links/connection/embed_id.py
+++ b/chainer/links/connection/embed_id.py
@@ -24,6 +24,9 @@ class EmbedID(link.Link):
         W (~chainer.Variable): Embedding parameter matrix.
 
     """
+
+    ignore_label = None
+
     def __init__(self, in_size, out_size, ignore_label=None):
         super(EmbedID, self).__init__(W=(in_size, out_size))
         self.W.data[...] = numpy.random.randn(in_size, out_size)
@@ -39,6 +42,4 @@ class EmbedID(link.Link):
             ~chainer.Variable: Batch of corresponding embeddings.
 
         """
-        # for old pickled files
-        ignore_label = getattr(self, 'ignore_label', None)
-        return embed_id.embed_id(x, self.W, ignore_label=ignore_label)
+        return embed_id.embed_id(x, self.W, ignore_label=self.ignore_label)

--- a/chainer/links/connection/embed_id.py
+++ b/chainer/links/connection/embed_id.py
@@ -39,4 +39,6 @@ class EmbedID(link.Link):
             ~chainer.Variable: Batch of corresponding embeddings.
 
         """
-        return embed_id.embed_id(x, self.W, ignore_label=self.ignore_label)
+        # for old pickled files
+        ignore_label = getattr(self, 'ignore_label', None)
+        return embed_id.embed_id(x, self.W, ignore_label=ignore_label)

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -102,4 +102,15 @@ class TestEmbedIDValueCheck(unittest.TestCase):
         self.check_value_check(self.t)
 
 
+class TestEmbedIDUnpickleOldFile(unittest.TestCase):
+
+    def test_old_unpickle(self):
+        embed = links.EmbedID(3, 4)
+        # To emulate an old pickled file
+        delattr(embed, 'ignore_label')
+        x = chainer.Variable(numpy.arange(2, dtype=numpy.int32))
+        y = embed(x)
+        self.assertEqual(y.data.shape, (2, 4))
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
From chainer 1.8.0, `links.EmbedID` has `ignore_label` parameter. So we cannot unpickle an old file generated with chainer 1.7 or older. We can avoid this problem easily.