### PR TITLE
[Experimental] patch toward out-of-core training on GPU

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -192,11 +192,13 @@ Actual: {0}'''.format(type(data))
 
     def to_cpu(self):
         """Copies the data and gradient arrays to CPU."""
+        # anaruse: debug
+        # print('[chainer/variable.py, to_cpu()] var:{}'.format(self))
         self.data = cuda.to_cpu(self.data)
         if self._grad is not None:
             self._grad = cuda.to_cpu(self._grad)
 
-    def to_gpu(self, device=None):
+    def to_gpu(self, device=None, stream=None):
         """Copies the data and gradient arrays to specified GPU.
 
         Args:
@@ -204,10 +206,20 @@ Actual: {0}'''.format(type(data))
                 used.
 
         """
+        # anaruse: debug
+        # print('[chainer/variable.py, to_gpu()] var:{}'.format(self))
         with cuda.get_device(device):
-            self.data = cuda.to_gpu(self.data)
+            self.data = cuda.to_gpu(self.data, stream=stream)
             if self._grad is not None:
-                self._grad = cuda.to_gpu(self._grad)
+                self._grad = cuda.to_gpu(self._grad, stream=stream)
+
+    def to_swap(self, stream=None):
+        """Move the data and gradient arrays on GPU/CPU to SWAP memory."""
+        # anaruse: debug
+        # print('[chainer/variable.py, to_swap()] var:{}, stream:{}'.format(self, stream))
+        self.data = cuda.to_swap(self.data, stream=stream)
+        if self._grad is not None:
+            self._grad = cuda.to_swap(self._grad, stream=stream)
 
     def zerograd(self):
         """Initializes the gradient array by zeros."""

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -71,7 +71,7 @@ cdef class ndarray:
         readonly ndarray base
 
 
-    def __init__(self, shape, dtype=float, memptr=None):
+    def __init__(self, shape, dtype=float, memptr=None, bint useSwapMemory=False):
         cdef Py_ssize_t size
         self._shape = internal.get_size(shape)
         ndim = self._shape.size()
@@ -83,8 +83,11 @@ cdef class ndarray:
         self._strides = internal.get_contiguous_strides(
             self._shape, self.itemsize)
 
+        # anaruse: debug
+        # print('[cupy/core/core.pyx: __init__()] useSwapMemory:{}'.format(useSwapMemory))
+
         if memptr is None:
-            self.data = memory.alloc(self.size * self.dtype.itemsize)
+            self.data = memory.alloc(self.size * self.dtype.itemsize, useSwapMemory)
         else:
             self.data = memptr
         self.base = None
@@ -92,6 +95,9 @@ cdef class ndarray:
         self._c_contiguous = True
         self._update_f_contiguity()
 
+        # anaruse: debug
+        # print('[cupy/core/core.pyx: __init__()] size:{}, ptr:{}, dev:{}, _swap:{}'
+        #       .format(self.data.mem.size, self.data.mem.ptr, self.data.mem.device, self.data.mem._swap))
 
     # The definition order of attributes and methods are borrowed from the
     # order of documentation at the following NumPy document.
@@ -1397,26 +1403,49 @@ cdef _argmax = create_reduction_func(
 # Array creation routines
 # -----------------------------------------------------------------------------
 
-cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
+cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0, stream=None, useSwapMemory=False):
     # TODO(beam2d): Support order and subok options
     cdef Py_ssize_t nvidem
     cdef ndarray a
-    if isinstance(obj, ndarray):
-        if dtype is None:
-            dtype = obj.dtype
-        a = obj.astype(dtype, copy)
-
-        ndim = a._shape.size()
-        if ndmin > ndim:
-            a.shape = (1,) * (ndmin - ndim) + a.shape
+    # anaruse: debug
+    # print('[cupy/core/core.pyx: array()] stream:{}, useSwapMemory:{}'.format(stream, useSwapMemory))
+    if isinstance(obj, ndarray) and obj.data.mem._swap is True:
+        # anaruse: debug
+        # print('[cupy/core/core.pyx: array()] obj.data is on SWAP memory')
+        a = ndarray(obj.shape, obj.dtype, useSwapMemory=useSwapMemory)
+        if stream is None:
+            a.data.copy_from_device(obj.data, obj.nbytes)
+        else:
+            a.data.copy_from_device_async(obj.data, obj.nbytes, stream)
         return a
+    elif isinstance(obj, ndarray):
+        # anaruse: debug
+        # print('[cupy/core/core.pyx: array()] obj.data is on GPU')
+        if useSwapMemory is False:
+            if dtype is None:
+                dtype = obj.dtype
+            a = obj.astype(dtype, copy)
+
+            ndim = a._shape.size()
+            if ndmin > ndim:
+                a.shape = (1,) * (ndmin - ndim) + a.shape
+            return a
+        else:
+            a = ndarray(obj.shape, obj.dtype, useSwapMemory=True)
+            if stream is None:
+                a.data.copy_from_device(obj.data, obj.nbytes)
+            else:
+                a.data.copy_from_device_async(obj.data, obj.nbytes, stream)
+            return a
     else:
+        # anaruse: debug
+        # print('[cupy/core/core.pyx: array()] obj.data is on CPU')
         a_cpu = numpy.array(obj, dtype=dtype, copy=False, ndmin=ndmin)
         if a_cpu.dtype.char not in '?bhilqBHILQefd':
             raise ValueError('Unsupported dtype %s' % a_cpu.dtype)
         if a_cpu.ndim > 0:
             a_cpu = numpy.ascontiguousarray(a_cpu)
-        a = ndarray(a_cpu.shape, dtype=a_cpu.dtype)
+        a = ndarray(a_cpu.shape, dtype=a_cpu.dtype, useSwapMemory=useSwapMemory)
         a.data.copy_from_host(a_cpu.ctypes.data_as(ctypes.c_void_p), a.nbytes)
         if a_cpu.dtype == a.dtype:
             return a

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -2,7 +2,7 @@ import cupy
 from cupy import core
 
 
-def array(obj, dtype=None, copy=True, ndmin=0):
+def array(obj, dtype=None, copy=True, ndmin=0, stream=None, useSwapMemory=False):
     """Creates an array on the current device.
 
     This function currently does not support the ``order`` and ``subok``
