### PR TITLE
Update release cycle in the documents

### DIFF
--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -52,7 +52,6 @@ The actual dropping should be done through the following steps:
 - At the major version announced in the above update, drop the API.
 
 Consequently, it takes at least two minor versions to drop any APIs after the first deprecation.
-Since each minor update is made for every six weeks, this dropping procedure takes at least 12 weeks (~ 3 months).
 
 API Changes and Its Preparation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -33,9 +33,9 @@ This classification is based on following criteria:
 
 The release classification is reflected into the version number x.y.z, where x, y, and z corresponds to major, minor, and revision updates, respectively.
 
-We sets milestones for some future releases.
-A milestone for a revision release is set right after the last release.
-On the other hand, a milestone for a minor or major release is set four weeks prior to its due.
+We set a milestone for an upcoming release.
+The milestone is of name 'vX.Y.Z', where the version number represents a revision release at the outset.
+If at least one *feature* PR is merged in the period, we rename the milestone to represent a minor release (see the next section for the PR types).
 
 See also :doc:`compatibility`.
 


### PR DESCRIPTION
As I noted in the release note of v1.9.1, we have decided to change the release cycle.
From the next release, we can include any feature updates that do not break the backward compatibility to any biweekly releases (i.e., we can made minor releases more frequently than once per six weeks). The versioning policy is kept as is.

I reflected this change to the documentation in this PR.