### PR TITLE
Loosen type condition in linear, convolution_2d and deconvolution_2d

### DIFF
--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -1,5 +1,3 @@
-import numpy
-
 from chainer import function
 from chainer.utils import type_check
 
@@ -18,8 +16,8 @@ class LinearFunction(function.Function):
         x_type, w_type = in_types[:2]
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
-            w_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
+            w_type.dtype.kind == 'f',
             x_type.ndim >= 2,
             w_type.ndim == 2,
             type_check.prod(x_type.shape[1:]) == w_type.shape[1],
@@ -27,7 +25,7 @@ class LinearFunction(function.Function):
         if n_in.eval() == 3:
             b_type = in_types[2]
             type_check.expect(
-                b_type.dtype == numpy.float32,
+                b_type.dtype == x_type.dtype,
                 b_type.ndim == 1,
                 b_type.shape[0] == w_type.shape[0],
             )
@@ -35,7 +33,7 @@ class LinearFunction(function.Function):
     def forward(self, inputs):
         x = _as_mat(inputs[0])
         W = inputs[1]
-        y = x.dot(W.T)
+        y = x.dot(W.T).astype(x.dtype)
         if len(inputs) == 3:
             b = inputs[2]
             y += b
@@ -46,8 +44,8 @@ class LinearFunction(function.Function):
         W = inputs[1]
         gy = grad_outputs[0]
 
-        gx = gy.dot(W).reshape(inputs[0].shape)
-        gW = gy.T.dot(x)
+        gx = gy.dot(W).astype(x.dtype).reshape(inputs[0].shape)
+        gW = gy.T.dot(x).astype(W.dtype)
         if len(inputs) == 3:
             gb = gy.sum(0)
             return gx, gW, gb

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -16,6 +16,8 @@ from chainer.testing import condition
 @testing.parameterize(*testing.product({
     'c_contiguous': [True, False],
     'cover_all': [True, False],
+    'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestConvolution2DFunction(unittest.TestCase):
 
@@ -28,18 +30,28 @@ class TestConvolution2DFunction(unittest.TestCase):
         self.use_cudnn = use_cudnn
         self.W = numpy.random.normal(
             0, numpy.sqrt(1. / (kh * kw * in_channels)),
-            (out_channels, in_channels, kh, kw)).astype(numpy.float32)
+            (out_channels, in_channels, kh, kw)).astype(self.W_dtype)
         self.b = numpy.random.uniform(
-            -1, 1, out_channels).astype(numpy.float32)
+            -1, 1, out_channels).astype(self.x_dtype)
 
-        self.x = numpy.random.uniform(-1, 1,
-                                      (2, 3, 4, 3)).astype(numpy.float32)
+        self.x = numpy.random.uniform(
+            -1, 1, (2, 3, 4, 3)).astype(self.x_dtype)
         if self.cover_all:
             self.gy = numpy.random.uniform(-1, 1,
-                                           (2, 2, 3, 2)).astype(numpy.float32)
+                                           (2, 2, 3, 2)).astype(self.x_dtype)
         else:
-            self.gy = numpy.random.uniform(-1, 1,
-                                           (2, 2, 2, 2)).astype(numpy.float32)
+            self.gy = numpy.random.uniform(
+                -1, 1, (2, 2, 2, 2)).astype(self.x_dtype)
+        self.check_forward_options = {}
+        self.check_backward_options = {'eps': 1e-2}
+        if self.x_dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_backward_options = {
+                'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1}
+        elif self.W_dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_backward_options = {
+                'eps': 2 ** -3, 'atol': 1e-3, 'rtol': 1e-2}
 
     @attr.cudnn
     def test_forward_consistency(self, nobias=False):
@@ -57,7 +69,8 @@ class TestConvolution2DFunction(unittest.TestCase):
             x_gpu, W_gpu, b_gpu, stride=self.stride, pad=self.pad,
             use_cudnn=self.use_cudnn, cover_all=self.cover_all)
 
-        gradient_check.assert_allclose(y_cpu.data, y_gpu.data.get())
+        gradient_check.assert_allclose(
+            y_cpu.data, y_gpu.data.get(), **self.check_forward_options)
 
     @attr.gpu
     def test_forward_consistency_im2col(self):
