### PR TITLE
add out option to cupy.core.core.scan & performance improvement

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2418,8 +2418,7 @@ def _add_scan_blocked_sum_kernel(dtype):
     source = string.Template("""
     extern "C" __global__ void ${name}(CArray<${dtype}, 1> src_dst){
         long long n = src_dst.size();
-        unsigned int idx = threadIdx.x + (blockDim.x + 1) * blockIdx.x;
-        unsigned int idxAdded = idx + (blockDim.x + 1);
+        unsigned int idxAdded = threadIdx.x + (blockDim.x + 1) * (blockIdx.x + 1);
         unsigned int idxAdd = (blockDim.x + 1) * (blockIdx.x + 1) - 1;
 
         if(idxAdded < n){

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2416,14 +2416,14 @@ def _add_scan_blocked_sum_kernel(dtype):
     name = "add_scan_blocked_sum_kernel"
     dtype = _get_typename(dtype)
     source = string.Template("""
-    extern "C" __global__ void ${name}(CArray<${dtype}, 1> src_dst,
-        CArray<${dtype}, 1> sum){
+    extern "C" __global__ void ${name}(CArray<${dtype}, 1> src_dst){
         long long n = src_dst.size();
-        unsigned int idx = threadIdx.x + blockDim.x * blockIdx.x;
-        unsigned int idxSum = idx + blockDim.x;
+        unsigned int idx = threadIdx.x + (blockDim.x + 1) * blockIdx.x;
+        unsigned int idxAdded = idx + (blockDim.x + 1);
+        unsigned int idxAdd = (blockDim.x + 1) * (blockIdx.x + 1) - 1;
 
-        if(idx < n){
-            src_dst[idxSum] = src_dst[idxSum] + sum[blockIdx.x];
+        if(idxAdded < n){
+            src_dst[idxAdded] += src_dst[idxAdd];
         }
     }
     """).substitute(name=name, dtype=dtype)
@@ -2489,11 +2489,13 @@ def _nonzero_kernel(src_dtype, src_ndim, index_dtype, dst_dtype):
 
     return module.get_function(name)
 
-def scan(a):
+def scan(a, out=None):
     """Return the prefix sum(scan) of the elements.
 
     Args:
         a (cupy.ndarray): input array.
+        out (cupy.ndarray): Alternative output array in which to place
+         the result. The same size and same type as the input array(a).
 
     Returns:
         cupy.ndarray: A new array holding the result is returned.
@@ -2504,20 +2506,23 @@ def scan(a):
 
     block_size = 256
 
-    scanned_array = ndarray(a.shape, dtype=a.dtype)
+    if out is None:
+        out = ndarray(a.shape, dtype=a.dtype)
+    else:
+        if a.size != out.size:
+            raise ValueError("Provided out is the wrong size")
+
     kern_scan = _inclusive_scan_kernel(a.dtype, block_size)
     kern_scan(grid=((a.size - 1) // (2 * block_size) + 1,),
               block=(block_size,),
-              args=(a, scanned_array),
+              args=(a, out),
               shared_mem=a.itemsize * block_size * 2)
 
-    if a.size // (block_size * 2) > 0:
-        blocked_sum = scanned_array[block_size * 2 - 1:-1:block_size * 2]
-        scanned_blocked_sum = scan(blocked_sum)
-
-        kern_add = _add_scan_blocked_sum_kernel(scanned_array.dtype)
+    if (a.size - 1) // (block_size * 2) > 0:
+        blocked_sum = out[block_size * 2 - 1:None:block_size * 2]
+        scan(blocked_sum, blocked_sum)
+        kern_add = _add_scan_blocked_sum_kernel(out.dtype)
         kern_add(grid=((a.size - 1) // (2 * block_size),),
-                 block=(2 * block_size,),
-                 args=(scanned_array, scanned_blocked_sum))
-
-    return scanned_array
+                 block=(2 * block_size - 1,),
+                 args=(out,))
+    return out

--- a/tests/cupy_tests/core_tests/test_scan.py
+++ b/tests/cupy_tests/core_tests/test_scan.py
@@ -13,7 +13,7 @@ class TestScan(unittest.TestCase):
     def test_scan(self, dtype):
         element_num = 10000
 
-        if dtype in {cupy.int8, cupy.uint8}:
+        if dtype in {cupy.int8, cupy.uint8, cupy.float16}:
             element_num = 100
 
         a = cupy.ones((element_num,), dtype=dtype)
@@ -35,3 +35,20 @@ class TestScan(unittest.TestCase):
         with cuda.Device(1):
             a = cupy.zeros((10,))
             cupy.core.core.scan(a)
+
+    @testing.for_all_dtypes()
+    def test_scan_out(self, dtype):
+        element_num = 10000
+
+        if dtype in {cupy.int8, cupy.uint8, cupy.float16}:
+            element_num = 100
+
+        a = cupy.ones((element_num,), dtype=dtype)
+        b = cupy.zeros_like(a)
+        cupy.core.core.scan(a, b)
+        expect = cupy.arange(start=1, stop=element_num + 1).astype(dtype)
+
+        testing.assert_array_equal(b, expect)
+
+        cupy.core.core.scan(a, a)
+        testing.assert_array_equal(a, expect)


### PR DESCRIPTION
This PR adds out option to cupy.core.core.scan.

Performance improvement
```
# before
In [2]: a = cupy.arange(10000)
In [3]: %timeit cupy.core.core.scan(a)
The slowest run took 143.12 times longer than the fastest. This could mean that an intermediate result is being cached.
1000 loops, best of 3: 259 µs per loop

# after
In [2]: a = cupy.arange(10000)
In [3]: %timeit cupy.core.core.scan(a)
The slowest run took 13.74 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 35.7 µs per loo

In [4]: b = cupy.zeros_like(a)
In [5]: %timeit cupy.core.core.scan(a,b)
The slowest run took 25.18 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 18.7 µs per loop
```
