### PR TITLE
Extractor

### DIFF
--- a/chainer/training/extensions/__init__.py
+++ b/chainer/training/extensions/__init__.py
@@ -2,6 +2,7 @@ from chainer.training.extensions import _snapshot
 from chainer.training.extensions import computational_graph
 from chainer.training.extensions import evaluator
 from chainer.training.extensions import exponential_shift
+from chainer.training.extensions import extractor
 from chainer.training.extensions import linear_shift
 from chainer.training.extensions import log_report
 from chainer.training.extensions import print_report
@@ -11,6 +12,7 @@ from chainer.training.extensions import progress_bar
 dump_graph = computational_graph.dump_graph
 Evaluator = evaluator.Evaluator
 ExponentialShift = exponential_shift.ExponentialShift
+Extractor = extractor.Extractor
 LinearShift = linear_shift.LinearShift
 LogReport = log_report.LogReport
 snapshot = _snapshot.snapshot

--- a/chainer/training/extensions/extractor.py
+++ b/chainer/training/extensions/extractor.py
@@ -1,0 +1,239 @@
+import copy
+
+import six
+
+from chainer import cuda
+from chainer.dataset import convert
+from chainer.dataset import iterator as iterator_module
+from chainer import link
+from chainer.training import extension
+from chainer import variable
+
+
+def concat_variables(variables, device=None):
+    """Concatenates a list of variables into a single variable.
+
+    Dataset iterator yields a list of examples. If each example is an array,
+    this function concatenates them along the newly-inserted first axis (called
+    `batch dimension`) into one array. The basic behavior is same for examples
+    consisting of multiple arrays, i.e., corresponding arrays of all examples
+    are concatenated.
+
+    For instance, consider each example consists of two arrays ``(x, y)``.
+    Then, this function concatenates ``x`` 's into one array, and ``y`` 's
+    into another array, and returns a tuple of these two arrays. Another
+    example: consider each example is a dictionary of two entries whose keys
+    are ``'x'`` and ``'y'``, respectively, and values are arrays. Then, this
+    function concatenates ``x`` 's into one array, and ``y`` 's into another
+    array, and returns a dictionary with two entries ``x`` and ``y`` whose
+    values are the concatenated arrays.
+
+    When the arrays to concatenate have different shapes, the behavior depends
+    on the ``padding`` value. If ``padding`` is ``None`` (default), it raises
+    an error. Otherwise, it builds an array of the minimum shape that the
+    contents of all arrays can be substituted to. The padding value is then
+    used to the extra elements of the resulting arrays.
+
+    TODO(beam2d): Add an example.
+
+    Args:
+        batch (list): A list of examples. This is typically given by a dataset
+            iterator.
+        device (int): Device ID to which each array is sent. Negative value
+            indicates the host memory (CPU). If it is omitted, all arrays are
+            left in the original device.
+        padding: Scalar value for extra elements. If this is None (default),
+            an error is raised on shape mismatch. Otherwise, an array of
+            minimum dimensionalities that can accomodate all arrays is created,
+            and elements outside of the examples are padded by this value.
+
+    Returns:
+        Array, a tuple of arrays, or a dictionary of arrays. The type depends
+        on the type of each example in the batch.
+
+    """
+    if len(variables) == 0:
+        raise ValueError('No variables given')
+
+    if device is None:
+        def to_device(x):
+            return x
+    elif device < 0:
+        to_device = cuda.to_cpu
+    else:
+        to_device = lambda x: cuda.to_gpu(x, device)
+
+    first_elem = variables[0]
+
+    if isinstance(first_elem, tuple):
+        result = []
+        for i in six.moves.range(len(first_elem)):
+            result.append(to_device(_concat_variables(
+                [example[i] for example in variables])))
+
+        return tuple(result)
+
+    elif isinstance(first_elem, dict):
+        result = {}
+        for key in first_elem:
+            result[key] = to_device(_concat_variables(
+                [example[key] for example in variables]))
+
+        return result
+
+    else:
+        return to_device(_concat_variables(variables))
+
+
+def _concat_variables(variables):
+    xp = cuda.get_array_module(variables[0].data)
+    with cuda.get_device(variables[0].data):
+        return variable.Variable(
+            xp.concatenate([var.data for var in variables])
+        )
+
+
+class Extractor(extension.Extension):
+
+    """Trainer extension to extract features using a trained model.
+
+    This extension extracts features using a trained model by a given
+    extraction function.
+
+    Extractor has a structure to customize similar to that of
+    :class:`~chainer.training.StandardUpdater`. The main differences are:
+
+    - There are no optimizers in an evaluator. Instead, it holds links
+      to evaluate.
+    - An evaluation loop function is used instead of an update function.
+    - Preparation routine can be customized, which is called before each
+      evaluation. It can be used, e.g., to initialize the state of stateful
+      recurrent networks.
+
+    There are two ways to modify the evaluation behavior besides setting a
+    custom evaluation function. One is by setting a custom evaluation loop via
+    the ``eval_loop`` argument. The other is by inheriting this class and
+    overriding the :meth:`evaluate` method. In latter case, users have to
+    create and handle a reporter object manually. Users also have to copy the
+    iterators before using them, in order to reuse them at the next time of
+    evaluation.
+
+    This extension is called at the end of each epoch by default.
+
+    Args:
+        iterator: Dataset iterator for the validation dataset. It can also be
+            a dictionary of iterators. If this is just an iterator, the
+            iterator is registered by the name ``'main'``.
+        target: Link object or a dictionary of links to evaluate. If this is
+            just a link object, the link is registered by the name ``'main'``.
+        converter: Converter function to build input arrays.
+            :func:`~chainer.dataset.concat_examples` is used by default.
+        device: Device to which the training data is sent. Negative value
+            indicates the host memory (CPU).
+        eval_hook: Function to prepare for each evaluation process. It is
+            called at the beginning of the evaluation. The evaluator extension
+            object is passed at each call.
+        eval_func: Evaluation function called at each iteration. The target
+            link to evaluate as a callable is used by default.
+
+    Attributes:
+        converter: Converter function.
+        device: Device to which the training data is sent.
+        eval_hook: Function to prepare for each evaluation process.
+        eval_func: Evaluation function called at each iteration.
+
+    """
+    trigger = 1, 'epoch'
+    default_name = 'extraction'
+    priority = extension.PRIORITY_WRITER
+
+    def __init__(self, iterator, target, converter=convert.concat_examples,
+                 device=None, extract_hook=None, extract_func=None,
+                 merger=concat_variables):
+        if isinstance(iterator, iterator_module.Iterator):
+            iterator = {'main': iterator}
+        self._iterators = iterator
+
+        if isinstance(target, link.Link):
+            target = {'main': target}
+        self._targets = target
+
+        self.converter = converter
+        self.merger = merger
+        self.device = device
+        self.extract_hook = extract_hook
+        self.extract_func = extract_func
+        self.features = None
+
+    def get_iterator(self, name):
+        """Returns the iterator of the given name."""
+        return self._iterators[name]
+
+    def get_all_iterators(self):
+        """Returns a dictionary of all iterators."""
+        return dict(self._iterators)
+
+    def get_target(self, name):
+        """Returns the target link of the given name."""
+        return self._targets[name]
+
+    def get_all_targets(self):
+        """Returns a dictionary of all target links."""
+        return dict(self._targets)
+
+    def __call__(self, trainer=None):
+        """Executes the extractor extension.
+
+        Unlike usual extensions, this extension can be executed without passing
+        a trainer object. This extension reports the performance on validation
+        dataset using the :func:`~chainer.report` function. Thus, users can use
+        this extension independently from any trainer by manutally configuring
+        a :class:`~chainer.Reporter` object.
+
+        Args:
+            trainer (~chainer.training.Trainer): Trainer object that invokes
+                this extension. It can be omitted in case of calling this
+                extension manually.
+
+        """
+        self.features = self.extract()
+
+    def extract(self):
+        """Evaluates the model and returns a result dictionary.
+
+        This method runs the extraction loop over the dataset. It accumulates
+        the extracted features to :class:`~chainer.DictSummary` and
+        returns a dictionary whose values are means computed by the summary.
+
+        Users can override this method to customize the extraction routine.
+
+        Returns:
+            dict: Result dictionary. This dictionary is further reported via
+                :func:`~chainer.report` without specifying any observer.
+
+        """
+        iterator = self._iterators['main']
+        target = self._targets['main']
+        extract_func = self.extract_func or target
+
+        if self.extract_hook:
+            self.extract_hook(self)
+        it = copy.copy(iterator)
+
+        features = []
+        for batch in it:
+            in_arrays = self.converter(batch, self.device)
+            if isinstance(in_arrays, tuple):
+                in_vars = tuple(variable.Variable(x) for x in in_arrays)
+                features_batch = extract_func(*in_vars)
+            elif isinstance(in_arrays, dict):
+                in_vars = {key: variable.Variable(x)
+                           for key, x in six.iteritems(in_arrays)}
+                features_batch = extract_func(**in_vars)
+            else:
+                in_var = variable.Variable(in_arrays)
+                features_batch = extract_func(in_var)
+
+            features.append(features_batch)
+
+        return self.merger(features)

