### PR TITLE
Refactor the cifar dataset loading code according to DRY.

### DIFF
--- a/chainer/datasets/cifar.py
+++ b/chainer/datasets/cifar.py
@@ -41,12 +41,7 @@ def get_cifar10(withlabel=True, ndim=3, scale=1.):
         datasets are arrays of images.
 
     """
-    raw = _retrieve_cifar('cifar-10')
-    train = _preprocess_cifar(raw['train_x'], raw['train_y'],
-                              withlabel, ndim, scale)
-    test = _preprocess_cifar(raw['test_x'], raw['test_y'],
-                             withlabel, ndim, scale)
-    return train, test
+    return _get_cifar('cifar-10', withlabel, ndim, scale)
 
 
 def get_cifar100(withlabel=True, ndim=3, scale=1.):
@@ -81,11 +76,62 @@ def get_cifar100(withlabel=True, ndim=3, scale=1.):
         datasets are arrays of images.
 
     """
-    raw = _retrieve_cifar_100()
+    return _get_cifar('cifar-100', withlabel, ndim, scale)
+
+
+def _get_cifar(name, *args):
+    npz_path = os.path.join(_root, '{}.npz'.format(name))
+    url = 'https://www.cs.toronto.edu/~kriz/{}-python.tar.gz'.format(name)
+
+    def creator(path):
+        archive_path = download.cached_download(url)
+
+        if name == 'cifar-10':
+            train_x = numpy.empty((5, 10000, 3072), dtype=numpy.uint8)
+            train_y = numpy.empty((5, 10000), dtype=numpy.uint8)
+            test_y = numpy.empty(10000, dtype=numpy.uint8)
+
+            dir_name = '{}-batches-py'.format(name)
+
+            with tarfile.open(archive_path, 'r:gz') as archive:
+                # training set
+                for i in range(5):
+                    file_name = '{}/data_batch_{}'.format(dir_name, i + 1)
+                    d = _pickle_load(archive.extractfile(file_name))
+                    train_x[i] = d['data']
+                    train_y[i] = d['labels']
+
+                # test set
+                file_name = '{}/test_batch'.format(dir_name)
+                d = _pickle_load(archive.extractfile(file_name))
+                test_x = d['data']
+                test_y[...] = d['labels']  # copy to array
+
+            train_x = train_x.reshape(50000, 3072)
+            train_y = train_y.reshape(50000)
+        else:
+            # name == 'cifar-100'
+            def load(archive, file_name):
+                d = _pickle_load(archive.extractfile(file_name))
+                x = d['data'].reshape((-1, 3072))
+                y = numpy.array(d['fine_labels'], dtype=numpy.uint8)
+                return x, y
+
+            archive_path = download.cached_download(url)
+            with tarfile.open(archive_path, 'r:gz') as archive:
+                train_x, train_y = load(archive, 'cifar-100-python/train')
+                test_x, test_y = load(archive, 'cifar-100-python/test')
+
+        numpy.savez_compressed(path, train_x=train_x, train_y=train_y,
+                               test_x=test_x, test_y=test_y)
+        return {'train_x': train_x, 'train_y': train_y,
+                'test_x': test_x, 'test_y': test_y}
+
+    raw = download.cache_or_load_file(npz_path, creator, numpy.load)
     train = _preprocess_cifar(raw['train_x'], raw['train_y'],
-                              withlabel, ndim, scale)
+                              *args)
     test = _preprocess_cifar(raw['test_x'], raw['test_y'],
-                             withlabel, ndim, scale)
+                             *args)
     return train, test
 
 
@@ -106,69 +152,8 @@ def _preprocess_cifar(images, labels, withlabel, ndim, scale):
         return images
 
 
