### PR TITLE
-rpath option for Mac OS X

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -128,6 +128,9 @@ def make_extensions(options, compiler):
         x for x in settings['library_dirs'] if path.exists(x)]
     if sys.platform != 'win32':
         settings['runtime_library_dirs'] = settings['library_dirs']
+    if sys.platform == 'darwin':
+        settings.setdefault('extra_link_args', []).append(
+            '-Wl,' + ','.join('-rpath,' + path for path in settings['library_dirs']))
 
     if options['linetrace']:
         settings['define_macros'].append(('CYTHON_TRACE', '1'))

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -129,8 +129,12 @@ def make_extensions(options, compiler):
     if sys.platform != 'win32':
         settings['runtime_library_dirs'] = settings['library_dirs']
     if sys.platform == 'darwin':
-        settings.setdefault('extra_link_args', []).append(
-            '-Wl,' + ','.join('-rpath,' + path for path in settings['library_dirs']))
+        args = settings.setdefault('extra_link_args', [])
+        args.append(
+            '-Wl,' + ','.join('-rpath,' + path
+                              for path in settings['library_dirs']))
+        # -rpath is only supported when targetting Mac OS X 10.5 or later
+        args.append('-mmacosx-version-min=10.5')
 
     if options['linetrace']:
         settings['define_macros'].append(('CYTHON_TRACE', '1'))


### PR DESCRIPTION
Add `-rpath` option for El-capitan.
Original work is #1153. Thank you @kcarnold !