### PR TITLE
Word2vec trainer

### DIFF
--- a/examples/word2vec/README.md
+++ b/examples/word2vec/README.md
@@ -3,8 +3,7 @@
 This is an example of word embedding.
 We implemented Mikolov's Skip-gram model and Continuous-BoW model with Hierarchical softmax and Negative sampling.
 
-First use `../ptb/download.py` to download `ptb.train.txt`.
-And then, run `train_word2vec.py` to train and get `model.pickle` which includes embedding data.
+Run `train_word2vec.py` to train and get `word2vec.model` which includes embedding data.
 You can find top-5 nearest embedding vectors using `search.py`.
 
 This example is based on the following word embedding implementation in C++.

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -182,6 +182,7 @@ vocab = chainer.datasets.get_ptb_words_vocabulary()
 index2word = {wid: word for word, wid in six.iteritems(vocab)}
 
 counts = collections.Counter(train)
+counts.update(collections.Counter(val))
 n_vocab = max(train) + 1
 
 print('n_vocab: %d' % n_vocab)

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -6,7 +6,6 @@ Use ../ptb/download.py to download 'ptb.train.txt'.
 """
 import argparse
 import collections
-import time
 
 import numpy as np
 import six
@@ -67,8 +66,8 @@ class ContinuousBoW(chainer.Chain):
 
     def __init__(self, n_vocab, n_units, loss_func):
         super(ContinuousBoW, self).__init__(
-            embed=F.EmbedID(n_vocab, n_units,
-                            initialW=I.Uniform(1. / n_units)),
+            embed=F.EmbedID(
+                n_vocab, n_units, initialW=I.Uniform(1. / n_units)),
             loss_func=loss_func,
         )
 
@@ -84,8 +83,8 @@ class SkipGram(chainer.Chain):
 
     def __init__(self, n_vocab, n_units, loss_func):
         super(SkipGram, self).__init__(
-            embed=L.EmbedID(n_vocab, n_units,
-                            initialW=I.Uniform(1. / n_units)),
+            embed=L.EmbedID(
+                n_vocab, n_units, initialW=I.Uniform(1. / n_units)),
             loss_func=loss_func,
         )
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -72,7 +72,7 @@ class ContinuousBoW(chainer.Chain):
             loss_func=loss_func,
         )
 
-    def __call__(self, context, x):
+    def __call__(self, x, context):
         e = self.embed(context)
         h = F.sum(e, axis=1) * (1. / context.data.shape[1])
         loss = self.loss_func(h, x)
@@ -89,7 +89,7 @@ class SkipGram(chainer.Chain):
             loss_func=loss_func,
         )
 
-    def __call__(self, context, x):
+    def __call__(self, x, context):
         e = self.embed(context)
         shape = e.data.shape
         x = F.broadcast_to(x[:, None], (shape[0], shape[1]))
@@ -130,7 +130,7 @@ class WindowDataset(chainer.dataset.DatasetMixin):
              np.arange(self.window + i + 1, end)])
         context = self.data.take(offset)
         center = self.data[i + self.window]
-        return context, center
+        return center, context
 
     def __len__(self):
         return len(self.data) - self.window * 2

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -174,6 +174,7 @@ if args.gpu >= 0:
     cuda.get_device(args.gpu).use()
 
 train, val, _ = chainer.datasets.get_ptb_words()
+n_vocab = max(train) + 1
 if args.test:
     train = train[:100]
     val = val[:100]
@@ -183,7 +184,6 @@ index2word = {wid: word for word, wid in six.iteritems(vocab)}
 
 counts = collections.Counter(train)
 counts.update(collections.Counter(val))
-n_vocab = max(train) + 1
 
 print('n_vocab: %d' % n_vocab)
 print('data length: %d' % len(train))


### PR DESCRIPTION
I fixed word2vec example to use Trainer. I implemented a custom iterator instead of making dataset as the default iterator and converter is too slow for this example. This iterator takes mini-batch data from a dataset using `numpy.take` which is faster than `__getitem__`.