### PR TITLE
Loosen type condition in softmax_cross_entropy function

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -15,8 +15,7 @@ if cuda.cudnn_enabled:
     _cudnn_version = libcudnn.getVersion()
 
 
-def logsumexp(x):
-    xp = cuda.get_array_module(x)
+def logsumexp(xp, x):
     m = x.max(axis=1, keepdims=True)
     y = x - m
     xp.exp(y, out=y)
@@ -25,11 +24,11 @@ def logsumexp(x):
 
 def softmax_log(x, use_cudnn):
     xp = cuda.get_array_module(x)
-    if xp != numpy and cuda.cudnn_enabled and use_cudnn \
-       and _cudnn_version >= 3000:
-        dtype = x.dtype
-        one = numpy.array(1, dtype=dtype).ctypes
-        zero = numpy.array(0, dtype=dtype).ctypes
+    if (xp != numpy and cuda.cudnn_enabled and use_cudnn and
+            _cudnn_version >= 3000):
+        oz_dtype = 'd' if x.dtype == 'd' else 'f'
+        one = numpy.array(1, dtype=oz_dtype).ctypes
+        zero = numpy.array(0, dtype=oz_dtype).ctypes
         handle = cudnn.get_handle()
         x_cube = x.reshape(x.shape[:2] + (-1, 1))
         desc = cudnn.create_tensor_descriptor(x_cube)
@@ -39,9 +38,8 @@ def softmax_log(x, use_cudnn):
             x_cube.data.ptr, zero.data, desc.value,
             y.data.ptr)
         return y
-
     else:
-        log_z = logsumexp(x)
+        log_z = logsumexp(xp, x)
         return x - log_z
 
 
@@ -61,7 +59,7 @@ class SoftmaxCrossEntropy(function.Function):
         x_type, t_type = in_types
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             t_type.dtype == numpy.int32,
             t_type.ndim == x_type.ndim - 1,
 
