### PR TITLE
Fix Travis CI status badge to show master's status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![pypi](https://img.shields.io/pypi/v/chainer.svg)](https://pypi.python.org/pypi/chainer)
 [![GitHub license](https://img.shields.io/github/license/pfnet/chainer.svg)](https://github.com/pfnet/chainer)
-[![travis](https://img.shields.io/travis/pfnet/chainer.svg)](https://travis-ci.org/pfnet/chainer)
+[![travis](https://img.shields.io/travis/pfnet/chainer/master.svg)](https://travis-ci.org/pfnet/chainer)
 [![coveralls](https://img.shields.io/coveralls/pfnet/chainer.svg)](https://coveralls.io/github/pfnet/chainer)
 [![Read the Docs](https://readthedocs.org/projects/chainer/badge/?version=stable)](http://docs.chainer.org/en/stable/?badge=stable)
 


### PR DESCRIPTION
This PR fixes travis status badge on README.md to show master branch's build status.

It's because the badge currently shows that of all branches in Chainer so it often says "build failing", it is not the case.
