### PR TITLE
gradient_check.check_backward supports dtype option

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -257,7 +257,7 @@ def check_backward(func, x_data, y_grad, params=(),
         if dtype is None:
             assert gx.dtype == x.grad.dtype
         else:
-            assert gx.dtype == dtype
+            assert gx.dtype.kind == 'f' and gx.dtype == dtype
 
     for p in params:
         gp, = numerical_grad(f, (p.data,), y_grad, eps=eps)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -93,7 +93,7 @@ def _as_tuple(x):
 
 
 def check_backward(func, x_data, y_grad, params=(),
-                   eps=1e-3, atol=1e-5, rtol=1e-4, no_grads=None):
+                   eps=1e-3, atol=1e-5, rtol=1e-4, no_grads=None, dtype=None):
     """Test backward procedure of a given function.
 
     This function automatically check backward-process of given function.
@@ -186,6 +186,8 @@ def check_backward(func, x_data, y_grad, params=(),
             :func:`chainer.testing.assert_allclose`.
         no_grads (list of bool): Flag to skip variable for gradient assertion.
             It should be same length as ``x_data``.
+        dtype (~numpy.dtype): `x_data` and `y_grad` are casted to this dtype
+            when calculating numerical gradients.
 
     See:
        :func:`numerical_grad`
@@ -211,7 +213,7 @@ def check_backward(func, x_data, y_grad, params=(),
         if len(y) != len(y_grad):
             raise ValueError(
                 '`y_grad` must have the same length of output values')
-        for iy, igy in zip(y, y_grad):
+        for iy, igy in six.moves.zip(y, y_grad):
             iy.grad = igy
     else:
         if len(y) != 1:
@@ -224,8 +226,16 @@ def check_backward(func, x_data, y_grad, params=(),
     # `Variable.backward` method calls `Function.backward` of its creator.
     y[0].backward()
 
+    if dtype is None:
+        cxs = [variable.Variable(x) for x in x_data]
+    else:
+        if len(params) > 0:
+            raise ValueError('`dtype` is available only if `params` is empty')
+        cxs = [variable.Variable(x.astype(dtype) if x.dtype.kind == 'f' else x)
+               for x in x_data]
+
     def f():
-        ys = func(*xs)
+        ys = func(*cxs)
         ys = _as_tuple(ys)
         return tuple(y.data for y in ys)
 
@@ -235,13 +245,16 @@ def check_backward(func, x_data, y_grad, params=(),
         if len(no_grads) != len(xs):
             raise ValueError(
                 'Length of no_grads param and xs should be same.')
-    for skip, x in six.moves.zip(no_grads, xs):
+    for skip, x, cx in six.moves.zip(no_grads, xs, cxs):
         if skip:
             assert x.grad is None
             continue
-        gx, = numerical_grad(f, (x.data,), y_grad, eps=eps)
+        gx, = numerical_grad(f, (cx.data,), y_grad, eps=eps)
         testing.assert_allclose(gx, x.grad, atol=atol, rtol=rtol)
-        assert gx.dtype is x.grad.dtype
+        if dtype is None:
+            assert gx.dtype == x.grad.dtype
+        else:
+            assert gx.dtype == dtype
 
     for p in params:
         gp, = numerical_grad(f, (p.data,), y_grad, eps=eps)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -26,9 +26,7 @@ class TestClippedReLU(unittest.TestCase):
 
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.z = 0.75
-        self.check_backward_options = {}
-        if self.dtype == numpy.float16:
-            self.check_backward_options = {'eps': 2.0 ** -8}
+        self.check_backward_options = {'dtype': numpy.float64}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
@@ -27,11 +27,11 @@ class TestELU(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.alpha = random.random()
         self.check_forward_options = {}
-        self.check_backward_options = {}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'eps': 2.0 ** -5, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_hard_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_hard_sigmoid.py
@@ -26,11 +26,11 @@ class TestHardSigmoid(unittest.TestCase):
                 self.x[i] = 0.0
 
         self.check_forward_option = {}
-        self.check_backward_option = {}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype is numpy.float16:
             self.check_forward_option = {'atol': 1e-3, 'rtol': 1e-3}
-            self.check_backward_option = \
-                {'eps': 2.0 ** -3, 'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
@@ -52,7 +52,7 @@ class TestHardSigmoid(unittest.TestCase):
     def check_backward(self, x_data, grad):
         gradient_check.check_backward(
             functions.HardSigmoid(), x_data, grad,
-            **self.check_backward_option)
+            **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
@@ -27,11 +27,11 @@ class TestLeakyReLU(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.slope = random.random()
         self.check_forward_options = {}
-        self.check_backward_options = {}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
             self.check_backward_options = {
-                'eps': 2.0 ** -5, 'atol': 5e-4, 'rtol': 5e-3}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -28,11 +28,11 @@ class TestLogSoftmax(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, self.x.shape).astype(self.dtype)
 
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2, 'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-3, 'rtol': 5e-2}
             self.check_backward_options = {
-                'eps': 0.125, 'atol': 5e-3, 'rtol': 5e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_lstm.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_lstm.py
@@ -28,11 +28,11 @@ class TestLSTM(unittest.TestCase):
         self.gh = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(self.dtype)
 
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
             self.check_backward_options = {
-                'eps': 0.125, 'atol': 5e-3, 'rtol': 5e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def flat(self):
         self.c_prev = self.c_prev[:, :, 0].copy()

--- a/tests/chainer_tests/functions_tests/activation_tests/test_prelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_prelu.py
@@ -29,7 +29,7 @@ class TestPReLU(unittest.TestCase):
         self.check_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
-                'eps': 2.0 ** -6, 'atol': 5e-3, 'rtol': 5e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, W_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -27,7 +27,7 @@ class TestReLU(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.check_backward_options = {}
         if self.dtype == numpy.float16:
-            self.check_backward_options = {'eps': 2.0 ** -10}
+            self.check_backward_options = {'dtype': numpy.float64}
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -26,7 +26,7 @@ class TestSigmoid(unittest.TestCase):
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
             self.check_backward_options = {
-                'eps': 2 ** -5, 'atol': 5e-4, 'rtol': 5e-3}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_slstm.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_slstm.py
@@ -32,11 +32,11 @@ class TestSLSTM(unittest.TestCase):
         self.gh = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(self.dtype)
 
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'eps': 2 ** -4, 'atol': 1e-2, 'rtol': 1e-1}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def flat(self):
         self.c_prev1 = self.c_prev1[:, :, 0].copy()

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -28,11 +28,11 @@ class TestSoftmax(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, self.x.shape).astype(self.dtype)
 
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
             self.check_backward_options = {
-                'eps': 2.0 ** -4, 'atol': 5e-3, 'rtol': 5e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
@@ -26,7 +26,7 @@ class TestSoftplus(unittest.TestCase):
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'eps': 2.0 ** -5, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -24,7 +24,7 @@ class TestTanh(unittest.TestCase):
         self.check_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
-                'eps': 2.0 ** -5, 'atol': 5e-4, 'rtol': 5e-3}
+                'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
@@ -40,10 +40,10 @@ class TestBroadcast(unittest.TestCase):
         self.grads = [uniform(0, 1, self.out_shape).astype(self.dtype)
                       for _ in range(len(self.in_shapes))]
 
-        self.check_backward_options = {}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
-                'eps': 2 ** -5, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, data):
         xs = [chainer.Variable(x) for x in data]

--- a/tests/chainer_tests/functions_tests/array_tests/test_where.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_where.py
@@ -25,9 +25,7 @@ class TestWhere(unittest.TestCase):
             numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.g_data = \
             numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.check_backward_options = {}
-        if self.dtype == numpy.float16:
-            self.check_backward_options = {'atol': 0.05, 'rtol': 0.05}
+        self.check_backward_options = {'dtype': numpy.float64}
 
     def check_forward(self, c_data, x_data, y_data):
         c = chainer.Variable(c_data)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -43,15 +43,11 @@ class TestConvolution2DFunction(unittest.TestCase):
             self.gy = numpy.random.uniform(
                 -1, 1, (2, 2, 2, 2)).astype(self.x_dtype)
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2}
-        if self.x_dtype == numpy.float16:
+        self.check_backward_options = {'dtype': numpy.float64}
+        if self.x_dtype == numpy.float16 or self.W_dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1}
-        elif self.W_dtype == numpy.float16:
-            self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
-            self.check_backward_options = {
-                'eps': 2 ** -3, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     @attr.cudnn
     def test_forward_consistency(self, nobias=False):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -58,15 +58,14 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         self.gy = numpy.random.uniform(
             -1, 1, (N, self.out_channels, outh, outw)).astype(self.x_dtype)
         self.test_forward_options = {}
-        self.check_backward_options = {
-            'eps': 1e-2, 'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.x_dtype == numpy.float16:
             self.test_forward_options = {'atol': 5e-3, 'rtol': 5e-2}
             self.check_backward_options = {
-                'eps': 2**-3, 'atol': 1e-2, 'rtol': 1e-1}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
         elif self.W_dtype == numpy.float16:
             self.check_backward_options = {
-                'eps': 2**-3, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     @attr.cudnn
     def test_forward_consistency(self):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
@@ -31,9 +31,11 @@ class TestNonparameterizedLinear(unittest.TestCase):
         self.check_backward_options = {}
         if self.x_dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_options = {'atol': 5e-2, 'rtol': 1e-1}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
         elif self.W_dtype == numpy.float16:
-            self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, W_data, b_data, y_expect):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -37,10 +37,11 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
                     len(self.ignore_index) <= self.t.ndim):
                 self.t[self.ignore_index] = -1
         self.check_forward_options = {}
-        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
-            self.check_backward_options = {'atol': 5e-2, 'rtol': 1e-1}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, t_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/math_tests/test_linear_interpolate.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_linear_interpolate.py
@@ -24,11 +24,11 @@ class TestLinearInterpolate(unittest.TestCase):
         self.g = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
 
         self.check_forward_options = {}
-        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-4}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
             self.check_backward_options = {
-                'eps': 0.3, 'atol': 1e-3, 'rtol': 1e-3}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, p_data, x_data, y_data):
         p = chainer.Variable(p_data)

--- a/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
@@ -30,11 +30,11 @@ class TestMaximum(unittest.TestCase):
         self.y_expected = numpy.maximum(self.x1, self.x2)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
             self.check_backward_options = {
-                'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x1_data, x2_data, y_expected):
         x1 = chainer.Variable(x1_data)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -41,13 +41,12 @@ class TestBatchNormalization(unittest.TestCase):
         self.args = [self.x, self.gamma, self.beta]
         self.mean = self.x.mean(axis=self.aggr_axes)
         self.var = self.x.var(axis=self.aggr_axes) + self.eps
-        self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_optionss = {
-            'eps': 1e-2, 'atol': 1e-4, 'rtol': 1e-3}
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
-            self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_optionss = {
-                'eps': 2 ** -3, 'atol': 5e-2, 'rtol': 1e-1}
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, args):
         y = functions.batch_normalization(
@@ -58,7 +57,7 @@ class TestBatchNormalization(unittest.TestCase):
             self.expander, self.gamma, self.beta, self.x, self.mean, self.var)
 
         testing.assert_allclose(
-            y_expect, y.data, **self.check_forward_optionss)
+            y_expect, y.data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -72,7 +71,7 @@ class TestBatchNormalization(unittest.TestCase):
     def check_backward(self, args, y_grad):
         gradient_check.check_backward(
             batch_normalization.BatchNormalizationFunction(eps=self.eps),
-            args, y_grad, **self.check_backward_optionss)
+            args, y_grad, **self.check_backward_options)
 
     @condition.retry(10)
     def test_backward_cpu(self):
@@ -106,13 +105,12 @@ class TestFixedBatchNormalization(unittest.TestCase):
         self.var = numpy.random.uniform(
             0.5, 1, (3,)).astype(self.dtype)
         self.args = [self.x, self.gamma, self.beta, self.mean, self.var]
-        self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_optionss = {
-            'eps': 1e-2, 'atol': 1e-4, 'rtol': 1e-3}
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
-            self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_optionss = {
-                'eps': 2 ** -5, 'atol': 1e-2, 'rtol': 1e-1}
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, args):
         y = functions.fixed_batch_normalization(
@@ -123,7 +121,7 @@ class TestFixedBatchNormalization(unittest.TestCase):
             self.expander, self.gamma, self.beta, self.x, self.mean, self.var)
 
         testing.assert_allclose(
-            y_expect, y.data, **self.check_forward_optionss)
+            y_expect, y.data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -137,7 +135,7 @@ class TestFixedBatchNormalization(unittest.TestCase):
     def check_backward(self, args, y_grad):
         gradient_check.check_backward(
             batch_normalization.BatchNormalizationFunction(eps=self.eps),
-            args, y_grad, **self.check_backward_optionss)
+            args, y_grad, **self.check_backward_options)
 
     @condition.retry(10)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -24,11 +24,11 @@ class TestAveragePooling2D(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1,
                                        (2, 3, 2, 2)).astype(self.dtype)
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'eps': 1e-1, 'atol': 5e-3, 'rtol': 5e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -38,10 +38,10 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
             (self.n, self.c, self.h, self.w)).astype(self.dtype)
         self.gy = numpy.random.uniform(
             -1, 1, (self.n, self.output_dim, 1, 1)).astype(self.dtype)
-        self.check_backward_options = {'eps': 2.0 ** -10}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
-                'eps': 2.0 ** -10, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
@@ -49,7 +49,8 @@ class TestUnpooling2D(unittest.TestCase):
             -1, 1, (self.N, self.n_channels, outh, outw)).astype(self.dtype)
         self.check_backward_options = {}
         if self.dtype == numpy.float16:
-            self.check_backward_options = {'atol': 0.05, 'rtol': 0.05}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -324,6 +324,9 @@ class Ident(chainer.Function):
         return grads
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [None, numpy.float32, numpy.float64],
+}))
 class TestCheckBackward(unittest.TestCase):
 
     def test_multiple_output(self):
@@ -337,7 +340,7 @@ class TestCheckBackward(unittest.TestCase):
             u = Ident()(t)
             return s, u
 
-        gradient_check.check_backward(f, (x1, x2), (g1, g2))
+        gradient_check.check_backward(f, (x1, x2), (g1, g2), dtype=self.dtype)
 
     def test_no_grads_for_not_float(self):
         x1 = numpy.array([1], dtype='f')

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -324,6 +324,7 @@ class Ident(chainer.Function):
         return grads
 
 
+# numpy.float16 is not tested because it is low precision.
 @testing.parameterize(*testing.product({
     'dtype': [None, numpy.float32, numpy.float64],
 }))


### PR DESCRIPTION
`gradient_check.check_backward` is poor accuracy for `numpy.float16` array.
I add `dtype` option.
`check_backward` casts input arrays.