@@ -91,7 +104,7 @@ class TestConvolution2DFunction(unittest.TestCase):
         gradient_check.check_backward(
             convolution_2d.Convolution2DFunction(
                 self.stride, self.pad, self.use_cudnn, self.cover_all),
-            args, y_grad, eps=1e-2)
+            args, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -130,6 +143,7 @@ class TestConvolution2DFunction(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'use_cudnn': [True, False],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
 class TestConvolution2DCudnnCall(unittest.TestCase):
@@ -141,12 +155,15 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
         self.stride = 2
         self.pad = 1
         self.x = cuda.cupy.random.uniform(
-            -1, 1, (2, 3, 4, 3)).astype(numpy.float32)
+            -1, 1, (2, 3, 4, 3)).astype(self.dtype)
         self.W = cuda.cupy.random.normal(
             0, numpy.sqrt(1. / (kh * kw * in_channels)),
-            (out_channels, in_channels, kh, kw)).astype(numpy.float32)
+            (out_channels, in_channels, kh, kw)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(
-            -1, 1, (2, 2, 2, 2)).astype(numpy.float32)
+            -1, 1, (2, 2, 2, 2)).astype(self.dtype)
+        self.expect = self.use_cudnn and (
+            cuda.cudnn.cudnn.getVersion() >= 3000 or
+            self.dtype != numpy.float16)
 
     def forward(self):
         x = chainer.Variable(self.x)
@@ -158,16 +175,18 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
     def test_call_cudnn_forward(self):
         with mock.patch('cupy.cudnn.cudnn.convolutionForward') as func:
             self.forward()
-            self.assertEqual(func.called, self.use_cudnn)
+            self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backrward(self):
         y = self.forward()
         y.grad = self.gy
-        v2 = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
-        v3 = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
-        with mock.patch(v2) as func_v2, mock.patch(v3) as func_v3:
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            name = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
+        else:
+            name = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
+        with mock.patch(name) as func:
             y.backward()
-            self.assertEqual(func_v2.called or func_v3.called, self.use_cudnn)
+            self.assertEqual(func.called, self.expect)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -21,20 +21,20 @@ def _pair(x):
     return x, x
 
 
-@parameterize(
-    *testing.product({
-        'in_channels': [3],
-        'out_channels': [2],
-        'wscale': [1],
-        'ksize': [3],
-        'stride': [1, 2],
-        'pad': [1],
-        'nobias': [True, False],
-        'use_cudnn': [True, False],
-        'test_outsize': [True, False],
-        'c_contiguous': [True, False],
-    })
-)
+@parameterize(*testing.product({
+    'in_channels': [3],
+    'out_channels': [2],
+    'wscale': [1],
+    'ksize': [3],
+    'stride': [1, 2],
+    'pad': [1],
+    'nobias': [True, False],
+    'use_cudnn': [True, False],
+    'test_outsize': [True, False],
+    'c_contiguous': [True, False],
+    'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestDeconvolution2DFunction(unittest.TestCase):
 
     def setUp(self, use_cudnn=True):
@@ -44,9 +44,9 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         self.W = numpy.random.normal(
             0, self.wscale * numpy.sqrt(1. / (kh * kw * self.in_channels)),
             (self.in_channels, self.out_channels, kh, kw)
-        ).astype(numpy.float32)
+        ).astype(self.W_dtype)
         self.b = None if self.nobias else numpy.random.uniform(
-            -1, 1, self.out_channels).astype(numpy.float32)
+            -1, 1, self.out_channels).astype(self.x_dtype)
 
         N = 2
         inh, inw = 4, 3
@@ -54,9 +54,18 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         outw = conv.get_deconv_outsize(inw, kw, sw, pw)
         self.outsize = (outh, outw) if self.test_outsize else None
         self.x = numpy.random.uniform(
-            -1, 1, (N, self.in_channels, inh, inw)).astype(numpy.float32)
+            -1, 1, (N, self.in_channels, inh, inw)).astype(self.x_dtype)
         self.gy = numpy.random.uniform(
-            -1, 1, (N, self.out_channels, outh, outw)).astype(numpy.float32)
+            -1, 1, (N, self.out_channels, outh, outw)).astype(self.x_dtype)
+        self.test_forward_options = {}
+        self.check_backward_options = {'eps': 1e-2}
+        if self.x_dtype == numpy.float16:
+            self.test_forward_options = {'atol': 5e-3, 'rtol': 5e-2}
+            self.check_backward_options = {
+                'eps': 2**-3, 'atol': 1e-2, 'rtol': 1e-1}
+        elif self.W_dtype == numpy.float16:
+            self.check_backward_options = {
+                'eps': 2**-3, 'atol': 1e-3, 'rtol': 1e-2}
 
     @attr.cudnn
     def test_forward_consistency(self):
