### PR TITLE
Add `deterministic` option into convolution_2d and deconvolution_2d

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -292,7 +292,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
             some output pixels. It may make the output size larger.
         deterministic (bool): The output of this function can be
             non-deterministic when it uses cuDNN.
-            If this option is `True`, then it forces cuDNN to use
+            If this option is ``True``, then it forces cuDNN to use
             a deterministic algorithm.
 
 

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -31,7 +31,8 @@ def _pair(x):
 
 class Convolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False, deterministic=False):
+    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False,
+                 deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.use_cudnn = use_cudnn
@@ -195,7 +196,7 @@ class Convolution2DFunction(function.Function):
                         self.conv_desc.value, self.filter_desc.value,
                         _bwd_filter_pref, workspace_size)
                 else:
-                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1  # NOQA
 
                 libcudnn.convolutionBackwardFilter_v3(
                     handle, one.data, x_desc.value, x.data.ptr,
@@ -209,7 +210,7 @@ class Convolution2DFunction(function.Function):
                         self.conv_desc.value, x_desc.value, _bwd_data_pref,
                         workspace_size)
                 else:
-                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1  # NOQA
 
                 libcudnn.convolutionBackwardData_v3(
                     handle, one.data, self.filter_desc.value, W.data.ptr,

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -217,6 +217,9 @@ class Convolution2DFunction(function.Function):
                     algo, workspace.data.ptr, workspace_size,
                     zero.data, x_desc.value, gx.data.ptr)
             else:
