### PR TITLE
Avoid division by zero

### DIFF
--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -52,6 +52,8 @@ class Contrastive(function.Function):
         y = xp.repeat(y[:, None], x_dim, axis=1)
         alpha = gy[0] / y.shape[0]
         dist = xp.repeat(self.dist[:, None], x_dim, axis=1)
+        # avoid division by zero
+        dist = xp.maximum(dist, 1e-8)
         # similar pair
         gx0 = alpha * y * self.diff
         # dissimilar pair

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -82,18 +82,12 @@ class TestContrastive(unittest.TestCase):
 
     @condition.retry(3)
     def test_backward_zero_dist_cpu(self):
-        x0 = self.x0
-        x1 = self.x0
-        self.dist = xp.sqrt(numpy.sum((x0 - x1) ** 2, axis=1))
-        self.check_backward(x0, x1, self.t)
+        self.check_backward(self.x0, self.x0, self.t)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_zero_dist_gpu_no_cudnn(self):
-        x0 = self.x0
-        x1 = self.x0
-        self.dist = cuda.to_gpu(numpy.sqrt(numpy.sum((x0 - x1) ** 2, axis=1)))
-        self.check_backward(cuda.to_gpu(x0), cuda.to_gpu(x1),
+        self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x0),
                             cuda.to_gpu(self.t))
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -80,5 +80,20 @@ class TestContrastive(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1),
                             cuda.to_gpu(self.t))
 
+    @condition.retry(3)
+    def test_backward_zero_dist_cpu(self):
+        x0 = self.x0
+        x1 = self.x0
+        self.dist = xp.sqrt(numpy.sum((x0 - x1) ** 2, axis=1))
+        self.check_backward(x0, x1, self.t)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_zero_dist_gpu_no_cudnn(self):
+        x0 = self.x0
+        x1 = self.x0
+        self.dist = cuda.to_gpu(numpy.sqrt(numpy.sum((x0 - x1) ** 2, axis=1)))
+        self.check_backward(cuda.to_gpu(x0), cuda.to_gpu(x1),
+                            cuda.to_gpu(self.t))
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
In Contrastive.backward(), division by zero occurs when ```dist``` is equal to zero.

```
gx0 += alpha * (1 - y) * mdist_p * mdist * -(self.diff / dist)
```

It causes that gradient value is nan.

Please see my proposed modification.