--- a/chainer/training/extensions/extractor.py
+++ b/chainer/training/extensions/extractor.py
@@ -13,43 +13,21 @@ from chainer import variable
 def concat_variables(variables, device=None):
     """Concatenates a list of variables into a single variable.
 
-    Dataset iterator yields a list of examples. If each example is an array,
-    this function concatenates them along the newly-inserted first axis (called
-    `batch dimension`) into one array. The basic behavior is same for examples
-    consisting of multiple arrays, i.e., corresponding arrays of all examples
-    are concatenated.
-
-    For instance, consider each example consists of two arrays ``(x, y)``.
-    Then, this function concatenates ``x`` 's into one array, and ``y`` 's
-    into another array, and returns a tuple of these two arrays. Another
-    example: consider each example is a dictionary of two entries whose keys
-    are ``'x'`` and ``'y'``, respectively, and values are arrays. Then, this
-    function concatenates ``x`` 's into one array, and ``y`` 's into another
-    array, and returns a dictionary with two entries ``x`` and ``y`` whose
-    values are the concatenated arrays.
-
-    When the arrays to concatenate have different shapes, the behavior depends
-    on the ``padding`` value. If ``padding`` is ``None`` (default), it raises
-    an error. Otherwise, it builds an array of the minimum shape that the
-    contents of all arrays can be substituted to. The padding value is then
-    used to the extra elements of the resulting arrays.
-
-    TODO(beam2d): Add an example.
+    The forward operation of a model yields a variable, tuple of variables
+    or a dict of variables for each batch. This function concatenates a list
+    of such variables to a single variable, tuple of varialbes or dict of
+    variables, respectively.
 
     Args:
-        batch (list): A list of examples. This is typically given by a dataset
-            iterator.
+        variables (list): A list of variables, list of tuples of variables
+            or a list of dicts of variables.
         device (int): Device ID to which each array is sent. Negative value
             indicates the host memory (CPU). If it is omitted, all arrays are
             left in the original device.
-        padding: Scalar value for extra elements. If this is None (default),
-            an error is raised on shape mismatch. Otherwise, an array of
-            minimum dimensionalities that can accomodate all arrays is created,
-            and elements outside of the examples are padded by this value.
 
     Returns:
-        Array, a tuple of arrays, or a dictionary of arrays. The type depends
-        on the type of each example in the batch.
+        Variable, a tuple of variables, or a dictionary of variables. The type
+        depends on the type of each example in the variables list.
 
     """
     if len(variables) == 0:
