### PR TITLE
Unit tests for cifar dataset loading.

### DIFF
--- a/tests/chainer_tests/datasets_tests/test_cifar.py
+++ b/tests/chainer_tests/datasets_tests/test_cifar.py
@@ -24,7 +24,7 @@ class TestCifar(unittest.TestCase):
             os.path.join('pfnet', 'chainer', 'cifar'))
 
     def tearDown(self):
-        if hasattr(self, 'cached_file'):
+        if hasattr(self, 'cached_file') and os.path.exists(self.cached_file):
             os.remove(self.cached_file)
 
     @attr.slow
@@ -42,10 +42,11 @@ class TestCifar(unittest.TestCase):
 
         for cifar_dataset in (train, test):
             if self.withlabel:
-                assert isinstance(cifar_dataset, tuple_dataset.TupleDataset)
+                self.assertIsInstance(cifar_dataset,
+                                      tuple_dataset.TupleDataset)
                 cifar_dataset = cifar_dataset._datasets[0]
             else:
-                assert isinstance(cifar_dataset, numpy.ndarray)
+                self.assertIsInstance(cifar_dataset, numpy.ndarray)
 
             if self.ndim == 1:
                 assert cifar_dataset.ndim == 2

--- a/tests/chainer_tests/datasets_tests/test_cifar.py
+++ b/tests/chainer_tests/datasets_tests/test_cifar.py
@@ -1,0 +1,75 @@
+import mock
+import os
+import unittest
+
+import numpy
+
+from chainer.dataset import download
+from chainer.datasets import get_cifar10
+from chainer.datasets import get_cifar100
+from chainer.datasets import tuple_dataset
+from chainer import testing
+
+
+@testing.parameterize(*testing.product({
+    'withlabel': [True, False],
+    'ndim': [1, 3],
+    'scale': [1., 255.]
+}))
+class TestCifar(unittest.TestCase):
+
+    def setUp(self):
+        self.root = download.get_dataset_directory(
+            os.path.join('pfnet', 'chainer',
+                         'cifar'))
+
+    def tearDown(self):
+        if hasattr(self, 'cached_file'):
+            os.remove(self.cached_file)
+
+    def test_get_cifar10(self):
+        self.check_retrieval_once('cifar-10.npz', get_cifar10)
+
+    def test_get_cifar100(self):
+        self.check_retrieval_once('cifar-100.npz', get_cifar100)
+
+    def check_retrieval_once(self, name, retrieval_func):
+        self.cached_file = os.path.join(self.root, name)
+        train, test = retrieval_func(withlabel=self.withlabel, ndim=self.ndim,
+                                     scale=self.scale)
+
+        for cifar_dataset in (train, test):
+            if self.withlabel:
+                assert isinstance(cifar_dataset, tuple_dataset.TupleDataset)
+                cifar_dataset = cifar_dataset._datasets[0]
+            else:
+                assert isinstance(cifar_dataset, numpy.ndarray)
+
+            if self.ndim == 1:
+                assert cifar_dataset.ndim == 2
+            else:
+                assert self.ndim == 3
+                assert cifar_dataset.ndim == 4
+                assert cifar_dataset.shape[2] == cifar_dataset.shape[3]  # 32
+
+    # test caching - call twice
+    def test_get_cifar10_cached(self):
+        self.check_retrieval_twice('cifar-10.npz', get_cifar10)
+
+    def test_get_cifar100_cached(self):
+        self.check_retrieval_twice('cifar-100.npz', get_cifar100)
+
+    def check_retrieval_twice(self, name, retrieval_func):
+        self.cached_file = os.path.join(self.root, name)
+        train, test = retrieval_func(withlabel=self.withlabel, ndim=self.ndim,
+                                     scale=self.scale)
+
+        with mock.patch('chainer.datasets.cifar.numpy') as mnumpy:
+            train, test = retrieval_func(withlabel=self.withlabel,
+                                         ndim=self.ndim,
+                                         scale=self.scale)
+        mnumpy.savez_compressed.assert_not_called()  # creator() not called
+        mnumpy.load.assert_called_once()
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/datasets_tests/test_cifar.py
+++ b/tests/chainer_tests/datasets_tests/test_cifar.py
@@ -1,14 +1,14 @@
-import mock
 import os
 import unittest
 
