### PR TITLE
deconvolution size calculation, odd case

### DIFF
--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -15,11 +15,10 @@ def get_deconv_outsize(size, k, s, p, cover_all=False):
     if cover_all:
         return s * (size - 1) + k - s + 1 - 2 * p
     else:
-        if size%2 == 0 and k > 1 and k%2 == 1:
-            return s * (size - 1) + k - 2 * p + k%s
+        if size % 2 == 0 and k > 1 and k % 2 == 1:
+            return s * (size - 1) + k - 2 * p + k % s
         else:
             return s * (size - 1) + k - 2 * p
-
 
 
 def im2col_cpu(img, kh, kw, sy, sx, ph, pw, pval=0, cover_all=False):

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -15,7 +15,11 @@ def get_deconv_outsize(size, k, s, p, cover_all=False):
     if cover_all:
         return s * (size - 1) + k - s + 1 - 2 * p
     else:
-        return s * (size - 1) + k - 2 * p
+        if size%2 == 0 and k > 1 and k%2 == 1:
+            return s * (size - 1) + k - 2 * p + k%s
+        else:
+            return s * (size - 1) + k - 2 * p
+
 
 
 def im2col_cpu(img, kh, kw, sy, sx, ph, pw, pval=0, cover_all=False):


### PR DESCRIPTION
When let's say the width of the input size  is even and kernel is odd during the convolution step we lose from 1-3 pixels, due to integer operation in the division part of convolution size equation:
 (size + p * 2 - k) // s

However during the inverse calculation in deconvolution operation s * (size - 1) + k - 2 * p this loss is not included. 
This issue can be solved by adding k%s term.

