### PR TITLE
Loosen inputs' shape condition of Accuracy Function

### DIFF
--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -19,7 +19,7 @@ class Accuracy(function.Function):
 
         t_ndim = t_type.ndim.eval()
         type_check.expect(
-            x_type.ndim >= t_ndim,
+            x_type.ndim >= t_type.ndim,
             x_type.shape[0] == t_type.shape[0],
             x_type.shape[2: t_ndim + 1] == t_type.shape[1:]
         )

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -1,4 +1,5 @@
 import numpy
+import six
 
 from chainer import cuda
 from chainer import function
@@ -16,19 +17,14 @@ class Accuracy(function.Function):
             t_type.dtype == numpy.int32
         )
 
-        if t_type.ndim.eval() == 1:
-            type_check.expect(
-                x_type.ndim >= 2,
-                x_type.shape[0] == t_type.shape[0]
-            )
-            for i in range(2, x_type.ndim.eval()):
-                type_check.expect(x_type.shape[i] == 1)
-        else:
-            type_check.expect(
-                t_type.ndim == x_type.ndim - 1,
-                x_type.shape[0] == t_type.shape[0],
-                x_type.shape[2:] == t_type.shape[1:]
-            )
+        t_ndim = t_type.ndim.eval()
+        type_check.expect(
+            x_type.ndim >= t_ndim,
+            x_type.shape[0] == t_type.shape[0],
+            x_type.shape[2: t_ndim + 1] == t_type.shape[1:]
+        )
+        for i in six.moves.range(t_ndim + 1, x_type.ndim.eval()):
+            type_check.expect(x_type.shape[i] == 1)
 
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -32,6 +32,8 @@ class Accuracy(function.Function):
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
         y, t = inputs
+        y = xp.rollaxis(y, 1)
+        y = xp.reshape(y, (-1,) + t.shape)
 
         if self.ignore_label is not None:
             mask = (t == self.ignore_label)
@@ -41,17 +43,15 @@ class Accuracy(function.Function):
             # TODO(henry0312)
             #   If cupy.where returns indexes, we could make the code better.
             #   Also, we would need Advanced Indexing.
-            pred = xp.where(mask, self.ignore_label, y.argmax(axis=1))
+            pred = xp.where(mask, self.ignore_label, y.argmax(axis=0))
             count = (pred == t).sum() - ignore_cnt
-            total = len(t) - ignore_cnt
+            total = t.size - ignore_cnt
 
             if total == 0:
                 return xp.asarray(0.0, dtype='f'),
             else:
                 return xp.asarray(float(count) / total, dtype='f'),
         else:
-            y = xp.rollaxis(y, 1)
-            y = xp.reshape(y, (-1,) + t.shape)
             pred = y.argmax(axis=0)
             return xp.asarray((pred == t).mean(dtype='f')),
 

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -13,19 +13,18 @@ class Accuracy(function.Function):
 
         type_check.expect(
             x_type.dtype == numpy.float32,
-            x_type.ndim >= 2,
             t_type.dtype == numpy.int32,
-            t_type.ndim == 1,
-            t_type.shape[0] == x_type.shape[0],
+            t_type.ndim == x_type.ndim - 1,
+
+            x_type.shape[0] == t_type.shape[0],
+            x_type.shape[2:] == t_type.shape[1:]
         )
-        for i in range(2, x_type.ndim.eval()):
-            type_check.expect(x_type.shape[i] == 1)
 
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
         y, t = inputs
-        y = y.reshape(len(y), -1)  # flatten
-        pred = y.argmax(axis=1)
+        y = xp.rollaxis(y, 1)
+        pred = y.argmax(axis=0)
         return xp.asarray((pred == t).mean(dtype='f')),
 
 

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -13,7 +13,10 @@ from chainer.testing import condition
 
 @testing.parameterize(
     {'x_shape': (10, 3), 't_shape': (10,)},
+    {'x_shape': (10, 3, 1), 't_shape': (10,)},
+    {'x_shape': (10, 3, 1, 1), 't_shape': (10,)},
     {'x_shape': (10, 3, 5), 't_shape': (10, 5)},
+    {'x_shape': (10, 3, 5, 4), 't_shape': (10, 5, 4)},
 )
 class TestAccuracy(unittest.TestCase):
 

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -11,11 +11,15 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(
+    {'x_shape': (10, 3), 't_shape': (10,)},
+    {'x_shape': (10, 3, 5), 't_shape': (10, 5)},
+)
 class TestAccuracy(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (10, 3)).astype(numpy.float32)
