### PR TITLE
Fix checking shape in BatchNormalizationFunction

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -18,9 +18,11 @@ class BatchNormalizationFunction(function.Function):
                 '%s == %s' % (in_types.size(), n_in))
 
         x_type, gamma_type, beta_type = in_types[:3]
+        M = gamma_type.ndim.eval()
         type_check.expect(
             x_type.dtype.kind == 'f',
             x_type.ndim >= gamma_type.ndim + 1,
+            x_type.shape[1:1 + M] == gamma_type.shape,
             # TODO(beam2d): Check shape
             gamma_type.dtype == x_type.dtype,
             beta_type.dtype == x_type.dtype,

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -245,11 +245,13 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
         self.check_backward(x, gy)
 
 
+@testing.parameterize(*testing.product({
+    'size': [3, (2, 3)],
+}))
 class TestInitialize(unittest.TestCase):
 
     def setUp(self):
         self.decay = 0.9
-        self.size = 3
         self.initial_gamma = numpy.random.uniform(-1, 1, self.size)
         self.initial_gamma = self.initial_gamma.astype(numpy.float32)
         self.initial_beta = numpy.random.uniform(-1, 1, self.size)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -289,22 +289,30 @@ class TestDefaultInitializer(unittest.TestCase):
         testing.assert_allclose(numpy.zeros(self.size), self.link.beta.data)
 
 
+@testing.parameterize(*testing.product({
+    'shape': [(2, 4), (2, 5, 3, 4)],
+}))
 class TestInvalidInput(unittest.TestCase):
 
     def setUp(self):
         self.link = links.BatchNormalization(3)
 
-    def test_invalid_initialize(self):
-        with self.assertRaises(TypeError):
-            self.link = links.BatchNormalization({})
-
-    def test_invalid_shape(self):
-        with self.assertRaises(type_check.InvalidType):
-            self.link(chainer.Variable(numpy.zeros((2, 5, 3, 4), dtype='f')))
-
     def test_invalid_shape_cpu(self):
         with self.assertRaises(type_check.InvalidType):
-            self.link(chainer.Variable(numpy.zeros((2, 4), dtype='f')))
+            self.link(chainer.Variable(numpy.zeros(self.shape, dtype='f')))
+
+    @attr.gpu
+    def test_invalid_shape_gpu(self):
+        self.link.to_gpu()
+        with self.assertRaises(type_check.InvalidType):
+            self.link(chainer.Variable(cuda.cupy.zeros(self.shape, dtype='f')))
+
+
+class TestInvalidInitialize(unittest.TestCase):
+
+    def test_invalid_type(self):
+        with self.assertRaises(TypeError):
+            self.link = links.BatchNormalization({})
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -10,6 +10,7 @@ from chainer import links
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
+from chainer.utils import type_check
 
 
 def _batch_normalization(expander, gamma, beta, x, mean, var, eps, test):
@@ -286,6 +287,24 @@ class TestDefaultInitializer(unittest.TestCase):
         self.link.to_gpu()
         testing.assert_allclose(numpy.ones(self.size), self.link.gamma.data)
         testing.assert_allclose(numpy.zeros(self.size), self.link.beta.data)
+
+
+class TestInvalidInput(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.BatchNormalization(3)
+
+    def test_invalid_initialize(self):
+        with self.assertRaises(TypeError):
+            self.link = links.BatchNormalization({})
+
+    def test_invalid_shape(self):
+        with self.assertRaises(type_check.InvalidType):
+            self.link(chainer.Variable(numpy.zeros((2, 5, 3, 4), dtype='f')))
+
+    def test_invalid_shape_cpu(self):
+        with self.assertRaises(type_check.InvalidType):
+            self.link(chainer.Variable(numpy.zeros((2, 4), dtype='f')))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Type checking is loose.
```
In [1]: import numpy

In [2]: import chainer

In [3]: bn0 = chainer.links.BatchNormalization(64)

In [4]: bn0(chainer.Variable(numpy.zeros((1,100,1,1),dtype='f')))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-ddda6c9bb1a9> in <module>()
----> 1 bn0(chainer.Variable(numpy.zeros((1,100,1,1),dtype='f')))

/home/okuta/env/chainer/chainer/chainer/links/normalization/batch_normalization.pyc in __call__(self, x, test, finetune)
     92         if use_batch_mean:
     93             func = batch_normalization.BatchNormalizationFunction(self.eps)
---> 94             ret = func(x, self.gamma, self.beta)
     95
     96             if finetune:

/home/okuta/env/chainer/chainer/chainer/function.pyc in __call__(self, *inputs)
    121         # Forward prop
    122         with cuda.get_device(*in_data):
--> 123             outputs = self.forward(in_data)
    124             assert type(outputs) == tuple
    125         for hook in six.itervalues(hooks):

/home/okuta/env/chainer/chainer/chainer/functions/normalization/batch_normalization.pyc in forward(self, inputs)
     62             x_mu = x - mean[expander]
     63             self.x_hat = x_mu / self.std[expander]
---> 64             y = gamma * self.x_hat
     65             y += beta
     66         else:

ValueError: operands could not be broadcast together with shapes (1,64,1,1) (1,100,1,1)
```