### PR TITLE
Fix check_gradient bug which ocurrs when a function to test returns multiple outputs

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -1,7 +1,7 @@
 import numpy
 
 from chainer import cuda
-from chainer import function
+from chainer.functions.math import identity
 from chainer import utils
 from chainer import variable
 
@@ -188,14 +188,6 @@ def check_backward(func, x_data, y_grad, params=(),
     See:
        :func:`numerical_grad`
     """
-    class Ident(function.Function):
-
-        def forward(self, inputs):
-            return inputs
-
-        def backward(self, inputs, grads):
-            return grads
-
     x_data = _as_tuple(x_data)
     if y_grad is not None:
         y_grad = _as_tuple(y_grad)
@@ -210,7 +202,7 @@ def check_backward(func, x_data, y_grad, params=(),
     # To do so we need to insert a dummy function `Ident` to the
     # computational graph.
     # Note that `func` may not be a `Function` object.
-    y = Ident()(*y)
+    y = identity.Identity()(*y)
     y = _as_tuple(y)
 
     if y_grad is not None:

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -3,6 +3,7 @@ import unittest
 import numpy
 import six
 
+import chainer
 from chainer import cuda
 from chainer import gradient_check
 from chainer import testing
@@ -312,6 +313,31 @@ class AssertAllCloseTest2(unittest.TestCase):
     @attr.gpu
     def test_rtol_gpu(self):
         self.check_rtol(cuda.to_gpu(self.x), cuda.to_gpu(self.y))
+
+
+class Ident(chainer.Function):
+
+    def forward(self, inputs):
+        return inputs
+
+    def backward(self, inputs, grads):
+        return grads
+
+
+class TestCheckBackward(unittest.TestCase):
+
+    def test_multiple_output(self):
+        x1 = numpy.array([1], dtype='f')
+        x2 = numpy.array([1], dtype='f')
+        g1 = numpy.array([1], dtype='f')
+        g2 = numpy.array([1], dtype='f')
+
+        def f(x, y):
+            s, t = Ident()(x, y)
+            u = Ident()(t)
+            return s, u
+
+        gradient_check.check_backward(f, (x1, x2), (g1, g2))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
In `check_backward`, we call `Variable.backward` method with the first `Variable` object of return value. It calls backward method of a creator `Function` of the first `Variable`. When a function to test is not a `Function` object but a callable object, all returned `Variable`s of the function may has different creator `Function`s. In this case, `backward` methods of other creators of `Variable`s are not called.
To fix it I add a dummy function and insert it to a computational graph.