### PR TITLE
cupy.cuda.compile_with_cache using memory cache(lru_cache)

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -11,6 +11,11 @@ import six
 from cupy.cuda import device
 from cupy.cuda import function
 
+if six.PY2:
+    import functools32 as functools
+else:
+    import functools
+
 
 def _get_arch():
     cc = device.Device().compute_capability
@@ -96,6 +101,7 @@ def get_cache_dir():
 _empty_file_preprocess_cache = {}
 
 
+@functools.lru_cache()
 def compile_with_cache(source, options=(), arch=None, cache_dir=None):
     global _empty_file_preprocess_cache
     if cache_dir is None:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ install_requires = [
     'six>=1.9.0',
 ]
 
+extras_require = {
+    ":python_version < '3.0'": ["functools32"]
+}
+
 
 # Hack for Read the Docs
 on_rtd = chainer_setup_build.check_readthedocs_environment()
@@ -81,6 +85,7 @@ setup(
     install_requires=install_requires,
     tests_require=['mock',
                    'nose'],
+    extras_require=extras_require,
     # To trick build into running build_ext
     ext_modules=[chainer_setup_build.dummy_extension],
     cmdclass={


### PR DESCRIPTION
This PR is added lru_cache to cupy.cuda.compile_with_cache.
`cupy.cuda.compile_with_cache` is slow because it uses the file cache.
So I add the memory cache.