@@ -101,47 +79,32 @@ class Extractor(extension.Extension):
     extraction function.
 
     Extractor has a structure to customize similar to that of
-    :class:`~chainer.training.StandardUpdater`. The main differences are:
-
-    - There are no optimizers in an evaluator. Instead, it holds links
-      to evaluate.
-    - An evaluation loop function is used instead of an update function.
-    - Preparation routine can be customized, which is called before each
-      evaluation. It can be used, e.g., to initialize the state of stateful
-      recurrent networks.
-
-    There are two ways to modify the evaluation behavior besides setting a
-    custom evaluation function. One is by setting a custom evaluation loop via
-    the ``eval_loop`` argument. The other is by inheriting this class and
-    overriding the :meth:`evaluate` method. In latter case, users have to
-    create and handle a reporter object manually. Users also have to copy the
-    iterators before using them, in order to reuse them at the next time of
-    evaluation.
-
-    This extension is called at the end of each epoch by default.
+    :class:`~chainer.training.extensions.Evaluator`.
 
     Args:
-        iterator: Dataset iterator for the validation dataset. It can also be
+        iterator: Dataset iterator for extracting features. It can also be
             a dictionary of iterators. If this is just an iterator, the
             iterator is registered by the name ``'main'``.
-        target: Link object or a dictionary of links to evaluate. If this is
+        target: Link object or a dictionary of links to process. If this is
             just a link object, the link is registered by the name ``'main'``.
         converter: Converter function to build input arrays.
             :func:`~chainer.dataset.concat_examples` is used by default.
         device: Device to which the training data is sent. Negative value
             indicates the host memory (CPU).
