### PR TITLE
Define cudaOutputMode_t to cupy_cuda.h

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -537,9 +537,11 @@ int curandGeneratePoisson(
 // cuda_profiler_api.h
 ///////////////////////////////////////////////////////////////////////////////
 
+typedef int cudaOutputMode_t;
+
 int cudaProfilerInitialize(const char *configFile, 
                            const char *outputFile, 
-                           int outputMode) {
+                           cudaOutputMode_t outputMode) {
   return 0;
 }
 


### PR DESCRIPTION
Lack of `cudaOutputMode_t` definition in `cupy_cuda.h` caused build failure of Read the Docs [Detail](https://readthedocs.org/projects/chainer/builds/4042871/).

I confirmed this PR makes the build successful [Detail](https://readthedocs.org/projects/chainer/builds/4049637/).