### PR TITLE
fix bug in roi pooling forwarding with cpu

### DIFF
--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -185,7 +185,8 @@ class ROIPooling2D(function.Function):
 
     def backward_cpu(self, inputs, gy):
         bottom_data, bottom_rois = inputs
-        n_rois, channels, height, width = bottom_data.shape
+        channels, height, width = bottom_data.shape[1:]
+        n_rois = bottom_rois.shape[0]
         bottom_delta = numpy.zeros_like(bottom_data, dtype=numpy.float32)
 
         for i_roi in six.moves.range(n_rois):

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -68,7 +68,8 @@ class ROIPooling2D(function.Function):
 
     def forward_cpu(self, inputs):
         bottom_data, bottom_rois = inputs
-        n_rois, channels, height, width = bottom_data.shape
+        channels, height, width = bottom_data.shape[1:]
+        n_rois = bottom_rois.shape[0]
         top_data = numpy.empty((n_rois, channels, self.outh, self.outw),
                                dtype=numpy.float32)
         self.argmax_data = numpy.empty_like(top_data).astype(numpy.int32)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
@@ -14,7 +14,7 @@ from chainer.testing import condition
 class TestROIPooling2D(unittest.TestCase):
 
     def setUp(self):
-        N = 4
+        N = 3
         n_channels = 3
         self.x = numpy.arange(
             N * n_channels * 12 * 8,


### PR DESCRIPTION
I implemented fast r-cnn https://github.com/apple2373/chainer-simple-fast-rnn, and realized roi pooling with cpu does not work. It always outputs only one roi when forwarding. I just copied two lines from GPU implementation. Also I am not sure backward function is also wrong or not because I only use forwarding now. 