### PR TITLE
snapshot and snapshot_object extension accept trigger

### DIFF
--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -25,9 +25,11 @@ def snapshot_object(target, filename, savefun=npz.save_npz,
             ``'snapshot_10000'`` at the 10,000th iteration.
         savefun: Function to save the object. It takes two arguments: the
             output file path and the object to serialize.
-        trigger: Trigger that decides when to take snapshot. If it is a tuple
-            in the form ``<int>, 'epoch'`` or ``<int>, 'iteration'``, it is
-            passed to :class:`IntervalTrigger`.
+        trigger: Trigger that decides when to take snapshot. It can be either
+            an already built trigger object (i.e., a callable object that
+            accepts a trainer object and returns a bool value), or a tuple in
+            the form ``<int>, 'epoch'`` or ``<int>, 'iteration'``. In latter
+            case, the tuple is passed to IntervalTrigger.
 
     Returns:
         An extension function.
@@ -64,9 +66,11 @@ def snapshot(savefun=npz.save_npz,
         filename (str): Name of the file into which the trainer is serialized.
             It can be a format string, where the trainer object is passed to
             the :meth:`str.format` method.
-        trigger: Trigger that decides when to take snapshot. If it is a tuple
-            in the form ``<int>, 'epoch'`` or ``<int>, 'iteration'``, it is
-            passed to :class:`IntervalTrigger`.
+        trigger: Trigger that decides when to take snapshot. It can be either
+            an already built trigger object (i.e., a callable object that
+            accepts a trainer object and returns a bool value), or a tuple in
+            the form ``<int>, 'epoch'`` or ``<int>, 'iteration'``. In latter
+            case, the tuple is passed to IntervalTrigger.
 
     """
     @extension.make_extension(trigger=trigger, priority=-100)

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -6,7 +6,8 @@ from chainer.serializers import npz
 from chainer.training import extension
 
 
-def snapshot_object(target, filename, savefun=npz.save_npz):
+def snapshot_object(target, filename, savefun=npz.save_npz,
+                    trigger=(1, 'epoch')):
     """Returns a trainer extension to take snapshots of a given object.
 
     This extension serializes the given object and saves it to the output
@@ -24,12 +25,15 @@ def snapshot_object(target, filename, savefun=npz.save_npz):
             ``'snapshot_10000'`` at the 10,000th iteration.
         savefun: Function to save the object. It takes two arguments: the
             output file path and the object to serialize.
+        trigger: Trigger that decides when to take snapshot. If it is a tuple
+            in the form ``<int>, 'epoch'`` or ``<int>, 'iteration'``, it is
+            passed to :class:`IntervalTrigger`.
 
     Returns:
         An extension function.
 
     """
-    @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
+    @extension.make_extension(trigger=trigger, priority=-100)
     def snapshot_object(trainer):
         _snapshot_object(trainer, target, filename.format(trainer), savefun)
 
@@ -37,7 +41,8 @@ def snapshot_object(target, filename, savefun=npz.save_npz):
 
 
 def snapshot(savefun=npz.save_npz,
-             filename='snapshot_iter_{.updater.iteration}'):
+             filename='snapshot_iter_{.updater.iteration}',
+             trigger=(1, 'epoch')):
     """Returns a trainer extension to take snapshots of the trainer.
 
     This extension serializes the trainer object and saves it to the output
@@ -59,9 +64,12 @@ def snapshot(savefun=npz.save_npz,
         filename (str): Name of the file into which the trainer is serialized.
             It can be a format string, where the trainer object is passed to
             the :meth:`str.format` method.
+        trigger: Trigger that decides when to take snapshot. If it is a tuple
+            in the form ``<int>, 'epoch'`` or ``<int>, 'iteration'``, it is
+            passed to :class:`IntervalTrigger`.
 
     """
-    @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
+    @extension.make_extension(trigger=trigger, priority=-100)
     def snapshot(trainer):
         _snapshot_object(trainer, trainer, filename.format(trainer), savefun)
 

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
@@ -4,11 +4,14 @@ import mock
 
 from chainer import testing
 from chainer.training import extensions
+from chainer.training import trigger
 
 
 @testing.parameterize(
     {'trigger': ('epoch', 2)},
     {'trigger': ('iteration', 10)},
+    {'trigger': trigger.IntervalTrigger(5, 'epoch')},
+    {'trigger': trigger.IntervalTrigger(20, 'iteration')},
 )
 class TestSnapshotObject(unittest.TestCase):
 
@@ -22,6 +25,8 @@ class TestSnapshotObject(unittest.TestCase):
 @testing.parameterize(
     {'trigger': ('epoch', 2)},
     {'trigger': ('iteration', 10)},
+    {'trigger': trigger.IntervalTrigger(5, 'epoch')},
+    {'trigger': trigger.IntervalTrigger(20, 'iteration')},
 )
 class TestSnapshot(unittest.TestCase):
 

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
@@ -1,0 +1,33 @@
+import unittest
+
+import mock
+
+from chainer import testing
+from chainer.training import extensions
+
+
+@testing.parameterize(
+    {'trigger': ('epoch', 2)},
+    {'trigger': ('iteration', 10)},
+)
+class TestSnapshotObject(unittest.TestCase):
+
+    def test_trigger(self):
+        target = mock.MagicMock()
+        snapshot_object = extensions.snapshot_object(target, 'myfile.dat',
+                                                     trigger=self.trigger)
+        self.assertEqual(snapshot_object.trigger, self.trigger)
+
+
+@testing.parameterize(
+    {'trigger': ('epoch', 2)},
+    {'trigger': ('iteration', 10)},
+)
+class TestSnapshot(unittest.TestCase):
+
+    def test_trigger(self):
+        snapshot = extensions.snapshot(trigger=self.trigger)
+        self.assertEqual(snapshot.trigger, self.trigger)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
Separated from #1400 
`snapshot` accepts trigger such as `trigger=(10, 'epoch')` and `MinValueTrigger` in #1400.
