### PR TITLE
Fix async to cpu

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -226,7 +226,7 @@ cdef class MemoryPointer:
         """
         if size > 0:
             runtime.memcpyAsync(mem.value, self.ptr, size,
-                                runtime.memcpyDeviceToHost, stream)
+                                runtime.memcpyDeviceToHost, stream.ptr)
 
     cpdef memset(self, int value, size_t size):
         """Fills a memory sequence by constant byte value.
@@ -249,7 +249,7 @@ cdef class MemoryPointer:
 
         """
         if size > 0:
-            runtime.memsetAsync(self.ptr, value, size, stream)
+            runtime.memsetAsync(self.ptr, value, size, stream.ptr)
 
 
 cpdef MemoryPointer _malloc(Py_ssize_t size):

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -203,8 +203,9 @@ cpdef memcpy(size_t dst, size_t src, size_t size, int kind):
 
 cpdef memcpyAsync(size_t dst, size_t src, size_t size, int kind,
                   size_t stream):
-    status = cudaMemcpyAsync(
-        <void*>dst, <void*>src, size, <MemoryKind>kind, <Stream>stream)
+    with nogil:
+        status = cudaMemcpyAsync(
+            <void*>dst, <void*>src, size, <MemoryKind>kind, <Stream>stream)
     check_status(status)
 
 
@@ -268,7 +269,8 @@ cpdef streamDestroy(size_t stream):
 
 
 cpdef streamSynchronize(size_t stream):
-    status = cudaStreamSynchronize(<Stream>stream)
+    with nogil:
+        status = cudaStreamSynchronize(<Stream>stream)
     check_status(status)
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -36,10 +36,10 @@ class TestArrayGet(unittest.TestCase):
     def test_contiguous_array_stream(self, dtype):
         def contiguous_array(xp):
             return testing.shaped_arange((3,), xp=xp, dtype=dtype)
-        self.check_get(contiguous_array, self.stream.ptr)
+        self.check_get(contiguous_array, self.stream)
 
     @testing.for_all_dtypes()
     def test_non_contiguous_array_stream(self, dtype):
         def non_contiguous_array(xp):
             return testing.shaped_arange((3,), xp=xp, dtype=dtype)[0::2]
-        self.check_get(non_contiguous_array, self.stream.ptr)
+        self.check_get(non_contiguous_array, self.stream)

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -13,12 +13,15 @@ class TestArrayGet(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        self.stream = cuda.Stream()
+        self.stream = cuda.Stream(null=True)
 
     def check_get(self, f, stream):
         a_gpu = f(cupy)
-        a_cpu = f(numpy)
-        np_testing.assert_array_equal(a_gpu.get(stream), a_cpu)
+        a_cpu = a_gpu.get(stream)
+        if stream:
+            stream.synchronize()
+        b_cpu = f(numpy)
+        np_testing.assert_array_equal(a_cpu, b_cpu)
 
     @testing.for_all_dtypes()
     def test_contiguous_array(self, dtype):

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -1,0 +1,24 @@
+import unittest
+
+from chainer import cuda
+from chainer.testing import attr
+from cupy import testing
+
+
+class TestStream(unittest.TestCase):
+
+    @attr.gpu
+    def test_get_and_add_callback(self):
+        N = 100
+        cupy_arrays = [testing.shaped_random((2, 3)) for _ in range(N)]
+
+        stream = cuda.Stream(null=True)
+        out = []
+        for i in range(N):
+            numpy_array = cupy_arrays[i].get(stream=stream)
+            stream.add_callback(
+                lambda _, __, t: out.append(t[0]),
+                (i, numpy_array))
+
+        stream.synchronize()
+        self.assertEqual(out, list(range(N)))


### PR DESCRIPTION
This PR fixes the problem that `cupy.ndarray.get` or `cuda.to_gpu` fails when we give `stream` parameter. I worked with @okuta san.