### PR TITLE
Update ParallelUpdater to enable CPU execution

### DIFF
--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -250,10 +250,10 @@ class ParallelUpdater(StandardUpdater):
             models = {'main': optimizer.target}
             for name in names:
                 model = optimizer.target.copy()
-                if devices[name] is not None and devices[name] >= 0:
+                if devices[name] >= 0:
                     model.to_gpu(devices[name])
                 models[name] = model
-            if devices['main'] is not None and devices['main'] >= 0:
+            if devices['main'] >= 0:
                 optimizer.target.to_gpu(devices['main'])
 
         self._devices = devices

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -250,9 +250,11 @@ class ParallelUpdater(StandardUpdater):
             models = {'main': optimizer.target}
             for name in names:
                 model = optimizer.target.copy()
-                model.to_gpu(devices[name])
+                if devices[name] is not None and devices[name] >= 0:
+                    model.to_gpu(devices[name])
                 models[name] = model
-            optimizer.target.to_gpu(devices['main'])
+            if devices['main'] is not None and devices['main'] >= 0:
+                optimizer.target.to_gpu(devices['main'])
 
         self._devices = devices
         self._models = models


### PR DESCRIPTION
Currently, `ParallelUpdater` can only be used with GPUs. This PR slightly modifies `ParallelUpdater` to enable CPU execution. Like other functions and modules, when `devices` include `-1` or `None`, corresponding models are placed on CPUs. This feature is useful for development iterations, e.g., to dry-run scripts on a local laptop PC without CUDA.

(As future enhancement/refactoring, I propose to define functions like `to_device` in function `concat_examples` (https://github.com/pfnet/chainer/blob/f26f08ca18cceddc225c3baf2dab48596eb81d2b/chainer/dataset/convert.py#L53) at somewhere to make them reusable.)