### PR TITLE
Add `deterministic` option into convolution_2d and deconvolution_2d

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -26,11 +26,12 @@ def _pair(x):
 
 class Convolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False):
+    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False, deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.use_cudnn = use_cudnn
         self.cover_all = cover_all
+        self.deterministic = deterministic
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -177,20 +178,28 @@ class Convolution2DFunction(function.Function):
                 workspace_size = cuda.get_max_workspace_size()
                 workspace = cuda.cupy.empty((workspace_size,), dtype='b')
 
-                algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
-                    handle, x_desc.value, gy_desc.value,
-                    self.conv_desc.value, self.filter_desc.value,
-                    _bwd_filter_pref, workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
+                        handle, x_desc.value, gy_desc.value,
+                        self.conv_desc.value, self.filter_desc.value,
+                        _bwd_filter_pref, workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
+
                 libcudnn.convolutionBackwardFilter_v3(
                     handle, one.data, x_desc.value, x.data.ptr,
                     gy_desc.value, gy.data.ptr, self.conv_desc.value,
                     algo, workspace.data.ptr, workspace_size,
                     zero.data, self.filter_desc.value, gW.data.ptr)
 
-                algo = libcudnn.getConvolutionBackwardDataAlgorithm(
-                    handle, self.filter_desc.value, gy_desc.value,
-                    self.conv_desc.value, x_desc.value, _bwd_data_pref,
-                    workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                        handle, self.filter_desc.value, gy_desc.value,
+                        self.conv_desc.value, x_desc.value, _bwd_data_pref,
+                        workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
+
                 libcudnn.convolutionBackwardData_v3(
                     handle, one.data, self.filter_desc.value, W.data.ptr,
                     gy_desc.value, gy.data.ptr, self.conv_desc.value,
@@ -239,7 +248,7 @@ class Convolution2DFunction(function.Function):
 
 
 def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
-                   cover_all=False):
+                   cover_all=False, deterministic=False):
     """Two-dimensional convolution function.
 
     This is an implementation of two-dimensional convolution in ConvNets.
@@ -269,6 +278,10 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
             available.
         cover_all (bool): If True, all spatial locations are convoluted into
             some output pixels. It may make the output size larger.
+        deterministic (bool): The output of this function can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
 
     Returns:
@@ -299,7 +312,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
     .. seealso:: :class:`Convolution2D`
 
     """
-    func = Convolution2DFunction(stride, pad, use_cudnn, cover_all)
+    func = Convolution2DFunction(stride, pad, use_cudnn, cover_all, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -26,11 +26,12 @@ def _pair(x):
 
 class Deconvolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, outsize=None, use_cudnn=True):