-def _retrieve_cifar_100():
-    root = download.get_dataset_directory('pfnet/chainer/cifar')
-    path = os.path.join(root, 'cifar-100.npz')
-    url = 'https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz'
-
-    def creator(path):
-
-        def load(archive, file_name):
-            d = _pickle_load(archive.extractfile(file_name))
-            x = d['data'].reshape((-1, 3072))
-            y = numpy.array(d['fine_labels'], dtype=numpy.uint8)
-            return x, y
-
-        archive_path = download.cached_download(url)
-        with tarfile.open(archive_path, 'r:gz') as archive:
-            train_x, train_y = load(archive, 'cifar-100-python/train')
-            test_x, test_y = load(archive, 'cifar-100-python/test')
-
-        numpy.savez_compressed(path, train_x=train_x, train_y=train_y,
-                               test_x=test_x, test_y=test_y)
-        return {'train_x': train_x, 'train_y': train_y,
-                'test_x': test_x, 'test_y': test_y}
-
-    return download.cache_or_load_file(path, creator, numpy.load)
-
-
-def _retrieve_cifar(name):
-    root = download.get_dataset_directory('pfnet/chainer/cifar')
-    path = os.path.join(root, '{}.npz'.format(name))
-    url = 'https://www.cs.toronto.edu/~kriz/{}-python.tar.gz'.format(name)
-
-    def creator(path):
-        archive_path = download.cached_download(url)
-
-        train_x = numpy.empty((5, 10000, 3072), dtype=numpy.uint8)
-        train_y = numpy.empty((5, 10000), dtype=numpy.uint8)
-        test_y = numpy.empty(10000, dtype=numpy.uint8)
-
-        dir_name = '{}-batches-py'.format(name)
-
-        with tarfile.open(archive_path, 'r:gz') as archive:
-            # training set
-            for i in range(5):
-                file_name = '{}/data_batch_{}'.format(dir_name, i + 1)
-                d = _pickle_load(archive.extractfile(file_name))
-                train_x[i] = d['data']
-                train_y[i] = d['labels']
-
-            # test set
-            file_name = '{}/test_batch'.format(dir_name)
-            d = _pickle_load(archive.extractfile(file_name))
-            test_x = d['data']
-            test_y[...] = d['labels']  # copy to array
-
-        train_x = train_x.reshape(50000, 3072)
-        train_y = train_y.reshape(50000)
-
-        numpy.savez_compressed(path, train_x=train_x, train_y=train_y,
-                               test_x=test_x, test_y=test_y)
-        return {'train_x': train_x, 'train_y': train_y,
-                'test_x': test_x, 'test_y': test_y}
-
-    return download.cache_or_load_file(path, creator, numpy.load)
+_root = download.get_dataset_directory(os.path.join('pfnet', 'chainer',
+                                                    'cifar'))
 
 
 def _pickle_load(f):

--- a/chainer/datasets/cifar.py
+++ b/chainer/datasets/cifar.py
@@ -79,8 +79,10 @@ def get_cifar100(withlabel=True, ndim=3, scale=1.):
     return _get_cifar('cifar-100', withlabel, ndim, scale)
 
 
-def _get_cifar(name, *args):
-    npz_path = os.path.join(_root, '{}.npz'.format(name))
+def _get_cifar(name, withlabel, ndim, scale):
+    root = download.get_dataset_directory(os.path.join('pfnet', 'chainer',
+                                                       'cifar'))
+    npz_path = os.path.join(root, '{}.npz'.format(name))
     url = 'https://www.cs.toronto.edu/~kriz/{}-python.tar.gz'.format(name)
 
     def creator(path):
@@ -117,8 +119,8 @@ def _get_cifar(name, *args):
                 y = numpy.array(d['fine_labels'], dtype=numpy.uint8)
                 return x, y
 
-            archive_path = download.cached_download(url)
-            with tarfile.open(archive_path, 'r:gz') as archive:
+            with tarfile.open(download.cached_download(url), 'r:gz') as \
+                    archive:
                 train_x, train_y = load(archive, 'cifar-100-python/train')
                 test_x, test_y = load(archive, 'cifar-100-python/test')
 
@@ -128,10 +130,10 @@ def _get_cifar(name, *args):
                 'test_x': test_x, 'test_y': test_y}
 
     raw = download.cache_or_load_file(npz_path, creator, numpy.load)
-    train = _preprocess_cifar(raw['train_x'], raw['train_y'],
-                              *args)
-    test = _preprocess_cifar(raw['test_x'], raw['test_y'],
-                             *args)
+    train = _preprocess_cifar(raw['train_x'], raw['train_y'], withlabel,
+                              ndim, scale)
+    test = _preprocess_cifar(raw['test_x'], raw['test_y'], withlabel, ndim,
+                             scale)
     return train, test
 
 
@@ -150,10 +152,6 @@ def _preprocess_cifar(images, labels, withlabel, ndim, scale):
         return tuple_dataset.TupleDataset(images, labels)
     else:
         return images
-
-
-_root = download.get_dataset_directory(os.path.join('pfnet', 'chainer',
-                                                    'cifar'))
 
 
 def _pickle_load(f):

--- a/chainer/datasets/cifar.py
+++ b/chainer/datasets/cifar.py
@@ -119,8 +119,7 @@ def _get_cifar(name, withlabel, ndim, scale):
                 y = numpy.array(d['fine_labels'], dtype=numpy.uint8)
                 return x, y
 
-            with tarfile.open(download.cached_download(url), 'r:gz') as \
-                    archive:
+            with tarfile.open(archive_path, 'r:gz') as archive:
                 train_x, train_y = load(archive, 'cifar-100-python/train')
                 test_x, test_y = load(archive, 'cifar-100-python/test')
 


### PR DESCRIPTION
Avoid having separate and similar retrieval functions for cifar-10 and cifar-100.
