### PR TITLE
Add stack function missed in Chainer reference.

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -135,6 +135,10 @@ split_axis
 ~~~~~~~~~~
 .. autofunction:: split_axis
 
+stack
+~~~~~
+.. autofunction:: stack
+
 swapaxes
 ~~~~~~~~
 .. autofunction:: swapaxes


### PR DESCRIPTION
This PR adds `stack` function to Chainer reference, it suppose to be missed in #1262 .
