### PR TITLE
Fix cupy.hstack

### DIFF
--- a/cupy/manipulation/join.py
+++ b/cupy/manipulation/join.py
@@ -123,7 +123,7 @@ def hstack(tup):
     axis = 1
     if arrs[0].ndim == 1:
         axis = 0
-    return concatenate(tup, axis)
+    return concatenate(arrs, axis)
 
 
 def vstack(tup):

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -80,6 +80,13 @@ class TestJoin(unittest.TestCase):
         return xp.hstack((a, b))
 
     @testing.numpy_cupy_array_equal()
+    def test_hstack_scalars(self, xp):
+        a = testing.shaped_arange((), xp)
+        b = testing.shaped_arange((), xp)
+        c = testing.shaped_arange((), xp)
+        return xp.hstack((a, b, c))
+
+    @testing.numpy_cupy_array_equal()
     def test_hstack(self, xp):
         a = testing.shaped_arange((2, 1), xp)
         b = testing.shaped_arange((2, 2), xp)


### PR DESCRIPTION
This bug prevented us from applying `hstack` to ndarrays with `ndim=0`.