@@ -24,7 +24,7 @@ def array(obj, dtype=None, copy=True, ndmin=0):
 
     """
     # TODO(beam2d): Support order and subok options
-    return core.array(obj, dtype, copy, ndmin)
+    return core.array(obj, dtype, copy, ndmin, stream, useSwapMemory)
 
 
 def asarray(a, dtype=None):

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -162,7 +162,15 @@ int cudaMalloc(void** devPtr, size_t size) {
     return 0;
 }
 
+int cudaMallocHost(void** devPtr, size_t size) {
+    return 0;
+}
+
 int cudaFree(void* devPtr) {
+    return 0;
+}
+
+int cudaFreeHost(void* devPtr) {
     return 0;
 }
 

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -6,6 +6,7 @@ cdef class Memory:
         public device.Device device
         public size_t ptr
         public Py_ssize_t size
+        public bint _swap
 
 
 cdef class MemoryPointer:
@@ -27,7 +28,7 @@ cdef class MemoryPointer:
     cpdef memset_async(self, int value, size_t size, stream)
 
 
-cpdef MemoryPointer alloc(Py_ssize_t size)
+cpdef MemoryPointer alloc(Py_ssize_t size, bint useSwapMemory=*)
 
 
 cpdef set_allocator(allocator=*)
@@ -51,7 +52,7 @@ cdef class SingleDeviceMemoryPool:
         object _weakref
         Py_ssize_t _allocation_unit_size
 
-    cpdef MemoryPointer malloc(self, Py_ssize_t size)
+    cpdef MemoryPointer malloc(self, Py_ssize_t size, bint useSwapMemory=*)
     cpdef free(self, size_t ptr, Py_ssize_t size)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
@@ -62,6 +63,6 @@ cdef class MemoryPool:
     cdef:
         object _pools
 
-    cpdef MemoryPointer malloc(self, Py_ssize_t size)
+    cpdef MemoryPointer malloc(self, Py_ssize_t size, bint useSwapMemory=*)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -56,7 +56,9 @@ cdef extern from "cupy_cuda.h":
 
     # Memory management
     int cudaMalloc(void** devPtr, size_t size) nogil
+    int cudaMallocHost(void** ptr, size_t size) nogil
     int cudaFree(void* devPtr) nogil
+    int cudaFreeHost(void* ptr) nogil
     int cudaMemGetInfo(size_t* free, size_t* total) nogil
     int cudaMemcpy(void* dst, const void* src, size_t count,
                    MemoryKind kind) nogil
@@ -182,9 +184,23 @@ cpdef size_t malloc(size_t size) except *:
     return <size_t>ptr
 
 
+cpdef size_t mallocHost(size_t size) except *:
+    cdef void* ptrHost
+    with nogil:
+        status = cudaMallocHost(&ptrHost, size)
+    check_status(status)
+    return <size_t>ptrHost
+
+
 cpdef free(size_t ptr):
     with nogil:
         status = cudaFree(<void*>ptr)
+    check_status(status)
+
+
+cpdef freeHost(size_t ptrHost):
+    with nogil:
+        status = cudaFreeHost(<void*>ptrHost)
     check_status(status)
 
 


### PR DESCRIPTION
I've implemented a method "to_swap()" that allow you to swap-out any cupy data on GPU memory to page-locked memory on CPU (so called pinned memory).  You can use "to_gpu()" to swap-in the data on pinned memory back to GPU memory.
You may wonder what is difference of "to_swap()" to "to_cpu()".  The key difference is whether asynchronous data transfer is naturally available or not.  As you know, "to_cpu()" moves (and transforms as well?)  cupy data on GPU to numpy data on CPU.  Considering numy data is typically on standard CPU memory, in other words, page-able memory, you have almost no chance to see real asynchronous data transfer with "to_cpu()" unless you change numpy's memory allocator.  However, if you use this "to_swap()", you can move data asynchronously and accordingly you may run data transfer and GPU kernels in parallel (that is my goal).
This is kind of experimental patch, so any feedback would be appreciated.
BR.