+    def __init__(self, stride=1, pad=0, outsize=None, use_cudnn=True, deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.use_cudnn = use_cudnn
         self.outh, self.outw = (None, None) if outsize is None else outsize
+        self.deterministic = deterministic
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -123,10 +124,14 @@ class Deconvolution2DFunction(function.Function):
             if _cudnn_version >= 4000:
                 workspace_size = cuda.get_max_workspace_size()
                 workspace = cuda.cupy.empty((workspace_size,), dtype='b')
-                algo = libcudnn.getConvolutionBackwardDataAlgorithm(
-                    handle, self.filter_desc.value, x_desc.value,
-                    self.conv_desc.value, y_desc.value, _bwd_data_pref,
-                    workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                        handle, self.filter_desc.value, x_desc.value,
+                        self.conv_desc.value, y_desc.value, _bwd_data_pref,
+                        workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
+
                 libcudnn.convolutionBackwardData_v3(
                     handle, one.data, self.filter_desc.value, W.data.ptr,
                     x_desc.value, x.data.ptr, self.conv_desc.value,
@@ -216,10 +221,13 @@ class Deconvolution2DFunction(function.Function):
             gW = cuda.cupy.empty_like(W)
             # filter backward
             if _cudnn_version >= 4000:
-                algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
-                    handle, gy_desc.value, gx_desc.value,
-                    self.conv_desc.value, self.filter_desc.value,
-                    _bwd_filter_pref, workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
+                        handle, gy_desc.value, gx_desc.value,
+                        self.conv_desc.value, self.filter_desc.value,
+                        _bwd_filter_pref, workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
 
                 libcudnn.convolutionBackwardFilter_v3(
                     handle, one.data, gy_desc.value, gy.data.ptr,
@@ -261,7 +269,7 @@ class Deconvolution2DFunction(function.Function):
 
 
 def deconvolution_2d(x, W, b=None, stride=1, pad=0,
-                     outsize=None, use_cudnn=True):
+                     outsize=None, use_cudnn=True, deterministic=False):
     """Two dimensional deconvolution function.
 
     This is an implementation of two-dimensional deconvolution.
@@ -283,6 +291,10 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
             input size, stride and pad.
         use_cudnn (bool): If ``True``, then this function uses cuDNN if
             available.
+        deterministic (bool): The output of this function can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`
@@ -302,7 +314,7 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
        w_O &= s_X (w - 1) + k_W - 2p_W.
 
     """
-    func = Deconvolution2DFunction(stride, pad, outsize, use_cudnn)
+    func = Deconvolution2DFunction(stride, pad, outsize, use_cudnn, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -28,6 +28,10 @@ class Convolution2D(link.Link):
             function uses to initialize ``wscale``.
         initial_bias (1-D array): Initial bias value. If ``None``, then this
             function uses to initialize ``bias``.
+        deterministic (bool): The output of this link can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
     .. seealso::
        See :func:`chainer.functions.convolution_2d` for the definition of
@@ -40,11 +44,12 @@ class Convolution2D(link.Link):
     """
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
                  wscale=1, bias=0, nobias=False, use_cudnn=True,
-                 initialW=None, initial_bias=None):
+                 initialW=None, initial_bias=None, deterministic=False):
         kh, kw = _pair(ksize)
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.use_cudnn = use_cudnn
+        self.deterministic = deterministic
 
         W_shape = (out_channels, in_channels, kh, kw)
         super(Convolution2D, self).__init__(W=W_shape)
@@ -74,7 +79,8 @@ class Convolution2D(link.Link):
 
         """
         return convolution_2d.convolution_2d(
-            x, self.W, self.b, self.stride, self.pad, self.use_cudnn)
+            x, self.W, self.b, self.stride, self.pad, self.use_cudnn,
+            deterministic=self.deterministic)
 
 
 def _pair(x):

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -36,6 +36,10 @@ class Deconvolution2D(link.Link):
             function uses to initialize ``wscale``.
         initial_bias (1-D array): Initial bias value. If ``None``, then this
             function uses to initialize ``bias``.
+        deterministic (bool): The output of this link can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`
     which indicate the number of the number of input channels, output channels,
@@ -56,12 +60,13 @@ class Deconvolution2D(link.Link):
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
                  wscale=1, bias=0, nobias=False, outsize=None, use_cudnn=True,
-                 initialW=None, initial_bias=None):
+                 initialW=None, initial_bias=None, deterministic=False):
         kh, kw = _pair(ksize)
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.outsize = (None, None) if outsize is None else outsize
         self.use_cudnn = use_cudnn
+        self.deterministic = deterministic
 
         W_shape = (in_channels, out_channels, kh, kw)
         super(Deconvolution2D, self).__init__(W=W_shape)
@@ -89,7 +94,8 @@ class Deconvolution2D(link.Link):
     def __call__(self, x):
         return deconvolution_2d.deconvolution_2d(
             x, self.W, self.b, self.stride, self.pad,
-            self.outsize, self.use_cudnn)
+            self.outsize, self.use_cudnn,
+            deterministic=self.deterministic)
 
 
 def _pair(x):


### PR DESCRIPTION
Some of convolution algorithm cuDNN provides are non-deterministic.
So outputs of current chainer convolution and deconvolution can be non-deterministic when cuDNN is available.
I think this might make trouble when you want to do reproducible experiments.

This PR add `deterministic` option into these two functions and links.
If `True`, the functions force cuDNN to use deterministic algorithms.