### PR TITLE
make MaxPooling2D.backward_cpu faster

### DIFF
--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -80,13 +80,18 @@ class MaxPooling2D(pooling_2d.Pooling2D):
     def backward_cpu(self, x, gy):
         n, c, out_h, out_w = gy[0].shape
         h, w = x[0].shape[2:]
-        gcol = numpy.zeros(
-            (n, c, self.kh, self.kw, out_h, out_w), dtype=x[0].dtype)
+        kh, kw = self.kh, self.kw
 
-        # TODO(beam2d): Make it fast
-        gcol_r = numpy.rollaxis(gcol.reshape(n, c, -1, out_h, out_w), 2)
-        for i in numpy.ndindex(n, c, out_h, out_w):
-            gcol_r[self.indexes[i]][i] = gy[0][i]
+        gcol = numpy.zeros(
+            (n * c * out_h * out_w * kh * kw), dtype=x[0].dtype)
+
+        indexes = self.indexes.ravel()
+        indexes += numpy.arange(0, indexes.size * kh * kw, kh * kw)
+
+        gcol[indexes] = gy[0].ravel()
+        gcol = gcol.reshape(n, c, out_h, out_w, kh, kw)
+        gcol = numpy.swapaxes(gcol, 2, 4)
+        gcol = numpy.swapaxes(gcol, 3, 5)
 
         gx = conv.col2im_cpu(gcol, self.sy, self.sx, self.ph, self.pw, h, w)
         return gx,


### PR DESCRIPTION
Hi,

Sometimes I want to use Chainer on cpu mode. Some days ago, I noticed that `MaxPooling2D.backward_cpu` is so slow and @beam2d leave a TODO comment: "Make it fast". I did it.

For training a simple LeNet like network, throughput was increased from 130 images/sec to 650 images/sec on my machine.

Here's a result of profiling which compares before applying this PR and after applying this PR. You can see that in the case of before applying, most of the time is consumed on `MaxPooling2D.backward_cpu`. After applying the patch, the most time consuming methods `tensordot`, `col2im_cpu` and `im2col_cpu`. `MaxPooling2D.backward_cpu` is still not negligible, but it's not a bottleneck any more.

I used [statprof-smarkets](https://pypi.python.org/pypi/statprof-smarkets) as a profiler.

before:
```
  %   cumulative      self
 time    seconds   seconds  name
 47.66    127.83    127.83  /home/ubuntu/chainer/chainer/functions/pooling/max_pooling_2d.py:89:backward_cpu
 14.45     38.77     38.77  /home/ubuntu/.local/lib/python3.4/site-packages/numpy/lib/index_tricks.py:586:__next__
 10.94     29.35     29.35  /home/ubuntu/.local/lib/python3.4/site-packages/numpy/lib/index_tricks.py:574:__next__
 10.53     28.24     28.24  /home/ubuntu/.local/lib/python3.4/site-packages/numpy/lib/index_tricks.py:587:__next__
  3.78    106.63     10.13  /home/ubuntu/chainer/chainer/functions/pooling/max_pooling_2d.py:88:backward_cpu
```

after:
```
  %   cumulative      self
 time    seconds   seconds  name
 24.46     19.29     19.29  /home/ubuntu/.local/lib/python3.4/site-packages/numpy/core/numeric.py:1332:tensordot
 17.45     13.76     13.76  /home/ubuntu/chainer/chainer/utils/conv.py:79:col2im_cpu
  7.37      5.81      5.81  /home/ubuntu/.local/lib/python3.4/site-packages/numpy/core/numeric.py:1331:tensordot
  6.03      4.75      4.75  /home/ubuntu/chainer/chainer/utils/conv.py:35:im2col_cpu
  5.89     10.90      4.64  /home/ubuntu/chainer/chainer/functions/connection/convolution_2d.py:152:backward_cpu
(snip)
  2.47      1.95      1.95  /home/ubuntu/chainer/chainer/functions/pooling/max_pooling_2d.py:91:backward_cpu
```