### PR TITLE
Support zero dot

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1850,6 +1850,9 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
     if k != 0:
         m = b.size // k
         n = a.size // k
+    else:
+        m = 0
+        n = 0
 
     ret_shape.assign(a._shape.begin() + 1, a._shape.end())
     ret_shape.insert(ret_shape.end(), b._shape.begin() + 1, b._shape.end())

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1851,6 +1851,8 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
         m = b.size // k
         n = a.size // k
     else:
+        # When k==0, the function must returns a matrix filled with zero
+        # like NumPy.
         m = 0
         n = 0
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1847,8 +1847,9 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
         b = rollaxis(b, b_axis, 0)
 
     k = a._shape[0]
-    m = b.size // k
-    n = a.size // k
+    if k != 0:
+        m = b.size // k
+        n = a.size // k
 
     ret_shape.assign(a._shape.begin() + 1, a._shape.end())
     ret_shape.insert(ret_shape.end(), b._shape.begin() + 1, b._shape.end())
@@ -1861,7 +1862,7 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
         elif b_is_vec:
             ret_shape.erase(ret_shape.begin())
     else:
-        if out.size != n * m:
+        if k != 0 and out.size != n * m:
             raise ValueError('Output array has an invalid size')
         if not out._c_contiguous:
             raise ValueError('Output array must be C-contiguous')

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -17,6 +17,9 @@ from cupy import testing
         ((0, 3), (3, 4)),
         ((2, 3), (3, 0)),
         ((0, 3), (3, 0)),
+        ((3, 0), (0, 4)),
+        ((2, 3, 0), (3, 0, 2)),
+        ((0, 0), (0, 0)),
     ],
     'trans_a': [True, False],
     'trans_b': [True, False],
@@ -54,7 +57,8 @@ class TestDot(unittest.TestCase):
             b = testing.shaped_arange(shape_b[::-1], xp, dtype_b).T
         else:
             b = testing.shaped_arange(shape_b, xp, dtype_b)
-        c = xp.empty((shape_a[0], shape_b[-1]), dtype=dtype_c)
+        shape_c = shape_a[:-1] + shape_b[:-2] + shape_b[-1:]
+        c = xp.empty(shape_c, dtype=dtype_c)
         xp.dot(a, b, out=c)
         return c
 


### PR DESCRIPTION
I fixed dot operator to support dot with zero-sized axis such as `(3, 0) x (0, 3)`.
related to #1336 