### PR TITLE
Implement function for reciprocal of square root.

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -240,6 +240,7 @@ Minimum = minimum.Minimum
 minimum = minimum.minimum
 Min = minmax.Min
 min = minmax.min
+rsqrt = sqrt.rsqrt
 scale = scale.scale
 Sin = trigonometric.Sin
 sin = trigonometric.sin

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -1,4 +1,3 @@
-import chainer
 from chainer import cuda
 from chainer import function
 from chainer import utils

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -1,3 +1,4 @@
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer import utils
@@ -45,3 +46,20 @@ def sqrt(x):
         ~chainer.Variable: Output variable.
     """
     return Sqrt()(x)
+
+
+def rsqrt(x):
+    """Computes elementwise reciprocal of square root of input :math:`x_i`.
+
+    .. math::
+       y_i = {1 \\over \\sqrt x_i}.
+
+    Args:
+        x (~chainer.Variable): Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+
+    .. seealso:: :func:`~chainer.functions.sqrt`
+    """
+    return 1.0 / sqrt(x)

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -335,6 +335,10 @@ minimum
 ~~~~~~~
 .. autofunction:: minimum
 
+rsqrt
+~~~~~
+.. autofunction:: rsqrt
+
 scale
 ~~~~~
 .. autofunction:: scale

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -34,7 +34,7 @@ class UnaryFunctionsTestBase(unittest.TestCase):
 
     def check_backward(self, op, x_data, y_grad):
         gradient_check.check_backward(
-            op, x_data, y_grad, atol=1e-4, rtol=1e-3, dtype=numpy.float64)
+            op, x_data, y_grad, atol=5e-4, rtol=5e-3, dtype=numpy.float64)
 
     def check_backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -101,7 +101,7 @@ class TestRsqrt(UnaryFunctionsTestBase):
     def test_forward_gpu(self):
         def cp_rsqrt(x, dtype=numpy.float32):
             return cuda.cupy.reciprocal(cuda.cupy.sqrt(x, dtype=dtype))
-        self.check_forward_gpu(F.rsqrt, cuda.cupy.rsqrt)
+        self.check_forward_gpu(F.rsqrt, cp_rsqrt)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -79,4 +79,38 @@ class TestSqrt(TestUnaryFunctionBase):
         self.check_label(F.Sqrt, 'sqrt')
 
 
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), ()],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestRsqrt(TestUnaryFunctionBase):
+
+    def make_data(self):
+        x = numpy.random.uniform(0.1, 1, self.shape).astype(self.dtype)
+        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        return x, gy
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        def np_rsqrt(x, dtype=numpy.float32):
+            return numpy.reciprocal(numpy.sqrt(x, dtype=dtype))
+        self.check_forward_cpu(F.rsqrt, np_rsqrt)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        def cp_rsqrt(x, dtype=numpy.float32):
+            return cuda.cupy.reciprocal(cuda.cupy.sqrt(x, dtype=dtype))
+        self.check_forward_gpu(F.rsqrt, cuda.cupy.rsqrt)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward_cpu(F.rsqrt)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward_gpu(F.rsqrt)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -11,7 +11,7 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-class TestUnaryFunctionBase(unittest.TestCase):
+class UnaryFunctionsTestBase(unittest.TestCase):
 
     def make_data(self):
         raise NotImplementedError
@@ -50,7 +50,7 @@ class TestUnaryFunctionBase(unittest.TestCase):
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestSqrt(TestUnaryFunctionBase):
+class TestSqrt(UnaryFunctionsTestBase):
 
     def make_data(self):
         x = numpy.random.uniform(0.1, 1, self.shape).astype(self.dtype)
@@ -83,7 +83,7 @@ class TestSqrt(TestUnaryFunctionBase):
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestRsqrt(TestUnaryFunctionBase):
+class TestRsqrt(UnaryFunctionsTestBase):
 
     def make_data(self):
         x = numpy.random.uniform(0.1, 1, self.shape).astype(self.dtype)


### PR DESCRIPTION
This PR implements a function that computes reciprocal of square root.

Currently it is implemented with combining Chainer functions, though it would be more efficient to use CUDA math API `rsqrt` for GPU implementation.

In contrast, numpy seems not to provide such optimized `rsqrt` counterpart.
