### PR TITLE
Make not to assign a lambda expression to conform to PEP8

### DIFF
--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -56,7 +56,8 @@ def concat_examples(batch, device=None, padding=None):
     elif device < 0:
         to_device = cuda.to_cpu
     else:
-        to_device = lambda x: cuda.to_gpu(x, device)
+        def to_device(x):
+            return cuda.to_gpu(x, device)
 
     first_elem = batch[0]
 


### PR DESCRIPTION
PEP8 recommends to use `def` instead of binding a lambda expression to an identifier.