### PR TITLE
Fix HuberLoss's backward computation

### DIFF
--- a/chainer/functions/loss/huber_loss.py
+++ b/chainer/functions/loss/huber_loss.py
@@ -31,7 +31,8 @@ class HuberLoss(function.Function):
     def backward(self, inputs, gy):
         xp = cuda.get_array_module(*inputs)
         mask = xp.abs(self.diff) <= self.delta
-        gx = xp.where(mask, self.diff, self.delta * xp.sign(self.diff))
+        gx = gy[0].reshape(gy[0].shape + (1,) * (self.diff.ndim - 1)) * \
+            xp.where(mask, self.diff, self.delta * xp.sign(self.diff))
         return gx, -gx
 
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
@@ -18,6 +18,7 @@ class TestHuberLoss(unittest.TestCase):
         self.x = (numpy.random.random(self.shape) - 0.5) * 20
         self.x = self.x.astype(numpy.float32)
         self.t = numpy.random.random(self.shape).astype(numpy.float32)
+        self.gy = numpy.random.random(self.shape[0]).astype(numpy.float32)
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
@@ -43,19 +44,20 @@ class TestHuberLoss(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
-    def check_backward(self, x_data, t_data):
+    def check_backward(self, x_data, t_data, y_grad):
         gradient_check.check_backward(
             functions.HuberLoss(delta=1),
-            (x_data, t_data), None, eps=1e-2, atol=1e-3)
+            (x_data, t_data), y_grad, eps=1e-2, atol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.t)
+        self.check_backward(self.x, self.t, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t),
+                            cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR fixes #1175 .

- Modified `HuberLoss`'s `backward()` so that it will compute correct gradients even when `gy` is not ones.
- Modified its test case so that `gy` is set to random values.

Since `backward()` will start to raise an error when `gy` is `None` after this PR, some existing code might stop to work.