### PR TITLE
Fix bug of cupy.dot when using with `out` argument

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1780,6 +1780,9 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
     cdef bint a_is_vec, b_is_vec
     cdef vector.vector[Py_ssize_t] ret_shape
     cdef vector.vector[Py_ssize_t] shape
+
+    if out is not None and numpy.result_type(a.dtype, b.dtype) != out.dtype:
+        raise ValueError('Not supported dtype combination.')
     a_ndim = a._shape.size()
     b_ndim = b._shape.size()
     assert a_ndim > 0 and b_ndim > 0

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -3,58 +3,63 @@ import unittest
 from cupy import testing
 
 
+@testing.parameterize(*testing.product({
+    'shape': [
+        ((2, 3, 4), (3, 4, 2)),
+        ((1, 1), (1, 1)),
+        ((1, 1), (1, 2)),
+        ((1, 2), (2, 1)),
+        ((2, 1), (1, 1)),
+        ((1, 2), (2, 3)),
+        ((2, 1), (1, 3)),
+        ((2, 3), (3, 1)),
+        ((2, 3), (3, 4)),
+    ],
+    'trans_a': [True, False],
+    'trans_b': [True, False],
+}))
+@testing.gpu
+class TestDot(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'])
+    @testing.numpy_cupy_allclose()
+    def test_dot(self, xp, dtype_a, dtype_b):
+        shape_a, shape_b = self.shape
+        if self.trans_a:
+            a = testing.shaped_arange(shape_a[::-1], xp, dtype_a).T
+        else:
+            a = testing.shaped_arange(shape_a, xp, dtype_a)
+        if self.trans_b:
+            b = testing.shaped_arange(shape_b[::-1], xp, dtype_b).T
+        else:
+            b = testing.shaped_arange(shape_b, xp, dtype_b)
+        return xp.dot(a, b)
+
+    @testing.for_float_dtypes(name='dtype_a')
+    @testing.for_float_dtypes(name='dtype_b')
+    @testing.for_float_dtypes(name='dtype_c')
+    @testing.numpy_cupy_allclose()
+    def test_dot_with_out(self, xp, dtype_a, dtype_b, dtype_c):
+        shape_a, shape_b = self.shape
+        if self.trans_a:
+            a = testing.shaped_arange(shape_a[::-1], xp, dtype_a).T
+        else:
+            a = testing.shaped_arange(shape_a, xp, dtype_a)
+        if self.trans_b:
+            b = testing.shaped_arange(shape_b[::-1], xp, dtype_b).T
+        else:
+            b = testing.shaped_arange(shape_b, xp, dtype_b)
+        c = xp.empty((shape_a[0], shape_b[-1]), dtype=dtype_c)
+        xp.dot(a, b, out=c)
+        return c
+
+
 @testing.gpu
 class TestProduct(unittest.TestCase):
 
     _multiprocess_can_split_ = True
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
-    def test_dot(self, xp, dtype):
-        a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        b = testing.shaped_arange((3, 4, 2), xp, dtype)
-        return xp.dot(a, b)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
-    def check_dot(self, shape_a, shape_b, trans_a, trans_b, xp, dtype):
-        a = testing.shaped_arange(shape_a, xp, dtype)
-        b = testing.shaped_arange(shape_b, xp, dtype)
-        if trans_a:
-            a = a.T
-        if trans_b:
-            b = b.T
-        return xp.dot(a, b)
-
-    def check_dot_for_all_trans(self, shape_a, shape_b):
-        self.check_dot(shape_a, shape_b, False, False)
-        self.check_dot(shape_a[::-1], shape_b, True, False)
-        self.check_dot(shape_a, shape_b[::-1], False, True)
-        self.check_dot(shape_a[::-1], shape_b[::-1], True, True)
-
-    def test_dot2(self):
-        self.check_dot_for_all_trans((1, 1), (1, 1))
-
-    def test_dot3(self):
-        self.check_dot_for_all_trans((1, 1), (1, 2))
-
-    def test_dot4(self):
-        self.check_dot_for_all_trans((1, 2), (2, 1))
-
-    def test_dot5(self):
-        self.check_dot_for_all_trans((2, 1), (1, 1))
-
-    def test_dot6(self):
-        self.check_dot_for_all_trans((1, 2), (2, 3))
-
-    def test_dot7(self):
-        self.check_dot_for_all_trans((2, 1), (1, 3))
-
-    def test_dot8(self):
-        self.check_dot_for_all_trans((2, 3), (3, 1))
-
-    def test_dot9(self):
-        self.check_dot_for_all_trans((2, 3), (3, 4))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
@@ -90,6 +95,15 @@ class TestProduct(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((4, 2, 3), xp, dtype).transpose(2, 0, 1)
         c = xp.ndarray((3, 2, 3, 2), dtype=dtype)
+        xp.dot(a, b, out=c)
+        return c
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_transposed_dot_with_out2(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
+        b = testing.shaped_arange((4, 2, 3), xp, dtype).transpose(2, 0, 1)
+        c = xp.ndarray((3, 2, 3, 2)[::-1], dtype=dtype).T
         xp.dot(a, b, out=c)
         return c
 


### PR DESCRIPTION
Code:
```python
import numpy, cupy
numpy.dot(numpy.ones((2,2),'f'), numpy.ones((2,2), 'd'), out=numpy.ones((2,2), 'f'))
#---------------------------------------------------------------------------
#ValueError                                Traceback (most recent call last)
#<ipython-input-4-77836e7ebc0d> in <module>()
#----> 1 numpy.dot(numpy.ones((2,2),'f'), numpy.ones((2,2), 'd'), out=numpy.ones((2,2), 'f'))
#
#ValueError: output array is not acceptable (must have the right type, nr dimensions, and be a C-Array)

cupy.dot(cupy.ones((2,2),'f'), cupy.ones((2,2), 'd'), out=cupy.ones((2,2), 'f'))
#array([[ 1.,  1.],
#       [ 1.,  1.]], dtype=float32)
```