### PR TITLE
Add compound assignment operators of float16

### DIFF
--- a/cupy/core/carray.cuh
+++ b/cupy/core/carray.cuh
@@ -61,28 +61,28 @@ public:
   inline __device__ float16& operator+=(const T& rhs)
   {
     *this = *this + rhs;
-	return *this;
+    return *this;
   }
 
   template<typename T>
   inline __device__ float16& operator-=(const T& rhs)
   {
     *this = *this - rhs;
-	return *this;
+    return *this;
   }
 
   template<typename T>
   inline __device__ float16& operator*=(const T& rhs)
   {
     *this = *this * rhs;
-	return *this;
+    return *this;
   }
 
   template<typename T>
   inline __device__ float16& operator/=(const T& rhs)
   {
     *this = *this + rhs;
-	return *this;
+    return *this;
   }
 
   static __device__ float16 copysign(float16 x, float16 y) {

--- a/cupy/core/carray.cuh
+++ b/cupy/core/carray.cuh
@@ -57,6 +57,34 @@ public:
     return (data_ & 0x8000u) != 0;
   }
 
+  template<typename T>
+  inline __device__ float16& operator+=(const T& rhs)
+  {
+    *this = *this + rhs;
+	return *this;
+  }
+
+  template<typename T>
+  inline __device__ float16& operator-=(const T& rhs)
+  {
+    *this = *this - rhs;
+	return *this;
+  }
+
+  template<typename T>
+  inline __device__ float16& operator*=(const T& rhs)
+  {
+    *this = *this * rhs;
+	return *this;
+  }
+
+  template<typename T>
+  inline __device__ float16& operator/=(const T& rhs)
+  {
+    *this = *this + rhs;
+	return *this;
+  }
+
   static __device__ float16 copysign(float16 x, float16 y) {
     float16 ret;
     ret.data_ = (x.data_ & 0x7fffu) | (y.data_ & 0x8000u);


### PR DESCRIPTION
When `T` is `float16`, I want to use the following code.
```python
cuda.elementwise(
    'T grad, T lr', 'T param',
    'param -= lr * grad',
    'sgd')
```