-        eval_hook: Function to prepare for each evaluation process. It is
-            called at the beginning of the evaluation. The evaluator extension
+        extract_hook: Function to prepare for each extraction process. It is
+            called at the beginning of the extraction. The evxtractor extension
             object is passed at each call.
-        eval_func: Evaluation function called at each iteration. The target
-            link to evaluate as a callable is used by default.
+        extract_func: extraction function called at each iteration. The target
+            link to extract as a callable is used by default.
+        merger: Merger function to build output variable of features. By
+            default it concatenates all output features along the batch axis.
 
     Attributes:
         converter: Converter function.
         device: Device to which the training data is sent.
-        eval_hook: Function to prepare for each evaluation process.
-        eval_func: Evaluation function called at each iteration.
-
+        extract_hook: Function to prepare for each extraction process.
+        extract_func: Extraction function called at each iteration.
+        features: The extracted features. Created after calling the extension.
     """
     trigger = 1, 'epoch'
     default_name = 'extraction'
@@ -185,10 +148,7 @@ class Extractor(extension.Extension):
         """Executes the extractor extension.
 
         Unlike usual extensions, this extension can be executed without passing
-        a trainer object. This extension reports the performance on validation
-        dataset using the :func:`~chainer.report` function. Thus, users can use
-        this extension independently from any trainer by manutally configuring
-        a :class:`~chainer.Reporter` object.
+        a trainer object.
 
         Args:
             trainer (~chainer.training.Trainer): Trainer object that invokes
@@ -197,19 +157,18 @@ class Extractor(extension.Extension):
 
         """
         self.features = self.extract()
+        return self.features
 
     def extract(self):
-        """Evaluates the model and returns a result dictionary.
+        """Extractes features using the target model.
 
         This method runs the extraction loop over the dataset. It accumulates
-        the extracted features to :class:`~chainer.DictSummary` and
-        returns a dictionary whose values are means computed by the summary.
+        the extracted features to a :class:`~chainer.Variable`.
 
         Users can override this method to customize the extraction routine.
 
         Returns:
-            dict: Result dictionary. This dictionary is further reported via
-                :func:`~chainer.report` without specifying any observer.
+            dict: Features variable.
 
         """
         iterator = self._iterators['main']
