### PR TITLE
Add evaluator argument to Classifier

### DIFF
--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -13,10 +13,12 @@ class Classifier(link.Chain):
     Args:
         predictor (~chainer.Link): Predictor network.
         lossfun (function): Loss function.
+        evaluator (function): Function that computes accuracy.
 
     Attributes:
         predictor (~chainer.Link): Predictor network.
         lossfun (function): Loss function.
+        evaluator (function): Function that computes accuracy.
         y (~chainer.Variable): Prediction for the last minibatch.
         loss (~chainer.Variable): Loss value for the last minibatch.
         accuracy (~chainer.Variable): Accuracy for the last minibatch.
@@ -28,9 +30,11 @@ class Classifier(link.Chain):
     compute_accuracy = True
 
     def __init__(self, predictor,
-                 lossfun=softmax_cross_entropy.softmax_cross_entropy):
+                 lossfun=softmax_cross_entropy.softmax_cross_entropy,
+                 evaluator=accuracy.accuracy):
         super(Classifier, self).__init__(predictor=predictor)
         self.lossfun = lossfun
+        self.evaluator = evaluator
         self.y = None
         self.loss = None
         self.accuracy = None
@@ -54,5 +58,5 @@ class Classifier(link.Chain):
         self.y = self.predictor(x)
         self.loss = self.lossfun(self.y, t)
         if self.compute_accuracy:
-            self.accuracy = accuracy.accuracy(self.y, t)
+            self.accuracy = self.evaluator(self.y, t)
         return self.loss

--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -13,12 +13,12 @@ class Classifier(link.Chain):
     Args:
         predictor (~chainer.Link): Predictor network.
         lossfun (function): Loss function.
-        evaluator (function): Function that computes accuracy.
+        accfun (function): Function that computes accuracy.
 
     Attributes:
         predictor (~chainer.Link): Predictor network.
         lossfun (function): Loss function.
-        evaluator (function): Function that computes accuracy.
+        accfun (function): Function that computes accuracy.
         y (~chainer.Variable): Prediction for the last minibatch.
         loss (~chainer.Variable): Loss value for the last minibatch.
         accuracy (~chainer.Variable): Accuracy for the last minibatch.
@@ -31,10 +31,10 @@ class Classifier(link.Chain):
 
     def __init__(self, predictor,
                  lossfun=softmax_cross_entropy.softmax_cross_entropy,
-                 evaluator=accuracy.accuracy):
+                 accfun=accuracy.accuracy):
         super(Classifier, self).__init__(predictor=predictor)
         self.lossfun = lossfun
-        self.evaluator = evaluator
+        self.accfun = accfun
         self.y = None
         self.loss = None
         self.accuracy = None
@@ -66,5 +66,5 @@ class Classifier(link.Chain):
         self.y = self.predictor(*x)
         self.loss = self.lossfun(self.y, t)
         if self.compute_accuracy:
-            self.accuracy = self.evaluator(self.y, t)
+            self.accuracy = self.accfun(self.y, t)
         return self.loss

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -1,0 +1,59 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import links
+from chainer.functions.evaluation import accuracy
+from chainer import testing
+from chainer.testing import attr
+
+
+class accuracy_with_ignore_label(object):
+
+    def __call__(self, y, t):
+        return accuracy.accuracy(y, t, ignore_label=1)
+
+
+@testing.parameterize(*testing.product({
+    'evaluator': [accuracy_with_ignore_label(), None],
+    'compute_accuracy': [True, False]
+}))
+class TestClassifier(unittest.TestCase):
+
+    def setUp(self):
+        predictor = links.Linear(10, 3)
+        if self.evaluator is None:
+            self.link = links.Classifier(predictor)
+        else:
+            self.link = links.Classifier(predictor, evaluator=self.evaluator)
+        self.link.compute_accuracy = self.compute_accuracy
+
+        self.x = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
+        self.t = numpy.random.randint(3, size=(5)).astype(numpy.int32)
+
+    def check_call(self):
+        xp = self.link.xp
+        x = chainer.Variable(xp.asarray(self.x))
+        t = chainer.Variable(xp.asarray(self.t))
+        loss = self.link(x, t)
+
+        self.assertTrue(hasattr(self.link, 'y'))
+        self.assertIsNotNone(self.link.y)
+
+        self.assertTrue(hasattr(self.link, 'loss'))
+        xp.testing.assert_allclose(self.link.loss.data, loss.data)
+
+        self.assertTrue(hasattr(self.link, 'accuracy'))
+        if self.compute_accuracy:
+            self.assertIsNotNone(self.link.accuracy)
+        else:
+            self.assertIsNone(self.link.accuracy)
+
+    def test_call_cpu(self):
+        self.check_call()
+
+    @attr.gpu
+    def test_call_gpu(self):
+        self.link.to_gpu()
+        self.check_call()

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -3,7 +3,6 @@ import unittest
 import numpy
 
 import chainer
