### PR TITLE
Fix coding style using autopep8

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [pep8]
 exclude=caffe_pb*
-diff=True 
+diff=True

--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[pep8]
+exclude=caffe_pb*
+diff=True 

--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [pep8]
-exclude=caffe_pb*
+exclude=caffe_pb*,.eggs,*.egg,build
 diff=True

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,13 @@ install:
   - pip install dist/*.tar.gz
   - pip install h5py
   - pip install nose hacking mock
+  - pip install autopep8
 
 script:
   - flake8
   - flake8 --config=.flake8.cython
+  - autopep8 -r . --global-config .pep8 | tee check_autopep8
+  - test ! -s check_autopep8
   - PYTHONWARNINGS='module::DeprecationWarning' nosetests -a '!gpu' --with-doctest tests/install_tests
   - cd tests
   - PYTHONWARNINGS='module::DeprecationWarning' nosetests -a '!gpu' --with-doctest chainer_tests

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -105,6 +105,7 @@ class DebugMode(object):
     Args:
         debug (bool): Debug mode used in the context.
     """
+
     def __init__(self, debug):
         self._debug = debug
 

--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -11,6 +11,7 @@ class DotNode(object):
     with some utilities for dot language.
 
     """
+
     def __init__(self, node, attribute=None):
         """Initializes DotNode.
 
@@ -53,6 +54,7 @@ class ComputationalGraph(object):
       We assume that the computational graph is directed and acyclic.
 
     """
+
     def __init__(self, nodes, edges, variable_style=None, function_style=None,
                  rankdir='TB'):
         """Initializes computational graph.

--- a/chainer/dataset/dataset_mixin.py
+++ b/chainer/dataset/dataset_mixin.py
@@ -11,6 +11,7 @@ class DatasetMixin(object):
     :meth:`__len__` operator explicitly.
 
     """
+
     def __getitem__(self, index):
         """Returns an example or a sequence of examples.
 

--- a/chainer/dataset/iterator.py
+++ b/chainer/dataset/iterator.py
@@ -29,6 +29,7 @@ class Iterator(object):
     iteration.
 
     """
+
     def __iter__(self):
         """Returns self."""
         return self

--- a/chainer/datasets/dict_dataset.py
+++ b/chainer/datasets/dict_dataset.py
@@ -13,6 +13,7 @@ class DictDataset(object):
             example. All datasets must have the same length.
 
     """
+
     def __init__(self, **datasets):
         if not datasets:
             raise ValueError('no datasets are given')

--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -43,6 +43,7 @@ class ImageDataset(dataset_mixin.DatasetMixin):
         dtype: Data type of resulting image arrays.
 
     """
+
     def __init__(self, paths, root='.', dtype=numpy.float32):
         _check_pillow_availability()
         if isinstance(paths, six.string_types):
@@ -95,6 +96,7 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
         label_dtype: Data type of the labels.
 
     """
+
     def __init__(self, pairs, root='.', dtype=numpy.float32,
                  label_dtype=numpy.int32):
         _check_pillow_availability()

--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -43,6 +43,7 @@ class SubDataset(dataset_mixin.DatasetMixin):
             If this is ``None``, then the ascending order of indexes is used.
 
     """
+
     def __init__(self, dataset, start, finish, order=None):
         if start < 0 or finish > len(dataset):
             raise ValueError('subset overruns the base dataset.')

--- a/chainer/datasets/tuple_dataset.py
+++ b/chainer/datasets/tuple_dataset.py
@@ -14,6 +14,7 @@ class TupleDataset(object):
             length.
 
     """
+
     def __init__(self, *datasets):
         if not datasets:
             raise ValueError('no datasets are given')

--- a/chainer/function_set.py
+++ b/chainer/function_set.py
@@ -21,6 +21,7 @@ class FunctionSet(link.Chain):
           been replaced by :class:`~chainer.Link` and :class:`~chainer.Chain`.
 
     """
+
     def __init__(self, **links):
         super(FunctionSet, self).__init__(**links)
         warnings.warn('FunctionSet is deprecated. Use Chain instead.',

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -44,6 +44,7 @@ class LSTM(function.Function):
     state. x must have four times channels compared to the number of units.
 
     """
+
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         c_type, x_type = in_types

--- a/chainer/functions/activation/slstm.py
+++ b/chainer/functions/activation/slstm.py
@@ -48,6 +48,7 @@ class SLSTM(function.Function):
     to the number of units.
 
     """
+
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 4)
         c1_type, c2_type, x1_type, x2_type = in_types
@@ -179,7 +180,6 @@ class SLSTM(function.Function):
 
 
 def slstm(c_prev1, c_prev2, x1, x2):
-
     """S-LSTM units as an activation function.
 
     This function implements S-LSTM unit. It is an extension of LSTM unit

--- a/chainer/functions/loss/crf1d.py
+++ b/chainer/functions/loss/crf1d.py
@@ -8,7 +8,6 @@ from chainer.functions.math import sum as _sum
 
 
 def crf1d(cost, xs, ys):
-
     """Calculates negative log-likelihood of linear-chain CRF.
 
     It takes a transition cost matrix, a sequence of costs, and a sequence of

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -102,8 +102,8 @@ class NegativeSamplingFunction(function.Function):
 
         gx = numpy.zeros_like(x)
         gW = numpy.zeros_like(W)
-        for i, (ix, k) in enumerate(six.moves.zip(x[self.ignore_mask],
-                                                  self.samples[self.ignore_mask])):
+        for i, (ix, k) in enumerate(six.moves.zip(
+                x[self.ignore_mask], self.samples[self.ignore_mask])):
             w = W[k]
             f = w.dot(ix)
 

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -72,8 +72,8 @@ class NegativeSamplingFunction(function.Function):
             wx = f;
             ''',
             'negative_sampling_wx'
-            )(W, x, self.ignore_mask[:, None], self.samples, n_in,
-              self.sample_size + 1)
+        )(W, x, self.ignore_mask[:, None], self.samples, n_in,
+          self.sample_size + 1)
 
         y = cuda.elementwise(
             'T wx, int32 c, int32 m', 'T y',
@@ -103,7 +103,7 @@ class NegativeSamplingFunction(function.Function):
         gx = numpy.zeros_like(x)
         gW = numpy.zeros_like(W)
         for i, (ix, k) in enumerate(six.moves.zip(x[self.ignore_mask],
-                                    self.samples[self.ignore_mask])):
+                                                  self.samples[self.ignore_mask])):
             w = W[k]
             f = w.dot(ix)
 
@@ -151,8 +151,8 @@ class NegativeSamplingFunction(function.Function):
             gx = w;
             ''',
             'negative_sampling_calculate_gx'
-            )(g, W, self.ignore_mask[:, None], self.samples, n_in,
-              self.sample_size + 1, gx)
+        )(g, W, self.ignore_mask[:, None], self.samples, n_in,
+          self.sample_size + 1, gx)
         gW = cupy.zeros_like(W)
         cuda.elementwise(
             'T g, raw T x, S k, bool mask, int32 c, int32 m',
@@ -166,8 +166,8 @@ class NegativeSamplingFunction(function.Function):
             }
             ''',
             'negative_sampling_calculate_gw'
-            )(g, x, self.samples, self.ignore_mask[:, None], n_in,
-              self.sample_size + 1, gW)
+        )(g, x, self.samples, self.ignore_mask[:, None], n_in,
+          self.sample_size + 1, gW)
         return gx, None, gW
 
 

--- a/chainer/functions/loss/triplet.py
+++ b/chainer/functions/loss/triplet.py
@@ -33,7 +33,7 @@ class Triplet(function.Function):
         N = anchor.shape[0]
 
         dist = xp.sum(
-            (anchor - positive)**2 - (anchor - negative)**2,
+            (anchor - positive) ** 2 - (anchor - negative) ** 2,
             axis=1) + self.margin
         self.dist_hinge = xp.maximum(dist, 0)
         loss = xp.sum(self.dist_hinge) / N

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -120,6 +120,7 @@ def _get_check_index(trans, right, row_idx=0, col_idx=1):
 
 
 class MatMul(function.Function):
+
     def __init__(self, transa=False, transb=False):
         self.transa = transa
         self.transb = transb
@@ -150,10 +151,10 @@ class MatMul(function.Function):
     def backward(self, x, gy):
         gx0 = _matmul(
             gy[0], x[1], transb=not self.transb, transout=self.transa
-            ).reshape(x[0].shape)
+        ).reshape(x[0].shape)
         gx1 = _matmul(
             x[0], gy[0], transa=not self.transa, transout=self.transb
-            ).reshape(x[1].shape)
+        ).reshape(x[1].shape)
         return gx0, gx1
 
 
@@ -179,6 +180,7 @@ def matmul(a, b, transa=False, transb=False):
 
 
 class BatchMatMul(function.Function):
+
     def __init__(self, transa=False, transb=False):
         self.transa = transa
         self.transb = transb

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -85,8 +85,8 @@ class BatchNormalizationFunction(function.Function):
                 self.running_mean = xp.array(self.running_mean)
                 self.running_var = xp.array(self.running_var)
         elif len(inputs) == 5:
-                self.fixed_mean = inputs[3]
-                self.fixed_var = inputs[4]
+            self.fixed_mean = inputs[3]
+            self.fixed_var = inputs[4]
 
         # TODO(bkvogel): Check for float16 support again in next cuDNN version.
         if x[0].dtype == numpy.float16:

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -53,7 +53,7 @@ class NormalizeL2(function.Function):
         norm = norm[:, numpy.newaxis]
 
         gx = gy * norm - (x * gy).sum(axis=1)[:, numpy.newaxis] * x / norm
-        gx = gx / norm**2
+        gx = gx / norm ** 2
 
         return gx,
 

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -235,7 +235,7 @@ def check_backward(func, x_data, y_grad, params=(),
         if len(params) > 0:
             raise ValueError('`dtype` is available only if `params` is empty')
         casted_xs = [variable.Variable(x.astype(dtype, copy=False)
-                     if x.dtype.kind == 'f' else x)
+                                       if x.dtype.kind == 'f' else x)
                      for x in x_data]
 
     def f():

--- a/chainer/initializer.py
+++ b/chainer/initializer.py
@@ -4,7 +4,6 @@ import numpy
 class Initializer(object):
 
     def __call__(self, array):
-
         """Initializes given array.
 
         This method destructively changes the value of array.

--- a/chainer/initializers/constant.py
+++ b/chainer/initializers/constant.py
@@ -47,14 +47,12 @@ class Constant(initializer.Initializer):
 
 
 def Zero():
-
     """Returns initializer that initializes array with the all-zero array."""
 
     return Constant(0.0)
 
 
 def One():
-
     """Returns initializer that initializes array with the all-one array."""
 
     return Constant(1.0)

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -31,6 +31,7 @@ class MultiprocessIterator(iterator.Iterator):
             used by default.
 
     """
+
     def __init__(self, dataset, batch_size, repeat=True, shuffle=True,
                  n_processes=None):
         self.dataset = dataset

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -29,6 +29,7 @@ class SerialIterator(iterator.Iterator):
             order of indexes.
 
     """
+
     def __init__(self, dataset, batch_size, repeat=True, shuffle=True):
         self.dataset = dataset
         self.batch_size = batch_size

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -88,6 +88,7 @@ class Link(object):
         name (str): Name of this link, given by the parent chain (if exists).
 
     """
+
     def __init__(self, **params):
         self._params = []
         self._persistent = []
@@ -470,6 +471,7 @@ class Chain(Link):
             also set to the links.
 
     """
+
     def __init__(self, **links):
         super(Chain, self).__init__()
         self._children = []
@@ -616,6 +618,7 @@ class ChainList(Link):
         links: Initial child links.
 
     """
+
     def __init__(self, *links):
         super(ChainList, self).__init__()
         self._children = []

--- a/chainer/links/activation/prelu.py
+++ b/chainer/links/activation/prelu.py
@@ -20,6 +20,7 @@ class PReLU(link.Link):
         W (~chainer.Variable): Coefficient of parametric ReLU.
 
     """
+
     def __init__(self, shape=(), init=0.25):
         super(PReLU, self).__init__(W=shape)
         self.W.data.fill(init)

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -115,6 +115,7 @@ class CaffeFunction(link.Chain):
         forwards (dict): A mapping from layer names to corresponding functions.
 
     """
+
     def __init__(self, model_path):
         if not available:
             msg = 'CaffeFunction is only supported on protobuf>=3 in Python3'
@@ -177,8 +178,8 @@ class CaffeFunction(link.Chain):
         variables = dict(inputs)
         for func_name, bottom, top in self.layers:
             if (func_name in disable or
-               func_name not in self.forwards or
-               any(blob not in variables for blob in bottom)):
+                func_name not in self.forwards or
+                    any(blob not in variables for blob in bottom)):
                 continue
 
             func = self.forwards[func_name]
@@ -228,12 +229,13 @@ class CaffeFunction(link.Chain):
         part_size = len(blobs[0].data) // param.group
         for i in six.moves.range(param.group):
             in_slice = slice(i * n_in // param.group,
-                             (i+1) * n_in // param.group)
+                             (i + 1) * n_in // param.group)
             out_slice = slice(i * n_out // param.group,
-                              (i+1) * n_out // param.group)
+                              (i + 1) * n_out // param.group)
             w = func.W.data[out_slice, in_slice]
 
-            data = numpy.array(blobs[0].data[i*part_size:(i+1)*part_size])
+            data = numpy.array(
+                blobs[0].data[i * part_size:(i + 1) * part_size])
             w[:] = data.reshape(w.shape)
 
         if param.bias_term:
@@ -519,6 +521,7 @@ def _get_width(blob):
 # Internal class
 
 class _SingleArgumentFunction(object):
+
     def __init__(self, func, *args, **kwargs):
         self.func = func
         self.args = args
@@ -529,6 +532,7 @@ class _SingleArgumentFunction(object):
 
 
 class _ListArgumentFcuntion(object):
+
     def __init__(self, func, **kwargs):
         self.func = func
         self.kwargs = kwargs
@@ -538,6 +542,7 @@ class _ListArgumentFcuntion(object):
 
 
 class _DropoutFunction(object):
+
     def __init__(self, caffe_func, ratio):
         # `caffe_func.train` is determined when calling `__call__`
         self.caffe_func = caffe_func
@@ -549,6 +554,7 @@ class _DropoutFunction(object):
 
 
 class _CallChildLink(object):
+
     def __init__(self, caffe_func, name):
         self.name = name
         self.caffe_func = caffe_func
@@ -558,6 +564,7 @@ class _CallChildLink(object):
 
 
 class _EltwiseFunction(object):
+
     def __init__(self, operation, coeffs=None):
         if coeffs is not None:
             assert len(coeffs) > 0

--- a/chainer/links/connection/bias.py
+++ b/chainer/links/connection/bias.py
@@ -26,6 +26,7 @@ class Bias(link.Link):
             no attributes.
 
     """
+
     def __init__(self, axis=1, shape=None):
         super(Bias, self).__init__()
 

--- a/chainer/links/connection/parameter.py
+++ b/chainer/links/connection/parameter.py
@@ -18,6 +18,7 @@ class Parameter(link.Link):
         W (~chainer.Variable): Parameter variable.
 
     """
+
     def __init__(self, array):
         super(Parameter, self).__init__()
         self.add_param('W', array.shape, dtype=array.dtype)

--- a/chainer/links/connection/peephole.py
+++ b/chainer/links/connection/peephole.py
@@ -49,6 +49,7 @@ class StatefulPeepholeLSTM(link.Chain):
         h (~chainer.Variable): Output at the current time step.
 
     """
+
     def __init__(self, in_size, out_size):
         super(StatefulPeepholeLSTM, self).__init__(
             upward=linear.Linear(in_size, 4 * out_size),

--- a/chainer/links/connection/scale.py
+++ b/chainer/links/connection/scale.py
@@ -35,6 +35,7 @@ class Scale(link.Chain):
             Otherwise, no bias attribute.
 
     """
+
     def __init__(self, axis=1, W_shape=None, bias_term=False, bias_shape=None):
         super(Scale, self).__init__()
 

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -74,6 +74,7 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
        See :class:`BinaryHierarchicalSoftmax` for details.
 
     """
+
     def __init__(self, tree):
         parser = TreeParser()
         parser.parse(tree)
@@ -291,6 +292,7 @@ class BinaryHierarchicalSoftmax(link.Link):
     AISTAT2005].
 
     """
+
     def __init__(self, in_size, tree):
         # This function object is copied on every forward computation.
         self._func = BinaryHierarchicalSoftmaxFunction(tree)

--- a/chainer/links/loss/negative_sampling.py
+++ b/chainer/links/loss/negative_sampling.py
@@ -26,6 +26,7 @@ class NegativeSampling(link.Link):
         W (~chainer.Variable): Weight parameter matrix.
 
     """
+
     def __init__(self, in_size, counts, sample_size, power=0.75):
         vocab_size = len(counts)
         super(NegativeSampling, self).__init__(W=(vocab_size, in_size))

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -58,6 +58,7 @@ class BatchNormalization(link.Link):
             to the batch variances.
 
     """
+
     def __init__(self, size, decay=0.9, eps=2e-5, dtype=numpy.float32,
                  use_gamma=True, use_beta=True,
                  initial_gamma=None, initial_beta=None):

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -11,6 +11,7 @@ class AdaGrad(optimizer.GradientMethod):
     See: http://jmlr.org/papers/v12/duchi11a.html
 
     """
+
     def __init__(self, lr=0.001, eps=1e-8):
         self.lr = lr
         self.eps = eps

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -13,6 +13,7 @@ class Adam(optimizer.GradientMethod):
     See: http://arxiv.org/abs/1412.6980v8
 
     """
+
     def __init__(self, alpha=0.001, beta1=0.9, beta2=0.999, eps=1e-8):
         self.alpha = alpha
         self.beta1 = beta1

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -12,6 +12,7 @@ class NesterovAG(optimizer.GradientMethod):
     See: http://arxiv.org/abs/1212.0901
 
     """
+
     def __init__(self, lr=0.01, momentum=0.9):
         self.lr = lr
         self.momentum = momentum

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -11,6 +11,7 @@ class RMSpropGraves(optimizer.GradientMethod):
     See http://arxiv.org/abs/1308.0850
 
     """
+
     def __init__(self, lr=1e-4, alpha=0.95, momentum=0.9, eps=1e-4):
         # Default parameter values are the ones in the original paper.
         self.lr = lr

--- a/chainer/reporter.py
+++ b/chainer/reporter.py
@@ -56,6 +56,7 @@ class Reporter(object):
         observation: Dictionary of observed values.
 
     """
+
     def __init__(self):
         self._observer_names = {}
         self.observation = {}
@@ -235,6 +236,7 @@ class Summary(object):
     Summary computes the statistics of given scalars online.
 
     """
+
     def __init__(self):
         self._x = 0
         self._x2 = 0
@@ -284,6 +286,7 @@ class DictSummary(object):
     values in the dictionaries.
 
     """
+
     def __init__(self):
         self._summaries = collections.defaultdict(Summary)
 

--- a/chainer/serializer.py
+++ b/chainer/serializer.py
@@ -56,6 +56,7 @@ class AbstractSerializer(object):
 class Serializer(AbstractSerializer):
 
     """Base class of all serializers."""
+
     def save(self, obj):
         """Saves an object by this serializer.
 
@@ -71,6 +72,7 @@ class Serializer(AbstractSerializer):
 class Deserializer(AbstractSerializer):
 
     """Base class of all deserializers."""
+
     def load(self, obj):
         """Loads an object from this deserializer.
 

--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -32,6 +32,7 @@ class HDF5Serializer(serializer.Serializer):
         compression (int): Gzip compression level.
 
     """
+
     def __init__(self, group, compression=4):
         _check_available()
 
@@ -83,6 +84,7 @@ class HDF5Deserializer(serializer.Deserializer):
         group (h5py.Group): The group that the deserialization starts from.
 
     """
+
     def __init__(self, group):
         _check_available()
         self.group = group

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -32,6 +32,7 @@ class DictionarySerializer(serializer.Serializer):
             :func:`numpy.savez_compressed` to serialize it in the NPZ format.
 
     """
+
     def __init__(self, target=None, path=''):
         self.target = {} if target is None else target
         self.path = path
@@ -83,6 +84,7 @@ class NpzDeserializer(serializer.Deserializer):
         path: The base path that the deserialization starts from.
 
     """
+
     def __init__(self, npz, path=''):
         self.npz = npz
         self.path = path

--- a/chainer/training/extensions/log_report.py
+++ b/chainer/training/extensions/log_report.py
@@ -49,6 +49,7 @@ class LogReport(extension.Extension):
             does not output the log to any file.
 
     """
+
     def __init__(self, keys=None, trigger=(1, 'epoch'), postprocess=None,
                  log_name='log'):
         self._keys = keys

--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -20,6 +20,7 @@ class PrintReport(extension.Extension):
         out: Stream to print the bar. Standard output is used by default.
 
     """
+
     def __init__(self, entries, log_report='LogReport', out=sys.stdout):
         self._entries = entries
         self._log_report = log_report

--- a/chainer/training/extensions/progress_bar.py
+++ b/chainer/training/extensions/progress_bar.py
@@ -26,6 +26,7 @@ class ProgressBar(extension.Extension):
         out: Stream to print the bar. Standard output is used by default.
 
     """
+
     def __init__(self, training_length=None, update_interval=100,
                  bar_length=50, out=sys.stdout):
         self._training_length = training_length

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -118,6 +118,7 @@ class Trainer(object):
         reporter: Reporter object to report observed values.
 
     """
+
     def __init__(self, updater, stop_trigger=None, out='result'):
         self.updater = updater
         self.stop_trigger = trigger_module.get_trigger(stop_trigger)

--- a/chainer/training/trigger.py
+++ b/chainer/training/trigger.py
@@ -15,6 +15,7 @@ class IntervalTrigger(object):
             either ``'iteration'`` or ``'epoch'``.
 
     """
+
     def __init__(self, period, unit):
         self.period = period
         assert unit == 'epoch' or unit == 'iteration'

--- a/chainer/training/triggers/minmax_value_trigger.py
+++ b/chainer/training/triggers/minmax_value_trigger.py
@@ -17,6 +17,7 @@ class BestValueTrigger(object):
             :class`IntervalTrigger`.
 
     """
+
     def __init__(self, key, compare, trigger=(1, 'epoch')):
         self._key = key
         self._best_value = None
@@ -76,6 +77,7 @@ class MaxValueTrigger(BestValueTrigger):
             :class`IntervalTrigger`.
 
     """
+
     def __init__(self, key, trigger=(1, 'epoch')):
         super(MaxValueTrigger, self).__init__(
             key, lambda max_value, new_value: new_value > max_value, trigger)
@@ -97,6 +99,7 @@ class MinValueTrigger(BestValueTrigger):
             :class`IntervalTrigger`.
 
     """
+
     def __init__(self, key, trigger=(1, 'epoch')):
         super(MinValueTrigger, self).__init__(
             key, lambda min_value, new_value: new_value < min_value, trigger)

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -13,6 +13,7 @@ class Updater(object):
     TODO(beam2d): document it.
 
     """
+
     def connect_trainer(self, trainer):
         """Connects the updater to the trainer that will call it.
 
@@ -114,6 +115,7 @@ class StandardUpdater(Updater):
         iteration: Current number of completed updates.
 
     """
+
     def __init__(self, iterator, optimizer, converter=convert.concat_examples,
                  device=None, loss_func=None):
         if isinstance(iterator, iterator_module.Iterator):
@@ -228,6 +230,7 @@ class ParallelUpdater(StandardUpdater):
             default.
 
     """
+
     def __init__(self, iterator, optimizer, converter=convert.concat_examples,
                  models=None, devices=None, loss_func=None):
         super(ParallelUpdater, self).__init__(

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -440,6 +440,7 @@ class InvalidType(Exception):
     """Raised when types of data for forward/backward are invalid.
 
     """
+
     def __init__(self, expect, actual, msg=None):
         if msg is None:
             msg = 'Expect: {0}\nActual: {1}'.format(expect, actual)

--- a/chainer/utils/walker_alias.py
+++ b/chainer/utils/walker_alias.py
@@ -18,6 +18,7 @@ class WalkerAlias(object):
     See: `Wikipedia article <https://en.wikipedia.org/wiki/Alias_method>`_
 
     """
+
     def __init__(self, probs):
         prob = numpy.array(probs, numpy.float32)
         prob /= numpy.sum(prob)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -86,6 +86,7 @@ class Variable(object):
             :class:`~chainer.Flag` for the detail of ternary flags.
 
     """
+
     def __init__(self, data, volatile=flag.OFF, name=None, grad=None):
         if not isinstance(data, (numpy.ndarray, cuda.ndarray)):
             msg = '''numpy.ndarray or cuda.ndarray are expected.

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -116,7 +116,6 @@ def check_library(compiler, includes=(), libraries=(),
 
 
 def make_extensions(options, compiler):
-
     """Produce a list of Extension instances which passed to cythonize()."""
 
     no_cuda = options['no_cuda']

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -21,6 +21,7 @@ class Event(object):
             the CUDA Runtime API via ctypes.
 
     """
+
     def __init__(self, block=False, disable_timing=False, interprocess=False):
         self.ptr = 0
 
@@ -97,6 +98,7 @@ class Stream(object):
             the CUDA Runtime API via ctypes.
 
     """
+
     def __init__(self, null=False, non_blocking=False):
         if null:
             self.ptr = 0

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -40,6 +40,7 @@ class RandomState(object):
                cupy.cuda.curand.CURAND_RNG_PHILOX4_32_10
 
     """
+
     def __init__(self, seed=None, method=curand.CURAND_RNG_PSEUDO_DEFAULT):
         self._generator = curand.createGenerator(method)
         self.seed(seed)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -770,6 +770,7 @@ def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
 
 
 class NumpyError(object):
+
     def __init__(self, **kw):
         self.kw = kw
 

--- a/cupy/testing/hypothesis.py
+++ b/cupy/testing/hypothesis.py
@@ -27,7 +27,7 @@ def chi_square_test(observed, expected, alpha=0.05, df=None):
     else:
         raise ValueError('support only alpha == 0.05 or 0.01')
 
-    chi_square = numpy.sum((observed-expected) ** 2 / expected)
+    chi_square = numpy.sum((observed - expected) ** 2 / expected)
     return chi_square < chi_square_table[alpha_idx][df]
 
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -104,7 +104,7 @@ To check Cython code, use ``.flake8.cython`` config file::
 
   $ flake8 --config=.flake8.cython path/to/your/cython/code.pyx
 
-The ``autopep8`` supports automatically format Python code to conform to the PEP 8 style guide::
+The autopep8 supports automatically correct Python code to conform to the PEP 8 style guide::
 
   $ autopep8 --in-place --global-config .pep8 path/to/your/code.py
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -94,14 +94,19 @@ Coding Guidelines
 
 We use `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ and a part of `OpenStack Style Guidelines <http://docs.openstack.org/developer/hacking/>`_ related to general coding style as our basic style guidelines.
 
-To check your code, use ``flake8`` command installed by ``hacking`` package::
+To check your code, use ``autopep8`` and ``flake8`` command installed by ``hacking`` package::
 
-  $ pip install hacking
+  $ pip install autopep8 hacking
+  $ autopep8 --global-config .pep8 path/to/your/code.py
   $ flake8 path/to/your/code.py
 
 To check Cython code, use ``.flake8.cython`` config file::
 
   $ flake8 --config=.flake8.cython path/to/your/cython/code.pyx
+
+The ``autopep8`` supports automatically format Python code to conform to the PEP 8 style guide::
+
+  $ autopep8 --in-place --global-config .pep8 path/to/your/code.py
 
 The ``flake8`` command lets you know the part of your code not obeying our style guidelines.
 Before sending a pull request, be sure to check that your code passes the ``flake8`` checking.

--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -108,6 +108,7 @@ class ParallelSequentialIterator(chainer.dataset.Iterator):
 
 # Custom updater for truncated BackProp Through Time (BPTT)
 class BPTTUpdater(training.StandardUpdater):
+
     def __init__(self, train_iter, optimizer, bprop_len, device):
         super(BPTTUpdater, self).__init__(
             train_iter, optimizer, device=device)

--- a/examples/vae/net.py
+++ b/examples/vae/net.py
@@ -8,6 +8,7 @@ import chainer.links as L
 
 class VAE(chainer.Chain):
     """Variational AutoEncoder"""
+
     def __init__(self, n_in, n_latent, n_h):
         super(VAE, self).__init__(
             # encoder

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -87,6 +87,7 @@ class SkipGram(chainer.Chain):
 
 
 class SoftmaxCrossEntropyLoss(chainer.Chain):
+
     def __init__(self, n_in, n_out):
         super(SoftmaxCrossEntropyLoss, self).__init__(
             out=L.Linear(n_in, n_out),

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -42,7 +42,7 @@ class TestGetItem(unittest.TestCase):
             self.slices = [slice(None)] * len(self.shape)
             for axis in self.axes:
                 self.slices[axis] = slice(self.offsets[axis],
-                                          self.offsets[axis]+self.shape[axis])
+                                          self.offsets[axis] + self.shape[axis])
 
             if hasattr(self, 'new_axes'):
                 self.slices.insert(self.new_axes, None)

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -41,8 +41,8 @@ class TestGetItem(unittest.TestCase):
 
             self.slices = [slice(None)] * len(self.shape)
             for axis in self.axes:
-                self.slices[axis] = slice(self.offsets[axis],
-                                          self.offsets[axis] + self.shape[axis])
+                self.slices[axis] = slice(
+                    self.offsets[axis], self.offsets[axis] + self.shape[axis])
 
             if hasattr(self, 'new_axes'):
                 self.slices.insert(self.new_axes, None)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
@@ -30,7 +30,7 @@ class TestHuberLoss(unittest.TestCase):
         diff_data = cuda.to_cpu(x_data) - cuda.to_cpu(t_data)
         expected_result = numpy.zeros(self.shape)
         mask = numpy.abs(diff_data) < 1
-        expected_result[mask] = 0.5 * diff_data[mask]**2
+        expected_result[mask] = 0.5 * diff_data[mask] ** 2
         expected_result[~mask] = numpy.abs(diff_data[~mask]) - 0.5
         loss_expect = numpy.sum(expected_result, axis=1)
         testing.assert_allclose(loss_value, loss_expect)

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -165,6 +165,7 @@ class TestMomentumSGD(OptimizerTestBase, unittest.TestCase):
     'dtype': [numpy.float16, numpy.float32, numpy.float64]
 }))
 class NesterovAG(OptimizerTestBase, unittest.TestCase):
+
     def create(self):
         return optimizers.NesterovAG(0.1)
 
@@ -200,6 +201,7 @@ class TestSGD(OptimizerTestBase, unittest.TestCase):
     'dtype': [numpy.float16, numpy.float32, numpy.float64]
 }))
 class TestSMORMS3(OptimizerTestBase, unittest.TestCase):
+
     def create(self):
         return optimizers.SMORMS3(0.1)
 

--- a/tests/chainer_tests/test_function.py
+++ b/tests/chainer_tests/test_function.py
@@ -312,6 +312,7 @@ class TestFunctionInvalidType(unittest.TestCase):
 
     def test_forward_invalid1(self):
         class Function(chainer.Function):
+
             def check_type_forward(self, in_types):
                 x_type, = in_types
                 type_check.expect(

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -436,7 +436,7 @@ class TestDebugPrint(unittest.TestCase):
         self.assertIn('dtype: float32', result)
         # py2.7 on win64 returns shape as long
         self.assertTrue(re.match(r'- shape: \(5L?, 3L?, 5L?, 5L?\)',
-                        result.splitlines()[4]))
+                                 result.splitlines()[4]))
 
         # no grad
         msg = 'statistics: mean={mean:.8f}, std={std:.8f}'
@@ -479,6 +479,7 @@ class TestDebugPrint(unittest.TestCase):
 
 
 class TestVariableSetCreator(unittest.TestCase):
+
     class MockFunction(object):
         pass
 


### PR DESCRIPTION
I tried autopep8 `find . -name '*.py' -exec autopep8 --in-place '{}' \;` except caffe_pb2.py and caffe_pb3.py.

Seealso #1300.