### PR TITLE
embed_id skip checks validity if value equals ignore label.

### DIFF
--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -33,8 +33,8 @@ class EmbedIDFunction(function.Function):
             if self.ignore_label is not None:
                 valid_x = xp.logical_or(valid_x, x == self.ignore_label)
             if not valid_x.all():
-                msg = 'Each `x` value need to satisfy `0 <= x < len(W)`'
-                raise ValueError(msg)
+                raise ValueError('Each not ignored `x` value need to satisfy'
+                                 '`0 <= x < len(W)`')
 
         if self.ignore_label is not None:
             mask = (x == self.ignore_label)

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -27,14 +27,16 @@ class EmbedIDFunction(function.Function):
     def forward(self, inputs):
         x, W = inputs
 
+        xp = cuda.get_array_module(*inputs)
         if chainer.is_debug():
-            if not ((0 <= x).all() and
-                    (x < len(W)).all()):
+            valid_x = xp.logical_and(0 <= x, x < len(W))
+            if self.ignore_label is not None:
+                valid_x = xp.logical_or(valid_x, x == self.ignore_label)
+            if not valid_x.all():
                 msg = 'Each `x` value need to satisfy `0 <= x < len(W)`'
                 raise ValueError(msg)
 
         if self.ignore_label is not None:
-            xp = cuda.get_array_module(*inputs)
             mask = (x == self.ignore_label)
             return xp.where(
                 mask[..., None], 0, W.take(xp.where(mask, 0, x), axis=0)),

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -69,14 +69,15 @@ class TestEmbedID(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'t_value': -1, 'valid': False},
-    {'t_value': 3,  'valid': False},
-    {'t_value': 0,  'valid': True},
+    {'t_value': -1, 'valid': False, 'ignore_label': None},
+    {'t_value': 3,  'valid': False, 'ignore_label': None},
+    {'t_value': 0,  'valid': True,  'ignore_label': None},
+    {'t_value': -1, 'valid': True,  'ignore_label': -1},
 )
 class TestEmbedIDValueCheck(unittest.TestCase):
 
     def setUp(self):
-        self.link = links.EmbedID(2, 2)
+        self.link = links.EmbedID(2, 2, ignore_label=self.ignore_label)
         self.t = numpy.array([self.t_value], dtype=numpy.int32)
         self.original_debug = chainer.is_debug()
         chainer.set_debug(True)

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -73,6 +73,8 @@ class TestEmbedID(unittest.TestCase):
     {'t_value': 3,  'valid': False, 'ignore_label': None},
     {'t_value': 0,  'valid': True,  'ignore_label': None},
     {'t_value': -1, 'valid': True,  'ignore_label': -1},
+    {'t_value': 3,  'valid': False, 'ignore_label': -1},
+    {'t_value': 0,  'valid': True,  'ignore_label': -1},
 )
 class TestEmbedIDValueCheck(unittest.TestCase):
 


### PR DESCRIPTION
This PR is for skipping checks validity if value equals `ignore_label` (#1351 ).
`embed_id ` will not raise error value is "invalid" but equals `ignore_label`.