### PR TITLE
Test use_cudnn without cuDNN

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -50,7 +50,7 @@ class TestLogSoftmax(unittest.TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
@@ -69,7 +69,7 @@ class TestLogSoftmax(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(10)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -46,7 +46,7 @@ class TestReLU(unittest.TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
@@ -65,12 +65,12 @@ class TestReLU(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_non_contiguous(self):
         self.check_backward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -37,12 +37,12 @@ class TestSigmoid(unittest.TestCase):
         testing.assert_allclose(
             y_expect.data, y.data, **self.check_forward_options)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), True)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
         self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)), True)
@@ -61,12 +61,12 @@ class TestSigmoid(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_non_contiguous(self):
         self.check_backward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -51,7 +51,7 @@ class TestSoftmax(unittest.TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
@@ -70,7 +70,7 @@ class TestSoftmax(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(10)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -33,12 +33,12 @@ class TestTanh(unittest.TestCase):
         y_expect = functions.tanh(chainer.Variable(self.x))
         testing.assert_allclose(y_expect.data, y.data)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), True)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
         self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)), True)
@@ -57,12 +57,12 @@ class TestTanh(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_non_contiguous(self):
         self.check_backward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -53,7 +53,7 @@ class TestConvolution2DFunction(unittest.TestCase):
             self.check_backward_options = {
                 'eps': 2 ** -3, 'atol': 1e-3, 'rtol': 1e-2}
 
-    @attr.cudnn
+    @attr.gpu
     def test_forward_consistency(self, nobias=False):
         x_cpu = chainer.Variable(self.x)
         W_cpu = chainer.Variable(self.W)
@@ -114,13 +114,13 @@ class TestConvolution2DFunction(unittest.TestCase):
     def test_backward_cpu_nobias(self):
         self.check_backward(self.x, self.W, None, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             cuda.to_gpu(self.b), cuda.to_gpu(self.gy))
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_nobias(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -68,7 +68,7 @@ class TestDeconvolution2DFunction(unittest.TestCase):
             self.check_backward_options = {
                 'eps': 2**-3, 'atol': 1e-3, 'rtol': 1e-2}
 
-    @attr.cudnn
+    @attr.gpu
     def test_forward_consistency(self):
         x_cpu = chainer.Variable(self.x)
         W_cpu = chainer.Variable(self.W)
@@ -123,7 +123,7 @@ class TestDeconvolution2DFunction(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.W, self.b, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(10)
     def test_backward_gpu(self):
         b = None if self.b is None else cuda.to_gpu(self.b)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -62,7 +62,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
@@ -85,7 +85,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -81,7 +81,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
@@ -101,7 +101,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
@@ -147,7 +147,7 @@ class TestSoftmaxCrossEntropyValueCheck(unittest.TestCase):
     def test_value_check_gpu(self):
         self.check_value_check(self.x, self.t, False)
 
-    @attr.cudnn
+    @attr.gpu
     def test_value_check_gpu_cudnn(self):
         self.check_value_check(cuda.to_gpu(self.x), cuda.to_gpu(self.t), True)
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -51,7 +51,7 @@ class TestAveragePooling2D(unittest.TestCase):
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
@@ -70,7 +70,7 @@ class TestAveragePooling2D(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -65,7 +65,7 @@ class TestMaxPooling2D(unittest.TestCase):
         x = chainer.Variable(x_data)
         functions.max_pooling_2d(x, 6, stride=6, pad=0)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
@@ -86,7 +86,7 @@ class TestMaxPooling2D(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -68,7 +68,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         self.check_forward(self.x)
         self.check_forward_ones(self.one)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
@@ -91,7 +91,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -52,7 +52,7 @@ class TestConvolution2D(unittest.TestCase):
 
         testing.assert_allclose(y_cpu.data, y_gpu.data.get())
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_consistency(self):
         self.check_forward_consistency()
@@ -71,7 +71,7 @@ class TestConvolution2D(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.link.to_gpu()

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -66,7 +66,7 @@ class TestDeconvolution2D(unittest.TestCase):
 
         testing.assert_allclose(y_cpu.data, y_gpu.data.get())
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_forward_consistency(self):
         self.link.use_cudnn = self.use_cudnn
@@ -84,7 +84,7 @@ class TestDeconvolution2D(unittest.TestCase):
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @attr.cudnn
+    @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.link.use_cudnn = self.use_cudnn


### PR DESCRIPTION
The default value of `use_cudnn` is `True`.
When `use_cudnn` options is `True`, we expect that functions can be used without cuDNN.
