### PR TITLE
Implement square root function.

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -68,6 +68,7 @@ from chainer.functions.math import maximum
 from chainer.functions.math import minimum
 from chainer.functions.math import minmax
 from chainer.functions.math import scale
+from chainer.functions.math import sqrt
 from chainer.functions.math import sum
 from chainer.functions.math import trigonometric
 from chainer.functions.noise import dropout
@@ -242,6 +243,8 @@ min = minmax.min
 scale = scale.scale
 Sin = trigonometric.Sin
 sin = trigonometric.sin
+Sqrt = sqrt.Sqrt
+sqrt = sqrt.sqrt
 Sum = sum.Sum
 sum = sum.sum
 

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -1,5 +1,3 @@
-import numpy
-
 from chainer import cuda
 from chainer import function
 from chainer import utils

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -1,0 +1,36 @@
+import numpy
+
+from chainer import cuda
+from chainer import function
+from chainer import utils
+from chainer.utils import type_check
+
+
+class Sqrt(function.Function):
+
+    @property
+    def label(self):
+        return 'sqrt'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(
+            in_types.size() == 1,
+            in_types[0].dtype.kind == 'f',
+        )
+
+    def forward(self, x):
+        xp = cuda.get_array_module(*x)
+        return utils.force_array(xp.sqrt(x[0], dtype=x[0].dtype)),
+
+    def backward(self, x, gy):
+        xp = cuda.get_array_module(*x)
+        gx = utils.force_array(xp.sqrt(x[0], dtype=x[0].dtype))
+        gx *= 2.0
+        xp.reciprocal(gx, out=gx)
+        gx *= gy[0]
+        return gx,
+
+
+def sqrt(x):
+    """Elementwise square root function."""
+    return Sqrt()(x)

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -35,7 +35,8 @@ def sqrt(x):
     .. math::
        y_i = \\sqrt x_i.
 
-    If the value of :math:`x_i` is negative, it returns ``Nan`` for :math:`y_i` respect to underlying numpy and cupy specification.
+    If the value of :math:`x_i` is negative, it returns ``Nan`` for :math:`y_i`
+    respect to underlying numpy and cupy specification.
 
     Args:
         x (~chainer.Variable): Input variable.

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -30,5 +30,17 @@ class Sqrt(function.Function):
 
 
 def sqrt(x):
-    """Elementwise square root function."""
+    """Elementwise square root function.
+
+    .. math::
+       y_i = \\sqrt x_i.
+
+    If the value of :math:`x_i` is negative, it returns ``Nan`` for :math:`y_i` respect to underlying numpy and cupy specification.
+
+    Args:
+        x (~chainer.Variable): Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Sqrt()(x)

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -343,6 +343,10 @@ sin
 ~~~
 .. autofunction:: sin
 
+sqrt
+~~~~
+.. autofunction:: sqrt
+
 sum
 ~~~
 .. autofunction:: sum

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -1,0 +1,82 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+import chainer.functions as F
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+
+class TestUnaryFunctionBase(unittest.TestCase):
+
+    def make_data(self):
+        raise NotImplementedError
+
+    def setUp(self):
+        self.x, self.gy = self.make_data()
+
+    def check_forward(self, op, op_xp, x_data):
+        x = chainer.Variable(x_data)
+        y = op(x)
+        self.assertEqual(x.data.dtype, y.data.dtype)
+        testing.assert_allclose(
+            op_xp(x_data, dtype=x_data.dtype), y.data, atol=1e-7, rtol=1e-7)
+
+    def check_forward_cpu(self, op, op_xp):
+        self.check_forward(op, op_xp, self.x)
+
+    def check_forward_gpu(self, op, op_xp):
+        self.check_forward(op, op_xp, cuda.to_gpu(self.x))
+
+    def check_backward(self, op, x_data, y_grad):
+        gradient_check.check_backward(
+            op, x_data, y_grad, atol=1e-4, rtol=1e-3, dtype=numpy.float64)
+
+    def check_backward_cpu(self, op):
+        self.check_backward(op, self.x, self.gy)
+
+    def check_backward_gpu(self, op):
+        self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    def check_label(self, op, expected):
+        self.assertEqual(op().label, expected)
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), ()],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestSqrt(TestUnaryFunctionBase):
+
+    def make_data(self):
+        x = numpy.random.uniform(0.1, 1, self.shape).astype(self.dtype)
+        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        return x, gy
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward_cpu(F.sqrt, numpy.sqrt)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.check_forward_gpu(F.sqrt, cuda.cupy.sqrt)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward_cpu(F.sqrt)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward_gpu(F.sqrt)
+
+    def test_label(self):
+        self.check_label(F.Sqrt, 'sqrt')
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -11,7 +11,7 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-class TestUnaryFunctionBase(unittest.TestCase):
+class UnaryFunctionsTestBase(unittest.TestCase):
 
     def make_data(self):
         raise NotImplementedError
@@ -50,7 +50,7 @@ class TestUnaryFunctionBase(unittest.TestCase):
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestSqrt(TestUnaryFunctionBase):
+class TestSqrt(UnaryFunctionsTestBase):
 
     def make_data(self):
         x = numpy.random.uniform(0.1, 1, self.shape).astype(self.dtype)


### PR DESCRIPTION
This PR implements `sqrt` function with covering test for input of dtype `float16`, `float32` and `float64`.

It uses `numpy.sqrt` and `cupy.sqrt` with specifying `dtype` keyword parameter to make them return output with the same `dtype` with input.
See http://docs.chainer.org/en/stable/cupy-reference/math.html#cupy.sqrt .