### PR TITLE
image_dataset.py doesn't work if an input image is gray scale

### DIFF
--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -59,7 +59,8 @@ class ImageDataset(dataset_mixin.DatasetMixin):
         path = os.path.join(self._root, self._paths[i])
         with Image.open(path) as f:
             image = numpy.asarray(f, dtype=self._dtype)
-        if len(image.shape) == 2:
+        if image.ndim == 2:
+            # image is greyscale
             image = image[:, :, numpy.newaxis]
         return image.transpose(2, 0, 1)
 
@@ -121,7 +122,8 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
         full_path = os.path.join(self._root, path)
         with Image.open(full_path) as f:
             image = numpy.asarray(f, dtype=self._dtype)
-        if len(image.shape) == 2:
+        if image.ndim == 2:
+            # image is greyscale
             image = image[:, :, numpy.newaxis]
         label = numpy.array(int_label, dtype=self._label_dtype)
         return image.transpose(2, 0, 1), label

--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -59,6 +59,8 @@ class ImageDataset(dataset_mixin.DatasetMixin):
         path = os.path.join(self._root, self._paths[i])
         with Image.open(path) as f:
             image = numpy.asarray(f, dtype=self._dtype)
+        if len(image.shape) == 2:
+            image = image[:, :, numpy.newaxis]
         return image.transpose(2, 0, 1)
 
 
@@ -118,7 +120,9 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
         path, int_label = self._pairs[i]
         full_path = os.path.join(self._root, path)
         with Image.open(full_path) as f:
-            image = numpy.asarray(f.convert('RGB'), dtype=self._dtype)
+            image = numpy.asarray(f, dtype=self._dtype)
+        if len(image.shape) == 2:
+            image = image[:, :, numpy.newaxis]
         label = numpy.array(int_label, dtype=self._label_dtype)
         return image.transpose(2, 0, 1), label
 

--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -118,7 +118,7 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
         path, int_label = self._pairs[i]
         full_path = os.path.join(self._root, path)
         with Image.open(full_path) as f:
-            image = numpy.asarray(f, dtype=self._dtype)
+            image = numpy.asarray(f.convert('RGB'), dtype=self._dtype)
         label = numpy.array(int_label, dtype=self._label_dtype)
         return image.transpose(2, 0, 1), label
 

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -2,7 +2,7 @@
 """Example code of learning a large scale convnet from ILSVRC2012 dataset.
 
 Prerequisite: To run this example, crop the center of ILSVRC2012 training and
-validation images, scale them to 256x256 and convert them to color, and make
+validation images, scale them to 256x256 and convert them to RGB, and make
 two lists of space-separated CSV whose first column is full path to image and
 second column is zero-origin label (this format is same as that used by Caffe's
 ImageDataLayer).

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -2,9 +2,10 @@
 """Example code of learning a large scale convnet from ILSVRC2012 dataset.
 
 Prerequisite: To run this example, crop the center of ILSVRC2012 training and
-validation images and scale them to 256x256, and make two lists of space-
-separated CSV whose first column is full path to image and second column is
-zero-origin label (this format is same as that used by Caffe's ImageDataLayer).
+validation images, scale them to 256x256 and convert them to color, and make
+two lists of space-separated CSV whose first column is full path to image and
+second column is zero-origin label (this format is same as that used by Caffe's
+ImageDataLayer).
 
 """
 from __future__ import print_function


### PR DESCRIPTION
If the image is gray scale, an error, "ValueError: axes don't match array" will occur in line 123.