+import mock
 import numpy
 
+from chainer import testing
 from chainer.dataset import download
 from chainer.datasets import get_cifar10
 from chainer.datasets import get_cifar100
 from chainer.datasets import tuple_dataset
-from chainer import testing
 from chainer.testing import attr
 
 

--- a/tests/chainer_tests/datasets_tests/test_cifar.py
+++ b/tests/chainer_tests/datasets_tests/test_cifar.py
@@ -9,6 +9,7 @@ from chainer.datasets import get_cifar10
 from chainer.datasets import get_cifar100
 from chainer.datasets import tuple_dataset
 from chainer import testing
+from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product({
@@ -20,16 +21,17 @@ class TestCifar(unittest.TestCase):
 
     def setUp(self):
         self.root = download.get_dataset_directory(
-            os.path.join('pfnet', 'chainer',
-                         'cifar'))
+            os.path.join('pfnet', 'chainer', 'cifar'))
 
     def tearDown(self):
         if hasattr(self, 'cached_file'):
             os.remove(self.cached_file)
 
+    @attr.slow
     def test_get_cifar10(self):
         self.check_retrieval_once('cifar-10.npz', get_cifar10)
 
+    @attr.slow
     def test_get_cifar100(self):
         self.check_retrieval_once('cifar-100.npz', get_cifar100)
 
@@ -53,9 +55,11 @@ class TestCifar(unittest.TestCase):
                 assert cifar_dataset.shape[2] == cifar_dataset.shape[3]  # 32
 
     # test caching - call twice
+    @attr.slow
     def test_get_cifar10_cached(self):
         self.check_retrieval_twice('cifar-10.npz', get_cifar10)
 
+    @attr.slow
     def test_get_cifar100_cached(self):
         self.check_retrieval_twice('cifar-100.npz', get_cifar100)
 

--- a/tests/chainer_tests/datasets_tests/test_cifar.py
+++ b/tests/chainer_tests/datasets_tests/test_cifar.py
@@ -4,11 +4,11 @@ import unittest
 import mock
 import numpy
 
-from chainer import testing
 from chainer.dataset import download
 from chainer.datasets import get_cifar10
 from chainer.datasets import get_cifar100
 from chainer.datasets import tuple_dataset
+from chainer import testing
 from chainer.testing import attr
 
 

--- a/tests/chainer_tests/datasets_tests/test_cifar.py
+++ b/tests/chainer_tests/datasets_tests/test_cifar.py
@@ -51,7 +51,7 @@ class TestCifar(unittest.TestCase):
             if self.ndim == 1:
                 self.assertEqual(cifar_dataset.ndim, 2)
             else:
-                assert self.ndim == 3
+                # self.ndim == 3
                 self.assertEqual(cifar_dataset.ndim == 4)
                 self.assertEqual(cifar_dataset.shape[2],
                                  cifar_dataset.shape[3])  # 32

--- a/tests/chainer_tests/datasets_tests/test_cifar.py
+++ b/tests/chainer_tests/datasets_tests/test_cifar.py
@@ -49,11 +49,12 @@ class TestCifar(unittest.TestCase):
                 self.assertIsInstance(cifar_dataset, numpy.ndarray)
 
             if self.ndim == 1:
-                assert cifar_dataset.ndim == 2
+                self.assertEqual(cifar_dataset.ndim, 2)
             else:
                 assert self.ndim == 3
-                assert cifar_dataset.ndim == 4
-                assert cifar_dataset.shape[2] == cifar_dataset.shape[3]  # 32
+                self.assertEqual(cifar_dataset.ndim == 4)
+                self.assertEqual(cifar_dataset.shape[2],
+                                 cifar_dataset.shape[3])  # 32
 
     # test caching - call twice
     @attr.slow


### PR DESCRIPTION
Test loading the cifar-10 and cifar-100 datasets; test caching them to an `.npz` file.

These tests run slowly. When https://github.com/pfnet/chainer/issues/1514 is resolved, they should be marked as slow.