@@ -224,14 +183,15 @@ class Extractor(extension.Extension):
         for batch in it:
             in_arrays = self.converter(batch, self.device)
             if isinstance(in_arrays, tuple):
-                in_vars = tuple(variable.Variable(x) for x in in_arrays)
+                in_vars = tuple(variable.Variable(x, volatile='on')
+                                for x in in_arrays)
                 features_batch = extract_func(*in_vars)
             elif isinstance(in_arrays, dict):
-                in_vars = {key: variable.Variable(x)
+                in_vars = {key: variable.Variable(x, volatile='on')
                            for key, x in six.iteritems(in_arrays)}
                 features_batch = extract_func(**in_vars)
             else:
-                in_var = variable.Variable(in_arrays)
+                in_var = variable.Variable(in_arrays, volatile='on')
                 features_batch = extract_func(in_var)
 
             features.append(features_batch)

--- a/examples/mnist/extract_mnist.py
+++ b/examples/mnist/extract_mnist.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import argparse
+import numpy
+
+import chainer
+import chainer.functions as F
+import chainer.links as L
+from chainer.training import extensions
+
+import train_mnist
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Chainer example: MNIST')
+    parser.add_argument('--batchsize', '-b', type=int, default=100,
+                        help='Number of images in each mini batch')
+    parser.add_argument('--gpu', '-g', type=int, default=-1,
+                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--out', '-o', default='result',
+                        help='Directory to output the result')
+    parser.add_argument('--unit', '-u', type=int, default=1000,
+                        help='Number of units')
+    parser.add_argument('model', help='Load the model from snapshot')
+    args = parser.parse_args()
+
+    print('GPU: {}'.format(args.gpu))
+    print('# unit: {}'.format(args.unit))
+    print('# Minibatch-size: {}'.format(args.batchsize))
+    print('')
+
+    # Set up a neural network to load trained model into.
+    model = train_mnist.MLP(784, args.unit, 10)
+
+    # Load the model from a snapshot
+    chainer.serializers.load_npz(args.model, model)
+
+    if args.gpu >= 0:
+        chainer.cuda.get_device(args.gpu).use()  # Make a specified GPU current
+        model.to_gpu()  # Copy the model to the GPU
+
+    # Load the MNIST dataset
+    train, _ = chainer.datasets.get_mnist(withlabel=False)
+    dataset_iter = chainer.iterators.SerialIterator(
+        train,
+        args.batchsize,
+        repeat=False,
+        shuffle=False
+    )
+
+    # Evaluate the model with the test dataset for each epoch
+    extractor = extensions.Extractor(dataset_iter, model, device=args.gpu)
+
+    # Run the extraction
+    features = extractor()
+    numpy.save(
+        'mnist_features.npy',
+        chainer.cuda.to_cpu(features.data)
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/mnist/extract_mnist.py
+++ b/examples/mnist/extract_mnist.py
@@ -4,8 +4,6 @@ import argparse
 import numpy
 
 import chainer
-import chainer.functions as F
-import chainer.links as L
 from chainer.training import extensions
 
 import train_mnist

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -80,6 +80,11 @@ def main():
     # Take a snapshot at each epoch
     trainer.extend(extensions.snapshot())
 
+    # Take a snapshot of the model at the last epoch
+    trainer.extend(extensions.snapshot_object(
+        model.predictor, 'model_iter_{.updater.iteration}'),
+        trigger=(args.epoch, 'epoch'))
+
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())
 


### PR DESCRIPTION
This pull request adds an `Extractor` extension. This extension can be used to extract features calculated using a trained model. Similarly to the `Evaluator` extension, it can be run standalone without a `Trainer`.

An example on the `mnist` dataset is given.
This is a resubmission of #1372 