+                if self.deterministic:
+                    raise ValueError("'deterministic' option not available "
+                                     "for cuDNN versions < v4")
                 libcudnn.convolutionBackwardFilter_v2(
                     handle, one.data, x_desc.value, x.data.ptr,
                     gy_desc.value, gy.data.ptr, self.conv_desc.value,
@@ -293,7 +296,8 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
         deterministic (bool): The output of this function can be
             non-deterministic when it uses cuDNN.
             If this option is ``True``, then it forces cuDNN to use
-            a deterministic algorithm.
+            a deterministic algorithm. This option is only available for
+            cuDNN version >= v4.
 
 
     Returns:
@@ -324,7 +328,8 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
     .. seealso:: :class:`Convolution2D`
 
     """
-    func = Convolution2DFunction(stride, pad, use_cudnn, cover_all, deterministic)
+    func = Convolution2DFunction(
+        stride, pad, use_cudnn, cover_all, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -31,11 +31,12 @@ def _pair(x):
 
 class Convolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False):
+    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False, deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.use_cudnn = use_cudnn
         self.cover_all = cover_all
+        self.deterministic = deterministic
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -188,20 +189,28 @@ class Convolution2DFunction(function.Function):
                 workspace_size = cuda.get_max_workspace_size()
                 workspace = cuda.cupy.empty((workspace_size,), dtype='b')
 
-                algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
-                    handle, x_desc.value, gy_desc.value,
-                    self.conv_desc.value, self.filter_desc.value,
-                    _bwd_filter_pref, workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
+                        handle, x_desc.value, gy_desc.value,
+                        self.conv_desc.value, self.filter_desc.value,
+                        _bwd_filter_pref, workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
+
                 libcudnn.convolutionBackwardFilter_v3(
                     handle, one.data, x_desc.value, x.data.ptr,
                     gy_desc.value, gy.data.ptr, self.conv_desc.value,
                     algo, workspace.data.ptr, workspace_size,
                     zero.data, self.filter_desc.value, gW.data.ptr)
 
-                algo = libcudnn.getConvolutionBackwardDataAlgorithm(
-                    handle, self.filter_desc.value, gy_desc.value,
-                    self.conv_desc.value, x_desc.value, _bwd_data_pref,
-                    workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                        handle, self.filter_desc.value, gy_desc.value,
+                        self.conv_desc.value, x_desc.value, _bwd_data_pref,
+                        workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
+
                 libcudnn.convolutionBackwardData_v3(
                     handle, one.data, self.filter_desc.value, W.data.ptr,
                     gy_desc.value, gy.data.ptr, self.conv_desc.value,
@@ -251,7 +260,7 @@ class Convolution2DFunction(function.Function):
 
 
 def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
-                   cover_all=False):
+                   cover_all=False, deterministic=False):
     """Two-dimensional convolution function.
 
     This is an implementation of two-dimensional convolution in ConvNets.
@@ -281,6 +290,10 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
             available.
         cover_all (bool): If True, all spatial locations are convoluted into
             some output pixels. It may make the output size larger.
+        deterministic (bool): The output of this function can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
 
     Returns:
@@ -311,7 +324,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
     .. seealso:: :class:`Convolution2D`
 
     """
-    func = Convolution2DFunction(stride, pad, use_cudnn, cover_all)
+    func = Convolution2DFunction(stride, pad, use_cudnn, cover_all, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -30,11 +30,12 @@ def _pair(x):
 
 class Deconvolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, outsize=None, use_cudnn=True):
+    def __init__(self, stride=1, pad=0, outsize=None, use_cudnn=True, deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.use_cudnn = use_cudnn
         self.outh, self.outw = (None, None) if outsize is None else outsize
+        self.deterministic = deterministic
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -133,10 +134,14 @@ class Deconvolution2DFunction(function.Function):
             if _cudnn_version >= 4000:
                 workspace_size = cuda.get_max_workspace_size()
                 workspace = cuda.cupy.empty((workspace_size,), dtype='b')
-                algo = libcudnn.getConvolutionBackwardDataAlgorithm(
-                    handle, self.filter_desc.value, x_desc.value,
-                    self.conv_desc.value, y_desc.value, _bwd_data_pref,
-                    workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                        handle, self.filter_desc.value, x_desc.value,
+                        self.conv_desc.value, y_desc.value, _bwd_data_pref,
+                        workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
+
                 libcudnn.convolutionBackwardData_v3(
                     handle, one.data, self.filter_desc.value, W.data.ptr,
                     x_desc.value, x.data.ptr, self.conv_desc.value,
@@ -230,10 +235,13 @@ class Deconvolution2DFunction(function.Function):
             gW = cuda.cupy.empty_like(W)
             # filter backward
             if _cudnn_version >= 4000:
-                algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
-                    handle, gy_desc.value, gx_desc.value,
-                    self.conv_desc.value, self.filter_desc.value,
-                    _bwd_filter_pref, workspace_size)
+                if not self.deterministic:
+                    algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
+                        handle, gy_desc.value, gx_desc.value,
+                        self.conv_desc.value, self.filter_desc.value,
+                        _bwd_filter_pref, workspace_size)
+                else:
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
 
                 libcudnn.convolutionBackwardFilter_v3(
                     handle, one.data, gy_desc.value, gy.data.ptr,
@@ -275,7 +283,7 @@ class Deconvolution2DFunction(function.Function):
 
 
 def deconvolution_2d(x, W, b=None, stride=1, pad=0,
-                     outsize=None, use_cudnn=True):
+                     outsize=None, use_cudnn=True, deterministic=False):
     """Two dimensional deconvolution function.
 
     This is an implementation of two-dimensional deconvolution.
@@ -297,6 +305,10 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
             input size, stride and pad.
         use_cudnn (bool): If ``True``, then this function uses cuDNN if
             available.
+        deterministic (bool): The output of this function can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`
@@ -316,7 +328,7 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
        w_O &= s_X (w - 1) + k_W - 2p_W.
 
     """
-    func = Deconvolution2DFunction(stride, pad, outsize, use_cudnn)
+    func = Deconvolution2DFunction(stride, pad, outsize, use_cudnn, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -307,7 +307,7 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
             available.
         deterministic (bool): The output of this function can be
             non-deterministic when it uses cuDNN.
-            If this option is `True`, then it forces cuDNN to use
+            If this option is ``True``, then it forces cuDNN to use
             a deterministic algorithm.
 
 

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -249,6 +249,9 @@ class Deconvolution2DFunction(function.Function):
                     algo, workspace.data.ptr, workspace_size,
                     zero.data, self.filter_desc.value, gW.data.ptr)
             else:
+                if self.deterministic:
+                    raise ValueError("'deterministic' option not available "
+                                     "for cuDNN versions < v4")
                 libcudnn.convolutionBackwardFilter_v2(
                     handle, one.data, gy_desc.value, gy.data.ptr,
                     gx_desc.value, x.data.ptr, self.conv_desc.value,
@@ -308,7 +311,8 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
         deterministic (bool): The output of this function can be
             non-deterministic when it uses cuDNN.
             If this option is ``True``, then it forces cuDNN to use
-            a deterministic algorithm.
+            a deterministic algorithm. This option is only available for
+            cuDNN version >= v4.
 
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`
@@ -328,7 +332,8 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
        w_O &= s_X (w - 1) + k_W - 2p_W.
 
     """
-    func = Deconvolution2DFunction(stride, pad, outsize, use_cudnn, deterministic)
+    func = Deconvolution2DFunction(
+        stride, pad, outsize, use_cudnn, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -30,7 +30,8 @@ def _pair(x):
 
 class Deconvolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, outsize=None, use_cudnn=True, deterministic=False):
+    def __init__(self, stride=1, pad=0, outsize=None, use_cudnn=True,
+                 deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.use_cudnn = use_cudnn
@@ -140,7 +141,7 @@ class Deconvolution2DFunction(function.Function):
                         self.conv_desc.value, y_desc.value, _bwd_data_pref,
                         workspace_size)
                 else:
-                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1  # NOQA
 
                 libcudnn.convolutionBackwardData_v3(
                     handle, one.data, self.filter_desc.value, W.data.ptr,
@@ -241,7 +242,7 @@ class Deconvolution2DFunction(function.Function):
                         self.conv_desc.value, self.filter_desc.value,
                         _bwd_filter_pref, workspace_size)
                 else:
-                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
+                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1  # NOQA
 
                 libcudnn.convolutionBackwardFilter_v3(
                     handle, one.data, gy_desc.value, gy.data.ptr,

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -38,8 +38,9 @@ class Convolution2D(link.Link):
             ``cupy.ndarray`` and edits its value.
         deterministic (bool): The output of this link can be
             non-deterministic when it uses cuDNN.
-            If this option is `True`, then it forces cuDNN to use
-            a deterministic algorithm.
+            If this option is ``True``, then it forces cuDNN to use
+            a deterministic algorithm. This option is only available for
+            cuDNN version >= v4.
 
     .. seealso::
        See :func:`chainer.functions.convolution_2d` for the definition of

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -36,6 +36,10 @@ class Convolution2D(link.Link):
             function uses to initialize ``bias``.
             May also be a callable that takes ``numpy.ndarray`` or
             ``cupy.ndarray`` and edits its value.
+        deterministic (bool): The output of this link can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
     .. seealso::
        See :func:`chainer.functions.convolution_2d` for the definition of
@@ -49,13 +53,14 @@ class Convolution2D(link.Link):
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
                  wscale=1, bias=0, nobias=False, use_cudnn=True,
-                 initialW=None, initial_bias=None):
+                 initialW=None, initial_bias=None, deterministic=False):
         super(Convolution2D, self).__init__()
         self.ksize = ksize
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.use_cudnn = use_cudnn
         self.out_channels = out_channels
+        self.deterministic = deterministic
 
         # For backward compatibility
         self.initialW = initialW
@@ -98,7 +103,8 @@ class Convolution2D(link.Link):
             with cuda.get_device(self._device_id):
                 self._initialize_params(x.shape[1])
         return convolution_2d.convolution_2d(
-            x, self.W, self.b, self.stride, self.pad, self.use_cudnn)
+            x, self.W, self.b, self.stride, self.pad, self.use_cudnn,
+            deterministic=self.deterministic)
 
 
 def _pair(x):

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -44,8 +44,9 @@ class Deconvolution2D(link.Link):
             ``cupy.ndarray`` and edits its value.
         deterministic (bool): The output of this link can be
             non-deterministic when it uses cuDNN.
-            If this option is `True`, then it forces cuDNN to use
-            a deterministic algorithm.
+            If this option is ``True``, then it forces cuDNN to use
+            a deterministic algorithm. This option is only available for
+            cuDNN version >= v4.
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`
     which indicate the number of the number of input channels, output channels,

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -42,6 +42,10 @@ class Deconvolution2D(link.Link):
             function uses to initialize ``bias``.
             May also be a callable that takes ``numpy.ndarray`` or
             ``cupy.ndarray`` and edits its value.
+        deterministic (bool): The output of this link can be
+            non-deterministic when it uses cuDNN.
+            If this option is `True`, then it forces cuDNN to use
+            a deterministic algorithm.
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`
     which indicate the number of the number of input channels, output channels,
@@ -63,12 +67,13 @@ class Deconvolution2D(link.Link):
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
                  wscale=1, bias=0, nobias=False, outsize=None, use_cudnn=True,
-                 initialW=None, initial_bias=None):
+                 initialW=None, initial_bias=None, deterministic=False):
         kh, kw = _pair(ksize)
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.outsize = (None, None) if outsize is None else outsize
         self.use_cudnn = use_cudnn
+        self.deterministic = deterministic
 
         W_shape = (in_channels, out_channels, kh, kw)
         super(Deconvolution2D, self).__init__(W=W_shape)
@@ -93,7 +98,8 @@ class Deconvolution2D(link.Link):
     def __call__(self, x):
         return deconvolution_2d.deconvolution_2d(
             x, self.W, self.b, self.stride, self.pad,
-            self.outsize, self.use_cudnn)
+            self.outsize, self.use_cudnn,
+            deterministic=self.deterministic)
 
 
 def _pair(x):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -178,7 +178,7 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
             self.forward()
             self.assertEqual(func.called, self.expect)
 
-    def test_call_cudnn_backrward(self):
+    def test_call_cudnn_backward(self):
         y = self.forward()
         y.grad = self.gy
         if cuda.cudnn.cudnn.getVersion() >= 4000:
@@ -188,6 +188,95 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
         with mock.patch(name) as func:
             y.backward()
             self.assertEqual(func.called, self.expect)
+
+
+@testing.parameterize(*testing.product({
+    'c_contiguous': [True, False],
+    'deterministic': [True, False],
+    'nobias': [True, False],
+}))
+class TestConvolution2DFunctionDeterministic(unittest.TestCase):
+
+    def setUp(self):
+        self.stride = 2
+        self.pad = 1
+        batch_sz = 2
+        in_channels = 64
+        out_channels = 64
+        kh, kw = (3, 3)
+        in_h, in_w = (32, 128)
+        out_h, out_w = (16, 64)
+        # should be same types for cudnn test
+        x_dtype = numpy.float32
+        W_dtype = numpy.float32
+        self.W = numpy.random.normal(
+            0, numpy.sqrt(1. / (kh * kw * in_channels)),
+            (out_channels, in_channels, kh, kw)).astype(W_dtype)
+        self.b = numpy.random.uniform(-1, 1, out_channels).astype(x_dtype)
+        self.x = numpy.random.uniform(
+            -1, 1, (batch_sz, in_channels, in_h, in_w)).astype(x_dtype)
+        self.gy = numpy.random.uniform(
+            -1, 1, (batch_sz, out_channels, out_h, out_w)).astype(x_dtype)
+
+    @attr.gpu
+    @attr.cudnn
+    def test_deterministic(self):
+        """Check deterministic behaviour.
+
+        Result of gradient of W after backward computation might be
+        non-deterministic.
+
+        """
+        x1, W1, b1, y1 = self._run()
+        x2, W2, b2, y2 = self._run()
+
+        cuda.cupy.testing.assert_array_equal(y1.data, y2.data)
+        if self.deterministic:
+            cuda.cupy.testing.assert_array_equal(W1.grad, W2.grad)
+        else:
+            with self.assertRaises(AssertionError):
+                cuda.cupy.testing.assert_array_equal(W1.grad, W2.grad)
+
+        if not self.nobias:
+            cuda.cupy.testing.assert_array_equal(b1.grad, b2.grad)
+        cuda.cupy.testing.assert_array_equal(x1.grad, x2.grad)
+
+    def _contiguous(self, x_data, W_data, b_data, gy_data):
+        if not self.c_contiguous:
+            x_data = numpy.asfortranarray(x_data)
+            W_data = numpy.asfortranarray(W_data)
+            gy_data = numpy.asfortranarray(gy_data)
+            self.assertFalse(x_data.flags.c_contiguous)
+            self.assertFalse(W_data.flags.c_contiguous)
+            self.assertFalse(gy_data.flags.c_contiguous)
+            b = numpy.empty((len(b_data) * 2,), dtype=self.b.dtype)
+            b[::2] = b_data
+            b_data = b[::2]
+            self.assertFalse(b_data.flags.c_contiguous)
+        return x_data, W_data, b_data, gy_data
+
+    def _make_gpu_args(self):
+        return tuple(cuda.to_gpu(data) for data in (self.x, self.W, self.b))
+
+    def _run(self):
+        # verify data continuity and move to gpu
+        x_data, W_data, b_data, gy_data = \
+            tuple(cuda.to_gpu(data) for data in self._contiguous(
+                self.x, self.W, self.b, self.gy))
+        x, W, b, y = self._run_forward(x_data, W_data, b_data)
+
+        y.grad = gy_data
+        y.backward()
+        return x, W, b, y
+
+    def _run_forward(self, x_data, W_data, b_data):
+        x = chainer.Variable(x_data)
+        W = chainer.Variable(W_data)
+        b = None if self.nobias else chainer.Variable(b_data)
+        y = functions.convolution_2d(
+            x, W, b, stride=self.stride, pad=self.pad, use_cudnn=True,
+            cover_all=False, deterministic=self.deterministic)
+        return x, W, b, y
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -255,9 +255,6 @@ class TestConvolution2DFunctionDeterministic(unittest.TestCase):
             self.assertFalse(b_data.flags.c_contiguous)
         return x_data, W_data, b_data, gy_data
 
-    def _make_gpu_args(self):
-        return tuple(cuda.to_gpu(data) for data in (self.x, self.W, self.b))
-
     def _run(self):
         # verify data continuity and move to gpu
         x_data, W_data, b_data, gy_data = \

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -1,6 +1,6 @@
+import mock
 import unittest
 
-import mock
 import numpy
 
 import chainer
@@ -220,15 +220,35 @@ class TestDeconvolution2DFunctionDeterministic(unittest.TestCase):
 
     @attr.gpu
     @attr.cudnn
+    def test_called(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            with mock.patch(
+                    'chainer.functions.connection.deconvolution_2d.libcudnn'
+            ) as mlibcudnn:
+                x, W, b, y = self._run()
+
+            expect = not self.deterministic
+
+            # in Deconvolution2DFunction.forward_gpu()
+            self.assertEqual(
+                mlibcudnn.getConvolutionBackwardDataAlgorithm.called,
+                expect)
+            mlibcudnn.convolutionBackwardData_v3.assert_called_once()
+
+            # in Deconvolution2DFunction.backward_gpu()
+            self.assertEqual(
+                mlibcudnn.getConvolutionBackwardFilterAlgorithm.called,
+                expect)
+            mlibcudnn.convolutionBackwardFilter_v3.assert_called_once()
+
+    @attr.gpu
+    @attr.cudnn
     def test_deterministic(self):
         x1, W1, b1, y1 = self._run()
         x2, W2, b2, y2 = self._run()
 
         if self.deterministic:
             cuda.cupy.testing.assert_array_equal(W1.grad, W2.grad)
-        else:
-            with self.assertRaises(AssertionError):
-                cuda.cupy.testing.assert_array_equal(W1.grad, W2.grad)
 
         if not self.nobias:
             cuda.cupy.testing.assert_array_equal(b1.grad, b2.grad)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -248,9 +248,6 @@ class TestDeconvolution2DFunctionDeterministic(unittest.TestCase):
             self.assertFalse(b_data.flags.c_contiguous)
         return x_data, W_data, b_data, gy_data
 
-    def _make_gpu_args(self):
-        return tuple(cuda.to_gpu(data) for data in (self.x, self.W, self.b))
-
     def _run(self):
         # verify data continuity and move to gpu
         x_data, W_data, b_data, gy_data = \

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -193,11 +193,14 @@ class TestDeconvolution2DCudnnCall(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'c_contiguous': [True, False],
-    'deterministic': [True, False],
     'nobias': [True, False],
 }))
+@attr.gpu
+@attr.cudnn
 class TestDeconvolution2DFunctionDeterministic(unittest.TestCase):
+
     def setUp(self):
+        self.cudnn_version = cuda.cudnn.cudnn.getVersion()
         self.stride = 2
         self.pad = 1
         batch_sz = 2
@@ -218,41 +221,37 @@ class TestDeconvolution2DFunctionDeterministic(unittest.TestCase):
         self.gy = numpy.random.uniform(
             -1, 1, (batch_sz, out_channels, out_h, out_w)).astype(x_dtype)
 
-    @attr.gpu
-    @attr.cudnn
     def test_called(self):
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
-            with mock.patch(
-                    'chainer.functions.connection.deconvolution_2d.libcudnn'
-            ) as mlibcudnn:
-                x, W, b, y = self._run()
+        with mock.patch(
+                'chainer.functions.connection.deconvolution_2d.libcudnn'
+        ) as mlibcudnn:
+            if cuda.cudnn.cudnn.getVersion() < 4000:
+                with self.assertRaises(ValueError):
+                    x, W, b, y = self._run()
+                return
 
-            expect = not self.deterministic
+            # cuDNN version >= v4 supports `deterministic` option
+            x, W, b, y = self._run()
 
             # in Deconvolution2DFunction.forward_gpu()
-            self.assertEqual(
-                mlibcudnn.getConvolutionBackwardDataAlgorithm.called,
-                expect)
-            mlibcudnn.convolutionBackwardData_v3.assert_called_once()
+            self.assertFalse(
+                mlibcudnn.getConvolutionBackwardDataAlgorithm.called)
 
             # in Deconvolution2DFunction.backward_gpu()
-            self.assertEqual(
-                mlibcudnn.getConvolutionBackwardFilterAlgorithm.called,
-                expect)
-            mlibcudnn.convolutionBackwardFilter_v3.assert_called_once()
+            self.assertFalse(
+                mlibcudnn.getConvolutionBackwardFilterAlgorithm.called)
 
-    @attr.gpu
-    @attr.cudnn
     def test_deterministic(self):
+        if self.cudnn_version < 4000:
+            # `deterministic` option is not supported
+            return
+
         x1, W1, b1, y1 = self._run()
         x2, W2, b2, y2 = self._run()
 
-        if self.deterministic:
-            cuda.cupy.testing.assert_array_equal(W1.grad, W2.grad)
-
-        if not self.nobias:
-            cuda.cupy.testing.assert_array_equal(b1.grad, b2.grad)
         cuda.cupy.testing.assert_array_equal(x1.grad, x2.grad)
+        cuda.cupy.testing.assert_array_equal(y1.data, y2.data)
+        cuda.cupy.testing.assert_array_equal(W1.grad, W2.grad)
 
     def _contiguous(self, x_data, W_data, b_data, gy_data):
         if not self.c_contiguous:
@@ -284,8 +283,7 @@ class TestDeconvolution2DFunctionDeterministic(unittest.TestCase):
         W = chainer.Variable(W_data)
         b = None if self.nobias else chainer.Variable(b_data)
         y = F.deconvolution_2d(x, W, b, stride=self.stride, pad=self.pad,
-                               use_cudnn=True,
-                               deterministic=self.deterministic)
+                               use_cudnn=True, deterministic=True)
         return x, W, b, y
 
 


### PR DESCRIPTION
@t-abe's https://github.com/pfnet/chainer/pull/1189 can't be reopened.
TODO (requested by @delta2323): Add test cases for this option where we call the function twice and compare results.

Some of convolution algorithm cuDNN provides are non-deterministic.
So outputs of current chainer convolution and deconvolution can be non-deterministic when cuDNN is available.
I think this might make trouble when you want to do reproducible experiments.

This PR add deterministic option into these two functions and links.
If True, the functions force cuDNN to use deterministic algorithms.