-from chainer.functions.evaluation import accuracy
 from chainer import links
 from chainer import testing
 from chainer.testing import attr

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -22,18 +22,18 @@ class AccuracyWithIgnoreLabel(object):
 
 
 @testing.parameterize(*testing.product({
-    'evaluator': [AccuracyWithIgnoreLabel(), None],
+    'accfun': [AccuracyWithIgnoreLabel(), None],
     'compute_accuracy': [True, False],
     'x_num': [1, 2]
 }))
 class TestClassifier(unittest.TestCase):
 
     def setUp(self):
-        if self.evaluator is None:
+        if self.accfun is None:
             self.link = links.Classifier(chainer.Link())
         else:
             self.link = links.Classifier(chainer.Link(),
-                                         evaluator=self.evaluator)
+                                         accfun=self.accfun)
         self.link.compute_accuracy = self.compute_accuracy
 
         self.x = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -11,14 +11,18 @@ from chainer import testing
 from chainer.testing import attr
 
 
-class accuracy_with_ignore_label(object):
+# testing.parameterize takes a list of dictionaries.
+# Currently, we cannot set a function to the value of the dictionaries.
+# As a workaround, we wrap the function and invoke it in __call__ method.
+# See issue #1337 for detail.
+class AccuracyWithIgnoreLabel(object):
 
     def __call__(self, y, t):
         return functions.accuracy(y, t, ignore_label=1)
 
 
 @testing.parameterize(*testing.product({
-    'evaluator': [accuracy_with_ignore_label(), None],
+    'evaluator': [AccuracyWithIgnoreLabel(), None],
     'compute_accuracy': [True, False],
     'x_num': [1, 2]
 }))

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -3,8 +3,8 @@ import unittest
 import numpy
 
 import chainer
-from chainer import links
 from chainer.functions.evaluation import accuracy
+from chainer import links
 from chainer import testing
 from chainer.testing import attr
 

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -57,3 +57,6 @@ class TestClassifier(unittest.TestCase):
     def test_call_gpu(self):
         self.link.to_gpu()
         self.check_call()
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -28,7 +28,8 @@ class TestClassifier(unittest.TestCase):
         if self.evaluator is None:
             self.link = links.Classifier(chainer.Link())
         else:
-            self.link = links.Classifier(chainer.Link(), evaluator=self.evaluator)
+            self.link = links.Classifier(chainer.Link(),
+                                         evaluator=self.evaluator)
         self.link.compute_accuracy = self.compute_accuracy
 
         self.x = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -5,6 +5,7 @@ import mock
 import numpy
 
 import chainer
+from chainer import functions
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
@@ -13,7 +14,7 @@ from chainer.testing import attr
 class accuracy_with_ignore_label(object):
 
     def __call__(self, y, t):
-        return accuracy.accuracy(y, t, ignore_label=1)
+        return functions.accuracy(y, t, ignore_label=1)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Current `L.Classifier` cannot change evaluator that calculates accuracy from default `Accuracy` Function with default argument. But we have other kind of accuracy such as `binary_accuracy`. Also, `Accuracy` Function itself has an argument `ignore_label`. This PR add the argument `evaluator` to `Classifier` and make the evaluator pluggable.