### PR TITLE
Fix rpath for OS X.

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -128,6 +128,9 @@ def make_extensions(options, compiler):
         x for x in settings['library_dirs'] if path.exists(x)]
     if sys.platform != 'win32':
         settings['runtime_library_dirs'] = settings['library_dirs']
+    if sys.platform == 'darwin':
+        settings.setdefault('extra_link_args', []).append(
+            '-Wl,' + ','.join('-rpath,' + path for path in settings['library_dirs']))
 
     if options['linetrace']:
         settings['define_macros'].append(('CYTHON_TRACE', '1'))


### PR DESCRIPTION
This resolves 'library not loaded (Image not found)' errors on El Capitan. See #780.
