### PR TITLE
Add log1p function to reference.

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -311,6 +311,10 @@ log
 ~~~
 .. autofunction:: log
 
+log1p
+~~~~~
+.. autofunction:: log1p
+
 logsumexp
 ~~~~~~~~~
 .. autofunction:: logsumexp


### PR DESCRIPTION
This PR adds `log1p` function to reference, which seems to be missing after it was implemented.
