### PR TITLE
Fix typos on dropout and mean square error test codes

### DIFF
--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -12,7 +12,7 @@ class Dropout(function.Function):
     def __init__(self, dropout_ratio):
         self.dropout_ratio = dropout_ratio
 
-    def check_type_forwrad(self, in_types):
+    def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
         # TODO(okuta): float type check
         # type_check.expect(in_types[0].dtype == numpy.float32)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
@@ -39,7 +39,7 @@ class TestMeanSquaredError(unittest.TestCase):
 
     @attr.gpu
     @condition.retry(3)
-    def test_forwrad_gpu(self):
+    def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
 
     def check_backward(self, x0_data, x1_data):


### PR DESCRIPTION
I found typos 'forwrad' in some codes.

