### PR TITLE
Loosen type condition in evaluation functions

### DIFF
--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -15,7 +15,7 @@ class Accuracy(function.Function):
         x_type, t_type = in_types
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             x_type.ndim >= 2,
             t_type.dtype == numpy.int32,
             t_type.ndim == 1,
@@ -42,12 +42,12 @@ class Accuracy(function.Function):
             total = len(t) - ignore_cnt
 
             if total == 0:
-                return xp.asarray(0.0, dtype='f'),
+                return xp.asarray(0.0, dtype=y.dtype),
             else:
-                return xp.asarray(float(count) / total, dtype='f'),
+                return xp.asarray(float(count) / total, dtype=y.dtype),
         else:
             pred = y.argmax(axis=1)
-            return xp.asarray((pred == t).mean(dtype='f')),
+            return xp.asarray((pred == t).mean(dtype=y.dtype)),
 
 
 def accuracy(y, t, ignore_label=None):

--- a/chainer/functions/evaluation/binary_accuracy.py
+++ b/chainer/functions/evaluation/binary_accuracy.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy
 
 from chainer import cuda
@@ -14,7 +16,7 @@ class BinaryAccuracy(function.Function):
         x_type, t_type = in_types
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             t_type.dtype == numpy.int32,
             t_type.shape == x_type.shape,
         )
@@ -27,7 +29,7 @@ class BinaryAccuracy(function.Function):
         t = t.ravel()
         c = (y >= 0)
         count = xp.maximum(1, (t != self.ignore_label).sum())
-        return xp.asarray((c == t).sum(dtype='f') / count, dtype='f'),
+        return xp.asarray((c == t).sum() / count, dtype=y.dtype),
 
 
 def binary_accuracy(y, t):

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -11,28 +11,31 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-@testing.parameterize(
-    {'x_data': numpy.random.uniform(-1, 1, (10, 3)).astype(numpy.float32),
-     't_data': numpy.random.randint(3, size=(10,)).astype(numpy.int32),
-     'ignore_label': None},
-    {'x_data': numpy.random.uniform(-1, 1, (20, 3)).astype(numpy.float32),
-     't_data': numpy.random.randint(3, size=(20,)).astype(numpy.int32),
-     'ignore_label': 0},
-    {'x_data': numpy.random.uniform(-1, 1, (20, 3)).astype(numpy.float32),
-     't_data': numpy.zeros((20,), dtype=numpy.int32),
-     'ignore_label': 0},
-)
+@testing.parameterize(*testing.product({
+    'shape': [(10, 3), (20, 3)],
+    't_data': ['random', 'zero'],
+    'ignore_label': [None, 0],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestAccuracy(unittest.TestCase):
 
     def setUp(self):
-        self.x = self.x_data
-        self.t = self.t_data
+        self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        if self.t_data == 'random':
+            self.t = numpy.random.randint(
+                3, size=self.shape[:1]).astype(numpy.int32)
+        elif self.t_data == 'zero':
+            self.t = numpy.zeros(self.shape[:1], dtype=numpy.int32)
+
+        self.check_forward_options = {}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
         y = chainer.functions.accuracy(x, t, self.ignore_label)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         self.assertEqual((), y.data.shape)
 
         if self.ignore_label is not None:
@@ -54,7 +57,8 @@ class TestAccuracy(unittest.TestCase):
             expected = 0.0
         else:
             expected = float(count) / total
-        gradient_check.assert_allclose(expected, cuda.to_cpu(y.data))
+        gradient_check.assert_allclose(
+            expected, cuda.to_cpu(y.data), **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_binary_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_binary_accuracy.py
@@ -12,21 +12,24 @@ from chainer.testing import condition
 from chainer.utils import type_check
 
 
-@testing.parameterize(
-    {'shape': (9, 11)},
-    {'shape': (99,)},
-)
+@testing.parameterize(*testing.product({
+    'shape': [(9, 11), (99,)],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestBinaryAccuracy(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.t = numpy.random.randint(-1, 2, self.shape).astype(numpy.int32)
+        self.check_forward_options = {}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
         y = chainer.functions.binary_accuracy(x, t)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         self.assertEqual((), y.data.shape)
 
         count = 0
@@ -41,7 +44,8 @@ class TestBinaryAccuracy(unittest.TestCase):
                 correct += 1
             count += 1
         expected = float(correct) / count
-        gradient_check.assert_allclose(expected, cuda.to_cpu(y.data))
+        gradient_check.assert_allclose(
+            expected, cuda.to_cpu(y.data), **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -53,17 +57,21 @@ class TestBinaryAccuracy(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestBinaryAccuracyIgnoreAll(unittest.TestCase):
 
     def setUp(self):
         shape = (5, 4)
-        self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.t = -numpy.ones(shape).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
         y = chainer.functions.binary_accuracy(x, t)
+        self.assertEqual(y.data.dtype, self.dtype)
 
         expected = 0.0
         gradient_check.assert_allclose(expected, cuda.to_cpu(y.data))


### PR DESCRIPTION
These fcuntions accept an array of numpy.float16, numpy.float32 and numpy.float64.
See also #555