### PR TITLE
Fix UnicodeDecodeError in get_cifar on python3

### DIFF
--- a/chainer/datasets/cifar.py
+++ b/chainer/datasets/cifar.py
@@ -123,13 +123,13 @@ def _retrieve_cifar(name):
             # training set
             for i in range(5):
                 file_name = '{}/data_batch_{}'.format(dir_name, i + 1)
-                d = pickle.load(archive.extractfile(file_name))
+                d = pickle.load(archive.extractfile(file_name), encoding='latin-1')
                 train_x[i] = d['data']
                 train_y[i] = d['labels']
 
             # test set
             file_name = '{}/test_batch'.format(dir_name)
-            d = pickle.load(archive.extractfile(file_name))
+            d = pickle.load(archive.extractfile(file_name), encoding='latin-1')
             test_x = d['data']
             test_y[...] = d['labels']  # copy to array
 

--- a/chainer/datasets/cifar.py
+++ b/chainer/datasets/cifar.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tarfile
 
 import numpy
@@ -123,13 +124,13 @@ def _retrieve_cifar(name):
             # training set
             for i in range(5):
                 file_name = '{}/data_batch_{}'.format(dir_name, i + 1)
-                d = pickle.load(archive.extractfile(file_name), encoding='latin-1')
+                d = _pickle_load(archive.extractfile(file_name))
                 train_x[i] = d['data']
                 train_y[i] = d['labels']
 
             # test set
             file_name = '{}/test_batch'.format(dir_name)
-            d = pickle.load(archive.extractfile(file_name), encoding='latin-1')
+            d = _pickle_load(archive.extractfile(file_name))
             test_x = d['data']
             test_y[...] = d['labels']  # copy to array
 
@@ -142,3 +143,12 @@ def _retrieve_cifar(name):
                 'test_x': test_x, 'test_y': test_y}
 
     return download.cache_or_load_file(path, creator, numpy.load)
+
+
+def _pickle_load(f):
+    if sys.version_info > (3, ):
+        # python3
+        return pickle.load(f, encoding='latin-1')
+    else:
+        # python2
+        return pickle.load(f)


### PR DESCRIPTION
This PR fixes `UnicodeDecodeError` in `chainer.datasets.get_cifar10` and `chainer.datasets.get_cifar100` when using Python 3.

The following code raises error:
```python
import chainer
chainer.datasets.get_cifar10()
```

And give a trackback:
```
Downloading from https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/fohte/.pyenv/versions/3.5.2/lib/python3.5/site-packages/chainer/datasets/cifar.py", line 43, in get_cifar10
    raw = _retrieve_cifar('cifar-10')
  File "/home/fohte/.pyenv/versions/3.5.2/lib/python3.5/site-packages/chainer/datasets/cifar.py", line 144, in _retrieve_cifar
    return download.cache_or_load_file(path, creator, numpy.load)
  File "/home/fohte/.pyenv/versions/3.5.2/lib/python3.5/site-packages/chainer/dataset/download.py", line 145, in cache_or_load_file
    content = creator(temp_path)
  File "/home/fohte/.pyenv/versions/3.5.2/lib/python3.5/site-packages/chainer/datasets/cifar.py", line 126, in creator
    d = pickle.load(archive.extractfile(file_name))
UnicodeDecodeError: 'ascii' codec can't decode byte 0x8b in position 6: ordinal not in range(128)
```