### PR TITLE
bug fix: scan kernel fails with multi gpu

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2344,7 +2344,7 @@ cdef _mean = create_reduction_func(
 # scan
 # -----------------------------------------------------------------------------
 
-@util.memoize()
+@util.memoize(for_each_device=True)
 def _inclusive_scan_kernel(dtype, block_size):
     """return Prefix Sum(Scan) cuda kernel
 
@@ -2411,7 +2411,7 @@ def _inclusive_scan_kernel(dtype, block_size):
 
     return module.get_function(name)
 
-@util.memoize()
+@util.memoize(for_each_device=True)
 def _add_scan_blocked_sum_kernel(dtype):
     name = "add_scan_blocked_sum_kernel"
     dtype = _get_typename(dtype)
@@ -2431,7 +2431,7 @@ def _add_scan_blocked_sum_kernel(dtype):
 
     return module.get_function(name)
 
-@util.memoize()
+@util.memoize(for_each_device=True)
 def _nonzero_1d_kernel(src_dtype, index_dtype):
     name = "nonzero_1d_kernel"
     src_dtype = _get_typename(src_dtype)
@@ -2454,7 +2454,7 @@ def _nonzero_1d_kernel(src_dtype, index_dtype):
 
     return module.get_function(name)
 
-@util.memoize()
+@util.memoize(for_each_device=True)
 def _nonzero_kernel(src_dtype, src_ndim, index_dtype, dst_dtype):
     name = "nonzero_kernel"
     src_dtype = _get_typename(src_dtype)

--- a/tests/cupy_tests/core_tests/test_scan.py
+++ b/tests/cupy_tests/core_tests/test_scan.py
@@ -3,6 +3,7 @@
 import unittest
 
 import cupy
+from cupy import cuda
 from cupy import testing
 
 
@@ -24,4 +25,13 @@ class TestScan(unittest.TestCase):
     def test_check_1d_array(self):
         with self.assertRaises(TypeError):
             a = cupy.zeros((2, 2))
+            cupy.core.core.scan(a)
+
+    @testing.multi_gpu(2)
+    def test_multi_gpu(self):
+        with cuda.Device(0):
+            a = cupy.zeros((10,))
+            cupy.core.core.scan(a)
+        with cuda.Device(1):
+            a = cupy.zeros((10,))
             cupy.core.core.scan(a)


### PR DESCRIPTION
```
import cupy
cupy.array([1,1]).nonzero()

with cupy.cuda.Device(1):
    cupy.array([2, 3]).nonzero() # -> CUDADriverError: CUDA_ERROR_INVALID_HANDLE: invalid resource handle
```