@@ -75,10 +84,14 @@ class TestDeconvolution2DFunction(unittest.TestCase):
             x_gpu, W_gpu, b_gpu, stride=self.stride, pad=self.pad,
             outsize=self.outsize, use_cudnn=self.use_cudnn)
 
-        gradient_check.assert_allclose(y_cpu.data, y_gpu.data.get())
+        self.assertEqual(y_cpu.data.dtype, self.x_dtype)
+        self.assertEqual(y_gpu.data.dtype, self.x_dtype)
+        gradient_check.assert_allclose(y_cpu.data, y_gpu.data.get(),
+                                       **self.test_forward_options)
 
     @attr.gpu
     def test_forward_consistency_im2col(self):
+        self.use_cudnn = False
         self.test_forward_consistency()
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
@@ -103,24 +116,24 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         gradient_check.check_backward(
             deconvolution_2d.Deconvolution2DFunction(
                 self.stride, self.pad, self.outsize, self.use_cudnn),
-            args, y_grad, eps=1e-2)
+            args, y_grad, **self.check_backward_options)
 
-    @condition.retry(3)
+    @condition.retry(10)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.W, self.b, self.gy)
 
     @attr.cudnn
-    @condition.retry(3)
+    @condition.retry(10)
     def test_backward_gpu(self):
         b = None if self.b is None else cuda.to_gpu(self.b)
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             b, cuda.to_gpu(self.gy))
 
 
-@testing.parameterize(
-    {'use_cudnn': True},
-    {'use_cudnn': False},
-)
+@testing.parameterize(*testing.product({
+    'use_cudnn': [True, False],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 @attr.cudnn
 class TestDeconvolution2DCudnnCall(unittest.TestCase):
 
@@ -133,15 +146,18 @@ class TestDeconvolution2DCudnnCall(unittest.TestCase):
         self.W = cuda.cupy.random.normal(
             0, numpy.sqrt(1. / (kh * kw * self.in_channels)),
             (self.in_channels, self.out_channels, kh, kw)
-        ).astype(numpy.float32)
+        ).astype(self.dtype)
         N = 2
         inh, inw = 4, 3
         outh = conv.get_deconv_outsize(inh, kh, sh, ph)
         outw = conv.get_deconv_outsize(inw, kw, sw, pw)
         self.x = cuda.cupy.random.uniform(
-            -1, 1, (N, self.in_channels, inh, inw)).astype(numpy.float32)
+            -1, 1, (N, self.in_channels, inh, inw)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(
-            -1, 1, (N, self.out_channels, outh, outw)).astype(numpy.float32)
+            -1, 1, (N, self.out_channels, outh, outw)).astype(self.dtype)
+        self.expect = self.use_cudnn and (
+            cuda.cudnn.cudnn.getVersion() >= 3000 or
+            self.dtype != numpy.float16)
 
     def forward(self):
         x = chainer.Variable(self.x)
@@ -150,18 +166,20 @@ class TestDeconvolution2DCudnnCall(unittest.TestCase):
             x, W, None, stride=1, pad=1, use_cudnn=self.use_cudnn)
 
     def test_call_cudnn_forward(self):
-        v2 = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
-        v3 = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
-        with mock.patch(v2) as func_v2, mock.patch(v3) as func_v3:
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            name = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
+        else:
+            name = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
+        with mock.patch(name) as func:
             self.forward()