-        self.t = numpy.random.randint(3, size=(10,)).astype(numpy.int32)
+        self.x = numpy.random.uniform(-1, 1, self.x_shape).astype(numpy.float32)
+        self.t = numpy.random.randint(3, size=self.t_shape).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
@@ -24,10 +28,12 @@ class TestAccuracy(unittest.TestCase):
         self.assertEqual(y.data.dtype, numpy.float32)
         self.assertEqual((), y.data.shape)
 
+        x_ = numpy.rollaxis(self.x, 1, self.x.ndim).reshape(self.t.size, -1)
+        t_ = self.t.ravel()
         count = 0
-        for i in six.moves.range(self.t.size):
-            pred = self.x[i].argmax()
-            if pred == self.t[i]:
+        for i in six.moves.range(t_.size):
+            pred = x_[i].argmax()
+            if pred == t_[i]:
                 count += 1
 
         expected = float(count) / self.t.size

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -13,7 +13,7 @@ from chainer.utils import type_check
 
 
 @testing.parameterize(
-    testing.product(
+    *testing.product_dict(
         [{'x_shape': (10, 3), 't_shape': (10,)},
          {'x_shape': (10, 3, 1), 't_shape': (10,)},
          {'x_shape': (10, 3, 1, 1), 't_shape': (10,)},
@@ -31,9 +31,9 @@ class TestAccuracy(unittest.TestCase):
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1,
                                       self.x_shape).astype(numpy.float32)
-        if t_data == 'randint':
+        if self.t_data == 'randint':
             self.t = numpy.random.randint(3, size=self.t_shape).astype(numpy.int32)
-        elif t_data == 'zero':
+        elif self.t_data == 'zero':
             self.t = numpy.zeros(self.t_shape).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data):
@@ -55,7 +55,7 @@ class TestAccuracy(unittest.TestCase):
                 total = (t_ != self.ignore_label).sum()
         else:
             count = 0
-            for i in six.moves.range(self.t_.size):
+            for i in six.moves.range(t_.size):
                 pred = x_[i].argmax()
                 if pred == t_[i]:
                     count += 1

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -21,7 +21,8 @@ from chainer.testing import condition
 class TestAccuracy(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.x_shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1,
+                                      self.x_shape).astype(numpy.float32)
         self.t = numpy.random.randint(3, size=self.t_shape).astype(numpy.int32)
 
     def check_forward(self, x_data, t_data):

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -9,6 +9,7 @@ from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
+from chainer.utils import type_check
 
 
 @testing.parameterize(
@@ -53,6 +54,35 @@ class TestAccuracy(unittest.TestCase):
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
+
+
+@testing.parameterize(
+    {'x_shape': (10, 3), 't_shape': (4,)},
+    {'x_shape': (10, 3, 2), 't_shape': (10,)},
+    {'x_shape': (10, 3, 1, 2), 't_shape': (10,)},
+    {'x_shape': (10, 3, 4), 't_shape': (10, 5)},
+    {'x_shape': (10, 3, 5, 2), 't_shape': (10, 5)},
+    {'x_shape': (10, 3, 5, 1, 2), 't_shape': (10, 5)},
+)
+class TestInvalidShape(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1,
+                                      self.x_shape).astype(numpy.float32)
+        self.t = numpy.random.randint(3, size=self.t_shape).astype(numpy.int32)
+
+    def check_invalid_shape(self, xp):
+        x = chainer.Variable(xp.asarray(self.x))
+        t = chainer.Variable(xp.asarray(self.t))
+        with self.assertRaises(type_check.InvalidType):
+            chainer.functions.accuracy(x, t)
+
+    def test_invalid_shape_cpu(self):
+        self.check_invalid_shape(numpy)
+
+    @attr.gpu
+    def test_invalid_shape_gpu(self):
+        self.check_invalid_shape(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -17,6 +17,8 @@ from chainer.testing import condition
     {'x_shape': (10, 3, 1, 1), 't_shape': (10,)},
     {'x_shape': (10, 3, 5), 't_shape': (10, 5)},
     {'x_shape': (10, 3, 5, 4), 't_shape': (10, 5, 4)},
+    {'x_shape': (10, 3, 5, 4, 1), 't_shape': (10, 5, 4)},
+    {'x_shape': (10, 3, 5, 4, 1, 1), 't_shape': (10, 5, 4)},
 )
 class TestAccuracy(unittest.TestCase):
 


### PR DESCRIPTION
Fix #1190

Let the shape of `t` be of the form `(S0, S1, ..., Sn)`, then accepted shapes of `x` is of the form `(S0, C, S1, ..., Sn[, 1, 1, ..., 1])` where `n >= 0` and the length of 1's is more than or equals to 0. This condition includes the previous condition. And it also supports the condition of `SoftMaxCrossEntropy`.

See the test cases for the combination of shapes accepted.
