### PR TITLE
Check type of axis in initializer of concat function

### DIFF
--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -11,6 +11,9 @@ class Concat(function.Function):
 
     # concat along the channel dimension by default
     def __init__(self, axis=1):
+        if not isinstance(axis, int):
+            raise TypeError('axis must be int')
+
         self.axis = axis
 
     def check_type_forward(self, in_types):

--- a/tests/chainer_tests/functions_tests/array_tests/test_concat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_concat.py
@@ -75,4 +75,11 @@ class TestConcat(unittest.TestCase):
                             axis=self.axis)
 
 
+class TestConcatInvalidAxisType(unittest.TestCase):
+
+    def test_invlaid_axis_type(self):
+        with self.assertRaises(TypeError):
+            functions.Concat('a')
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
I fixed concat function to check its argument.