-            self.assertEqual(func_v2.called or func_v3.called, self.use_cudnn)
+            self.assertEqual(func.called, self.expect)
 
-    def test_call_cudnn_backrward(self):
+    def test_call_cudnn_backward(self):
         y = self.forward()
         y.grad = self.gy
         with mock.patch('cupy.cudnn.cudnn.convolutionForward') as func:
             y.backward()
-            self.assertEqual(func.called, self.use_cudnn)
+            self.assertEqual(func.called, self.expect)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
@@ -12,17 +12,28 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(*testing.product({
+    'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestNonparameterizedLinear(unittest.TestCase):
 
     def setUp(self):
         self.W = numpy.random.uniform(
-            -1, 1, (2, 3)).astype(numpy.float32)
+            -1, 1, (2, 3)).astype(self.W_dtype)
         self.b = numpy.random.uniform(
-            -1, 1, 2).astype(numpy.float32)
+            -1, 1, 2).astype(self.x_dtype)
 
-        self.x = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, (4, 2)).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, (4, 3)).astype(self.x_dtype)
+        self.gy = numpy.random.uniform(-1, 1, (4, 2)).astype(self.x_dtype)
         self.y = self.x.dot(self.W.T) + self.b
+        self.check_forward_options = {}
+        self.check_backward_options = {}
+        if self.x_dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_backward_options = {'atol': 5e-2, 'rtol': 1e-1}
+        elif self.W_dtype == numpy.float16:
+            self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
 
     def check_forward(self, x_data, W_data, b_data, y_expect):
         x = chainer.Variable(x_data)
@@ -32,7 +43,9 @@ class TestNonparameterizedLinear(unittest.TestCase):
         else:
             b = chainer.Variable(b_data)
             y = functions.linear(x, W, b)
-        gradient_check.assert_allclose(y_expect, y.data)
+        self.assertEqual(y.data.dtype, self.x_dtype)
+        gradient_check.assert_allclose(
+            y_expect, y.data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -63,7 +76,8 @@ class TestNonparameterizedLinear(unittest.TestCase):
             args = args + (b_data,)
 
         gradient_check.check_backward(
-            linear.LinearFunction(), args, y_grad, eps=1e-2)
+            linear.LinearFunction(), args, y_grad,
+            eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/test_function.py
+++ b/tests/chainer_tests/test_function.py
@@ -283,8 +283,19 @@ class TestFunctionBackwardIntegration(unittest.TestCase):
 
 class TestFunctionInvalidType(unittest.TestCase):
 
-    def test_forward_invalid(self):
-        f = F.Linear(5, 5)
+    def test_forward_invalid1(self):
+        class Function(chainer.Function):
+            def check_type_forward(self, in_types):
+                x_type, = in_types
+                type_check.expect(
+                    x_type.dtype == numpy.float32,
+                    x_type.ndim >= 2,
+                )
+
+            def forward(self, inputs):
+                return inputs
+
+        f = Function()
 
         # OK
         v = chainer.Variable(numpy.random.randn(1, 5).astype(numpy.float32))
@@ -294,7 +305,7 @@ class TestFunctionInvalidType(unittest.TestCase):
         # Incorrect dtype
         # in py3, numpy dtypes are represented as class
         msg = """\
-Invalid operation is performed in: LinearFunction \\(Forward\\)
+Invalid operation is performed in: Function \\(Forward\\)
 
 Expect: in_types\\[0\\]\\.dtype == <(type|class) 'numpy\\.float32'>
 Actual: float64 \\!= <(type|class) 'numpy\\.float32'>"""
@@ -306,7 +317,7 @@ Actual: float64 \\!= <(type|class) 'numpy\\.float32'>"""
 
         # Incorrect dim
         msg = """\
-Invalid operation is performed in: LinearFunction \\(Forward\\)
+Invalid operation is performed in: Function \\(Forward\\)
 
 Expect: in_types\\[0\\]\\.ndim >= 2
 Actual: 1 < 2"""


### PR DESCRIPTION
These fcuntions accept an array of numpy.float16, numpy.float32 and numpy.float64.
See also #555.
Fix #519.