### PR TITLE
Suppress warnings in test

### DIFF
--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -40,13 +40,15 @@ class TestCuda(unittest.TestCase):
     def test_empy_unavailable(self):
         if not cuda.available:
             with self.assertRaises(RuntimeError):
-                cuda.empty(())
+                with warnings.catch_warnings():
+                    cuda.empty(())
 
     def test_empy_like_unavailable(self):
         x = numpy.array([1])
         if not cuda.available:
             with self.assertRaises(RuntimeError):
-                cuda.empty_like(x)
+                with warnings.catch_warnings():
+                    cuda.empty_like(x)
 
 
 @testing.parameterize(


### PR DESCRIPTION
I appended `catch_warnings` to suppress warnings in traivs.