### PR TITLE
Loosen type condition in normalization functions

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -19,20 +19,20 @@ class BatchNormalizationFunction(function.Function):
 
         x_type, gamma_type, beta_type = in_types[:3]
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             x_type.ndim >= gamma_type.ndim + 1,
             # TODO(beam2d): Check shape
-            gamma_type.dtype == numpy.float32,
-            beta_type.dtype == numpy.float32,
+            gamma_type.dtype == x_type.dtype,
+            beta_type.dtype == x_type.dtype,
             gamma_type.shape == beta_type.shape,
         )
 
         if len(in_types) == 5:
             mean_type, var_type = in_types[3:]
             type_check.expect(
-                mean_type.dtype == numpy.float32,
+                mean_type.dtype == x_type.dtype,
                 mean_type.shape == gamma_type.shape,
-                var_type.dtype == numpy.float32,
+                var_type.dtype == x_type.dtype,
                 var_type.shape == gamma_type.shape,
             )
 

--- a/chainer/functions/normalization/local_response_normalization.py
+++ b/chainer/functions/normalization/local_response_normalization.py
@@ -47,7 +47,7 @@ class LocalResponseNormalization(function.Function):
         x_type, = in_types
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             x_type.ndim >= 2,
         )
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -22,6 +22,7 @@ def _batch_normalization(expander, gamma, beta, x, mean, var):
 
 @testing.parameterize(*testing.product({
     'ndim': [0, 1, 2, 3],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestBatchNormalization(unittest.TestCase):
 
@@ -30,26 +31,32 @@ class TestBatchNormalization(unittest.TestCase):
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
         self.eps = 1e-5
 
-        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(numpy.float32)
-        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
+        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(self.dtype)
+        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
 
         shape = (7, 3) + (2,) * self.ndim
-        self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
 
         self.args = [self.x, self.gamma, self.beta]
         self.mean = self.x.mean(axis=self.aggr_axes)
         self.var = self.x.var(axis=self.aggr_axes) + self.eps
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {'atol': 5e-1, 'rtol': 1e-1}
 
     def check_forward(self, args):
         y = functions.batch_normalization(
             *[chainer.Variable(i) for i in args], eps=self.eps)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_normalization(
             self.expander, self.gamma, self.beta, self.x, self.mean, self.var)
 
-        gradient_check.assert_allclose(y_expect, y.data, rtol=1e-3, atol=1e-4)
+        gradient_check.assert_allclose(
+            y_expect, y.data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -63,14 +70,14 @@ class TestBatchNormalization(unittest.TestCase):
     def check_backward(self, args, y_grad):
         gradient_check.check_backward(
             batch_normalization.BatchNormalizationFunction(eps=self.eps),
-            args, y_grad, eps=1e-2, rtol=1e-3, atol=1e-4)
+            args, y_grad, eps=1e-2, **self.check_backward_options)
 
-    @condition.retry(3)
+    @condition.retry(10)
     def test_backward_cpu(self):
         self.check_backward(self.args, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
+    @condition.retry(10)
     def test_backward_gpu(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))
@@ -78,34 +85,41 @@ class TestBatchNormalization(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'ndim': [0, 1, 2, 3],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestFixedBatchNormalization(unittest.TestCase):
 
     def setUp(self):
-        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(numpy.float32)
-        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
+        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(self.dtype)
+        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
         self.expander = (None, Ellipsis) + (None,) * self.ndim
 
         shape = (7, 3) + (2,) * self.ndim
-        self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.eps = 1e-5
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
 
-        self.mean = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
+        self.mean = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
         self.var = numpy.random.uniform(
-            0.5, 1, (3,)).astype(numpy.float32)
+            0.5, 1, (3,)).astype(self.dtype)
         self.args = [self.x, self.gamma, self.beta, self.mean, self.var]
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {'atol': 5e-2, 'rtol': 1e-1}
 
     def check_forward(self, args):
         y = functions.fixed_batch_normalization(
             *[chainer.Variable(i) for i in args], eps=self.eps)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_normalization(
             self.expander, self.gamma, self.beta, self.x, self.mean, self.var)
 
-        gradient_check.assert_allclose(y_expect, y.data, rtol=1e-3, atol=1e-4)
+        gradient_check.assert_allclose(
+            y_expect, y.data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -119,14 +133,14 @@ class TestFixedBatchNormalization(unittest.TestCase):
     def check_backward(self, args, y_grad):
         gradient_check.check_backward(
             batch_normalization.BatchNormalizationFunction(eps=self.eps),
-            args, y_grad, eps=1e-2, rtol=1e-3, atol=1e-4)
+            args, y_grad, eps=1e-2, **self.check_backward_options)
 
-    @condition.retry(3)
+    @condition.retry(10)
     def test_backward_cpu(self):
         self.check_backward(self.args, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
+    @condition.retry(10)
     def test_backward_gpu(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_local_response_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_local_response_normalization.py
@@ -12,18 +12,26 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestLocalResponseNormalization(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1,
-                                      (2, 7, 3, 2)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1,
-                                       (2, 7, 3, 2)).astype(numpy.float32)
+        self.x = numpy.random.uniform(
+            -1, 1, (2, 7, 3, 2)).astype(self.dtype)
+        self.gy = numpy.random.uniform(
+            -1, 1, (2, 7, 3, 2)).astype(self.dtype)
+        self.check_forward_options = {}
+        self.check_backward_options = {}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = functions.local_response_normalization(x)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
         # Naive implementation
@@ -35,7 +43,8 @@ class TestLocalResponseNormalization(unittest.TestCase):
             denom = (2 + 1e-4 * s) ** .75
             y_expect[n, c, h, w] = self.x[n, c, h, w] / denom
 
-        gradient_check.assert_allclose(y_expect, y_data, atol=1e-4)
+        gradient_check.assert_allclose(
+            y_expect, y_data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -49,7 +58,7 @@ class TestLocalResponseNormalization(unittest.TestCase):
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             functions.LocalResponseNormalization(), x_data, y_grad,
-            eps=1, atol=1e-4)
+            eps=1, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -85,6 +85,7 @@ class BatchNormalizationTest(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.multi_gpu(2)
+    @condition.retry(3)
     def test_forward_multi_gpu(self):
         with cuda.get_device(1):
             self.link.to_gpu()

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -26,6 +26,7 @@ def _batch_normalization(expander, gamma, beta, x, mean, var, eps, test):
     'test': [True, False],
     'volatile': ['on', 'off'],
     'ndim': [0, 1, 2, 3],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class BatchNormalizationTest(unittest.TestCase):
 
@@ -33,7 +34,7 @@ class BatchNormalizationTest(unittest.TestCase):
         self.expander = (None, Ellipsis) + (None,) * self.ndim
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
 
-        self.link = links.BatchNormalization(3)
+        self.link = links.BatchNormalization(3, dtype=self.dtype)
         gamma = self.link.gamma.data
         gamma[...] = numpy.random.uniform(.5, 1, gamma.shape)
         beta = self.link.beta.data
@@ -44,28 +45,34 @@ class BatchNormalizationTest(unittest.TestCase):
         self.beta = beta.copy()[self.expander]   # fixed on CPU
 
         shape = (7, 3) + (2,) * self.ndim
-        self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
 
         if self.test:
-            self.mean = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
-            self.var = numpy.random.uniform(0.5, 1, (3,)).astype(numpy.float32)
+            self.mean = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
+            self.var = numpy.random.uniform(0.5, 1, (3,)).astype(self.dtype)
             self.link.avg_mean[...] = self.mean
             self.link.avg_var[...] = self.var
         else:
             self.mean = self.x.mean(axis=self.aggr_axes)
             self.var = self.x.var(axis=self.aggr_axes)
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {'atol': 5e-1, 'rtol': 1e-1}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data, volatile=self.volatile)
         y = self.link(x, test=self.test)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_normalization(
             self.expander, self.gamma, self.beta, self.x, self.mean,
             self.var, self.link.eps, self.test)
 
-        gradient_check.assert_allclose(y_expect, y.data, rtol=1e-3, atol=1e-4)
+        gradient_check.assert_allclose(
+            y_expect, y.data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -88,7 +95,7 @@ class BatchNormalizationTest(unittest.TestCase):
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             self.link, x_data, y_grad, (self.link.gamma, self.link.beta),
-            eps=1e-2, rtol=1e-3, atol=1e-4)
+            eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):


### PR DESCRIPTION
These fcuntions accept an array of numpy.float16, numpy.float32 and numpy.float64.
See also #555