@@ -119,7 +117,7 @@ class SoftmaxCrossEntropy(function.Function):
         log_y = cupy.rollaxis(log_y, 1, log_y.ndim)
         ret = cuda.reduce(
             'S t, raw T log_y, int32 n_channel, raw T coeff', 'T out',
-            't == -1 ? 0 : log_y[_j * n_channel + t]',
+            't == -1 ? T(0) : log_y[_j * n_channel + t]',
             'a + b', 'out = a * -coeff[0]', '0', 'crossent_fwd'
         )(t, log_y.reduced_view(), log_y.shape[-1], self._coeff)
         return ret,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -13,24 +13,43 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(*testing.product({
+    'shape': [None, (4, 3), (4, 3, 2), (4, 3, 2, 5)],
+    'cache_score': [True, False],
+    'normalize': [True, False],
+    'ignore_index': [None, (slice(None),), (2,), (0, 1), (0, 1, 2)],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestSoftmaxCrossEntropy(unittest.TestCase):
 
-    shape = (4, 3)
-    backward_atol = 1e-4
-    cache_score = True
-
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
-        out_shape = (self.shape[0],) + self.shape[2:]
-        self.t = numpy.random.randint(0, 3, out_shape).astype(numpy.int32)
+        if self.shape is None:
+            if self.dtype == numpy.float16:
+                self.x = numpy.array([[-5, 1]], dtype=self.dtype)
+            else:
+                self.x = numpy.array([[-1000, 1]], dtype=self.dtype)
+            self.t = numpy.array([0], dtype=numpy.int32)
+        else:
+            self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+            out_shape = (self.shape[0],) + self.shape[2:]
+            self.t = numpy.random.randint(0, 3, out_shape).astype(numpy.int32)
+            if (self.ignore_index is not None and
+                    len(self.ignore_index) <= self.t.ndim):
+                self.t[self.ignore_index] = -1
+        self.check_forward_options = {}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_backward_options = {'atol': 5e-2, 'rtol': 1e-1}
 
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
         loss = functions.softmax_cross_entropy(
-            x, t, use_cudnn=use_cudnn, cache_score=self.cache_score)
+            x, t, use_cudnn=use_cudnn, normalize=self.normalize,
+            cache_score=self.cache_score)
         self.assertEqual(loss.data.shape, ())
-        self.assertEqual(loss.data.dtype, numpy.float32)
+        self.assertEqual(loss.data.dtype, self.dtype)
         self.assertEqual(hasattr(loss.creator, 'y'), self.cache_score)
         loss_value = float(cuda.to_cpu(loss.data))
 
@@ -47,12 +66,16 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             loss_expect -= (xi - log_z)[ti]
             count += 1
 
-        if count == 0:
-            loss_expect = 0.0
+        if self.normalize:
+            if count == 0:
+                loss_expect = 0.0
+            else:
+                loss_expect /= count
         else:
-            loss_expect /= count
+            loss_expect /= len(t_data)
 
-        self.assertAlmostEqual(loss_expect, loss_value, places=5)
+        gradient_check.assert_allclose(
+            loss_expect, loss_value, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -72,7 +95,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         gradient_check.check_backward(
             functions.SoftmaxCrossEntropy(
                 use_cudnn=use_cudnn, cache_score=self.cache_score),
-            (x_data, t_data), None, eps=0.02, atol=self.backward_atol)
+            (x_data, t_data), None, eps=0.02, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -87,81 +110,6 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), False)
-
-
-class TestSoftmaxCrossEntropyRemoveForward(TestSoftmaxCrossEntropy):
-
-    cache_score = False
-
-
-class TestSoftmaxCrossEntropyUnstable(TestSoftmaxCrossEntropy):
-
-    backward_atol = 1e-3
-
-    def setUp(self):
-        self.x = numpy.array([[-1000, 1]], dtype=numpy.float32)
-        self.t = numpy.array([0], dtype=numpy.int32)
-
-
-class TestReplicatedSoftmaxCrossEntropy1(TestSoftmaxCrossEntropy):
-
-    def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (4, 3, 2)).astype(numpy.float32)
-        self.t = numpy.random.randint(0, 3, (4, 2)).astype(numpy.int32)
-
-
-class TestReplicatedSoftmaxCrossEntropy2(TestSoftmaxCrossEntropy):
-
-    def setUp(self):
-        self.x = numpy.random.uniform(
-            -1, 1, (4, 3, 2, 5)).astype(numpy.float32)
-        self.t = numpy.random.randint(0, 3, (4, 2, 5)).astype(numpy.int32)
-
-
-class TestSoftmaxCrossEntropyWithIgnoreLabel(TestSoftmaxCrossEntropy):
-
-    def setUp(self):
-        super(TestSoftmaxCrossEntropyWithIgnoreLabel, self).setUp()
-        self.t[2] = -1
-
-
-class TestSoftmaxCrossEntropyIgnoreAll(TestSoftmaxCrossEntropy):
-
-    def setUp(self):
-        super(TestSoftmaxCrossEntropyIgnoreAll, self).setUp()
-        self.t[:] = -1
-
-
-class TestReplicatedSoftmaxCrossEntropy1IgnoreLabel(
-        TestReplicatedSoftmaxCrossEntropy1):
-
-    def setUp(self):
-        super(TestReplicatedSoftmaxCrossEntropy1IgnoreLabel, self).setUp()
-        self.t[0, 1] = -1
-
-
-class TestReplicatedSoftmaxCrossEntropy2IgnoreLabel(
-        TestReplicatedSoftmaxCrossEntropy2):
-
-    def setUp(self):
-        super(TestReplicatedSoftmaxCrossEntropy2IgnoreLabel, self).setUp()
-        self.t[0, 1, 2] = -1
-
-
-class TestReplicatedSoftmaxCrossEntropy1IgnoreAll(
-        TestReplicatedSoftmaxCrossEntropy1):
-
-    def setUp(self):
-        super(TestReplicatedSoftmaxCrossEntropy1IgnoreAll, self).setUp()
-        self.t[:] = -1
-
-
-class TestReplicatedSoftmaxCrossEntropy2IgnoreAll(
-        TestReplicatedSoftmaxCrossEntropy2):
-
-    def setUp(self):
-        super(TestReplicatedSoftmaxCrossEntropy2IgnoreAll, self).setUp()
-        self.t[:] = -1
 
 
 @testing.parameterize(
@@ -204,15 +152,15 @@ class TestSoftmaxCrossEntropyValueCheck(unittest.TestCase):
         self.check_value_check(cuda.to_gpu(self.x), cuda.to_gpu(self.t), True)
 
 
-@testing.parameterize(
-    {'use_cudnn': True},
-    {'use_cudnn': False},
-)
+@testing.parameterize(*testing.product({
+    'use_cudnn': [True, False],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 @attr.cudnn
 class TestSoftmaxCrossEntropyCudnnCall(unittest.TestCase):
 
     def setUp(self):
-        self.x = cuda.cupy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
+        self.x = cuda.cupy.random.uniform(-1, 1, (4, 3)).astype(self.dtype)
         self.t = cuda.cupy.random.randint(0, 3, (4,)).astype(numpy.int32)
 
     def forward(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -14,10 +14,10 @@ from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
-    'shape': [None, (4, 3), (4, 3, 2), (4, 3, 2, 5)],
+    'shape': [None, (2, 3), (2, 3, 2), (2, 3, 2, 2)],
     'cache_score': [True, False],
     'normalize': [True, False],
-    'ignore_index': [None, (slice(None),), (2,), (0, 1), (0, 1, 2)],
+    'ignore_index': [None, (slice(None),), (0,), (0, 1), (0, 1, 0)],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestSoftmaxCrossEntropy(unittest.TestCase):


### PR DESCRIPTION
These fcuntions accept an array of numpy.float16, numpy.float32 and numpy.float64.
See also #555