### PR TITLE
Fix gradient_check.assert_allclose to testing.assert_allclose.

### DIFF
--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -128,7 +128,7 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
     def test_im2col_consistency(self):
         col_cpu = conv.im2col_cpu(self.x, 3, 3, 2, 2, 1, 1)
         col_gpu = conv.im2col_gpu(cuda.to_gpu(self.x), 3, 3, 2, 2, 1, 1)
-        gradient_check.assert_allclose(col_cpu, col_gpu.get(), atol=0, rtol=0)
+        testing.assert_allclose(col_cpu, col_gpu.get(), atol=0, rtol=0)
 
     @attr.gpu
     def test_col2im_consistency(self):
@@ -136,7 +136,7 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
         h, w = self.x.shape[2:]
         im_cpu = conv.col2im_cpu(col, 2, 2, 1, 1, h, w)
         im_gpu = conv.col2im_gpu(cuda.to_gpu(col), 2, 2, 1, 1, h, w)
-        gradient_check.assert_allclose(im_cpu, im_gpu.get())
+        testing.assert_allclose(im_cpu, im_gpu.get())
 
     def check_forward_consistency(self):
         x_cpu = chainer.Variable(self.x)
@@ -148,7 +148,7 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
         y_gpu = self.link(x_gpu)
         self.assertEqual(y_gpu.data.dtype, numpy.float32)
 
-        gradient_check.assert_allclose(y_cpu.data, y_gpu.data.get())
+        testing.assert_allclose(y_cpu.data, y_gpu.data.get())
 
     @attr.cudnn
     @condition.retry(3)
@@ -197,7 +197,7 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
         y = self.link(x)
         y_data2 = y.data
 
-        gradient_check.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
+        testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
 
     def test_pickling_cpu(self):
         self.check_pickling(self.x)

--- a/tests/chainer_tests/links_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_linear.py
@@ -101,7 +101,7 @@ class TestLinearParameterShapePlaceholder(unittest.TestCase):
         x = chainer.Variable(x_data)
         y = self.link(x)
         self.assertEqual(y.data.dtype, numpy.float32)
-        gradient_check.assert_allclose(self.y, y.data)
+        testing.assert_allclose(self.y, y.data)
 
     @condition.retry(3)
     def test_forward_cpu(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_peephole.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_peephole.py
@@ -76,16 +76,16 @@ class TestPeephole(unittest.TestCase):
 
         h1 = self.link(x)
         c1_expect, h1_expect = _peephole(self.link, c_data, h_data, x_data)
-        gradient_check.assert_allclose(h1.data, h1_expect)
-        gradient_check.assert_allclose(self.link.c.data, c1_expect)
-        gradient_check.assert_allclose(self.link.h.data, h1_expect)
+        testing.assert_allclose(h1.data, h1_expect)
+        testing.assert_allclose(self.link.c.data, c1_expect)
+        testing.assert_allclose(self.link.h.data, h1_expect)
 
         h2 = self.link(x)
         c2_expect, h2_expect = _peephole(self.link,
                                          c1_expect, h1_expect, x_data)
-        gradient_check.assert_allclose(h2.data, h2_expect)
-        gradient_check.assert_allclose(self.link.c.data, c2_expect)
-        gradient_check.assert_allclose(self.link.h.data, h2_expect)
+        testing.assert_allclose(h2.data, h2_expect)
+        testing.assert_allclose(self.link.c.data, c2_expect)
+        testing.assert_allclose(self.link.h.data, h2_expect)
 
     def test_forward_cpu(self):
         self.check_forward(self.c, self.h, self.x)
@@ -107,7 +107,7 @@ class TestPeephole(unittest.TestCase):
             c, y = _peephole(self.link, c_data, h_data, x_data)
             return y,
         gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
-        gradient_check.assert_allclose(gx, x.grad, atol=1e-3)
+        testing.assert_allclose(gx, x.grad, atol=1e-3)
 
     def test_backward_cpu(self):
         self.check_backward(self.c, self.h, self.x, self.gy)


### PR DESCRIPTION
This PR fixes `gradient_check.assert_allclose` used in recent commits to `testing.assert_allclose`.