### PR TITLE
Replace zerograd(s) with cleargrad(s)

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -357,6 +357,16 @@ class Link(object):
         for name in self._params:
             dst[name].copydata(src[name])
 
+    def cleargrads(self):
+        """Clears all gradient arrays.
+
+        This method should be called before the backward computation at every
+        iteration of the optimization.
+
+        """
+        for param in self.params():
+            param.cleargrad()
+
     def zerograds(self):
         """Initializes all gradient arrays by zero.
 

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -370,8 +370,8 @@ class Link(object):
     def zerograds(self):
         """Initializes all gradient arrays by zero.
 
-        This method should be called before the backward computation at every
-        iteration of the optimization.
+        This method can be used for the same purpose of cleargrads, but less
+        efficient. This method is left for backward compatibility.
 
         """
         for param in self.params():

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -384,11 +384,7 @@ class GradientMethod(Optimizer):
 
         """
         if lossfun is not None:
-            if 'use_cleargrads' in kwds:
-                use_cleargrads = kwds['use_cleargrads']
-                del kwds['use_cleargrads']
-            else:
-                use_cleargrads = False
+            use_cleargrads = kwds.pop('use_cleargrads', False)
             loss = lossfun(*args, **kwds)
             if use_cleargrads:
                 self.target.cleargrads()

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -388,7 +388,7 @@ class GradientMethod(Optimizer):
                 use_cleargrads = kwds['use_cleargrads']
                 del kwds['use_cleargrads']
             else:
-                use_cleargrads = True
+                use_cleargrads = False
             loss = lossfun(*args, **kwds)
             if use_cleargrads:
                 self.target.cleargrads()

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -384,8 +384,16 @@ class GradientMethod(Optimizer):
 
         """
         if lossfun is not None:
+            if 'use_cleargrads' in kwds:
+                use_cleargrads = kwds['use_cleargrads']
+                del kwds['use_cleargrads']
+            else:
+                use_cleargrads = True
             loss = lossfun(*args, **kwds)
-            self.target.zerograds()
+            if use_cleargrads:
+                self.target.cleargrads()
+            else:
+                self.target.zerograds()
             loss.backward()
             del loss
         self.call_hooks()

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -289,7 +289,7 @@ class ParallelUpdater(StandardUpdater):
                 batch[i::n], self._devices[key])
 
         for model in six.itervalues(self._models):
-            model.zerograds()
+            model.cleargrads()
 
         losses = []
         for model_key, model in six.iteritems(self._models):

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -226,6 +226,10 @@ Actual: {0}'''.format(type(data))
             if self._grad is not None:
                 self._grad = cuda.to_gpu(self._grad)
 
+    def cleargrad(self):
+        """Clears the gradient array."""
+        self._grad = None
+
     def zerograd(self):
         """Initializes the gradient array by zeros."""
         with cuda.get_device(self.data) as dev:

--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -135,7 +135,7 @@ class BPTTUpdater(training.StandardUpdater):
             # Compute the loss at this time step and accumulate it
             loss += optimizer.target(chainer.Variable(x), chainer.Variable(t))
 
-        optimizer.target.zerograds()  # Initialize the parameter gradients
+        optimizer.target.cleargrads()  # Clear the parameter gradients
         loss.backward()  # Backprop
         loss.unchain_backward()  # Truncate the graph
         optimizer.update()  # Update the parameters

--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -208,7 +208,7 @@ for epoch in range(n_epoch):
         count += 1
 
         if count >= batchsize:
-            model.zerograds()
+            model.cleargrads()
             accum_loss.backward()
             optimizer.update()
             total_loss += float(accum_loss.data)

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -184,7 +184,7 @@ for epoch in range(args.epoch):
         accum_loss += loss.data
         word_count += args.batchsize
 
-        model.zerograds()
+        model.cleargrads()
         loss.backward()
         del loss
         optimizer.update()

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -73,7 +73,7 @@ class TestMaxout(unittest.TestCase):
                                  self.wscale, initialW, initial_bias)
 
         self.y = _maxout(self.x, initialW, initial_bias)
-        self.link.zerograds()
+        self.link.cleargrads()
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/links_tests/activation_tests/test_prelu.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_prelu.py
@@ -17,7 +17,7 @@ class TestPReLUSingle(unittest.TestCase):
         self.link = links.PReLU()
         W = self.link.W.data
         W[...] = numpy.random.uniform(-1, 1, W.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.W = W.copy()  # fixed on CPU
 
@@ -71,7 +71,7 @@ class TestPReLUMulti(TestPReLUSingle):
         self.link = links.PReLU(shape=(3,))
         W = self.link.W.data
         W[...] = numpy.random.uniform(-1, 1, W.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.W = W.copy()  # fixed on CPU
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_bias.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_bias.py
@@ -31,7 +31,7 @@ class TestBias(unittest.TestCase):
             self.link.b.data = self.b
         else:
             self.link = links.Bias(axis, None)
-        self.link.zerograds()
+        self.link.cleargrads()
 
     def test_attribute_presence(self):
         self.assertEqual(self.learn_b, hasattr(self.link, 'b'))

--- a/tests/chainer_tests/links_tests/connection_tests/test_bilinear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_bilinear.py
@@ -49,7 +49,7 @@ class TestBilinear(unittest.TestCase):
         self.f.V1.data[...] = _uniform(*self.f.V1.data.shape)
         self.f.V2.data[...] = _uniform(*self.f.V2.data.shape)
         self.f.b.data[...] = _uniform(*self.f.b.data.shape)
-        self.f.zerograds()
+        self.f.cleargrads()
 
         self.W = self.f.W.data.copy()
         self.V1 = self.f.V1.data.copy()
@@ -153,7 +153,7 @@ class TestBilinearWOBias(TestBilinear):
             self.in_shape[0], self.in_shape[1], self.out_size, True)
         W = self.f.W.data
         W[...] = numpy.random.uniform(-1, 1, W.shape)
-        self.f.zerograds()
+        self.f.cleargrads()
 
         self.W = W.copy()
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -19,7 +19,7 @@ class TestConvolution2D(unittest.TestCase):
         self.link = links.Convolution2D(3, 2, 3, stride=2, pad=1)
         b = self.link.b.data
         b[...] = numpy.random.uniform(-1, 1, b.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.x = numpy.random.uniform(-1, 1,
                                       (2, 3, 4, 3)).astype(numpy.float32)
@@ -120,7 +120,7 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
         self.link(chainer.Variable(self.x))
         b = self.link.b.data
         b[...] = numpy.random.uniform(-1, 1, b.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
         self.gy = numpy.random.uniform(-1, 1,
                                        (2, 2, 2, 2)).astype(numpy.float32)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -42,7 +42,7 @@ class TestDeconvolution2D(unittest.TestCase):
             self.link.b.data[...] = numpy.random.uniform(
                 -1, 1, self.link.b.data.shape).astype(numpy.float32)
 
-        self.link.zerograds()
+        self.link.cleargrads()
 
         N = 2
         h, w = 3, 2

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -22,7 +22,7 @@ class TestEmbedID(unittest.TestCase):
     def setUp(self):
         self.link = links.EmbedID(3, 2, ignore_label=self.ignore_label)
         self.link.ignore_label
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.W = self.link.W.data.copy()  # fixed on CPU
         self.x = numpy.array(self.x_data, dtype=numpy.int32)

--- a/tests/chainer_tests/links_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_linear.py
@@ -27,7 +27,7 @@ class TestLinear(unittest.TestCase):
         W[...] = numpy.random.uniform(-1, 1, W.shape)
         b = self.link.b.data
         b[...] = numpy.random.uniform(-1, 1, b.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.W = W.copy()  # fixed on CPU
         self.b = b.copy()  # fixed on CPU
@@ -86,7 +86,7 @@ class TestLinearParameterShapePlaceholder(unittest.TestCase):
         W[...] = numpy.random.uniform(-1, 1, W.shape)
         b = self.link.b.data
         b[...] = numpy.random.uniform(-1, 1, b.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.W = W.copy()  # fixed on CPU
         self.b = b.copy()  # fixed on CPU

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -22,7 +22,7 @@ class TestLSTM(unittest.TestCase):
         upward[...] = numpy.random.uniform(-1, 1, upward.shape)
         lateral = self.link.lateral.W.data
         lateral[...] = numpy.random.uniform(-1, 1, lateral.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.upward = upward.copy()  # fixed on CPU
         self.lateral = lateral.copy()  # fixed on CPU
@@ -230,7 +230,7 @@ class TestStatelessLSTM(unittest.TestCase):
         upward[...] = numpy.random.uniform(-1, 1, upward.shape)
         lateral = self.link.lateral.W.data
         lateral[...] = numpy.random.uniform(-1, 1, lateral.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.upward = upward.copy()  # fixed on CPU
         self.lateral = lateral.copy()  # fixed on CPU

--- a/tests/chainer_tests/links_tests/connection_tests/test_scale.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_scale.py
@@ -44,7 +44,7 @@ class TestScale(unittest.TestCase):
                 axis, None, bias_term, bias_shape)
             if bias_term:
                 self.link.bias.b.data = self.b
-        self.link.zerograds()
+        self.link.cleargrads()
 
     def test_attribute_presence(self):
         self.assertEqual(self.learn_W, hasattr(self.link, 'W'))

--- a/tests/chainer_tests/links_tests/loss_tests/test_hierarchical_softmax.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_hierarchical_softmax.py
@@ -37,7 +37,7 @@ class TestBinaryHierarchicalSoftmax(unittest.TestCase):
     def setUp(self):
         tree = ((0, 1), ((2, 3), 4))
         self.link = links.BinaryHierarchicalSoftmax(3, tree)
-        self.link.zerograds()
+        self.link.cleargrads()
         self.x = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
         self.t = numpy.array([0, 2]).astype(numpy.int32)
         self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -40,7 +40,7 @@ class BatchNormalizationTest(unittest.TestCase):
         gamma[...] = numpy.random.uniform(.5, 1, gamma.shape)
         beta = self.link.beta.data
         beta[...] = numpy.random.uniform(-1, 1, beta.shape)
-        self.link.zerograds()
+        self.link.cleargrads()
 
         self.gamma = gamma.copy()[self.expander]  # fixed on CPU
         self.beta = beta.copy()[self.expander]   # fixed on CPU
@@ -190,7 +190,7 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
             self.link.avg_mean[...] = mean
             var = numpy.random.uniform(0.5, 1, (3,)).astype(numpy.float32)
             self.link.avg_var[...] = var
-        self.link.zerograds()
+        self.link.cleargrads()
 
         shape = (7, 3) + (2,) * self.ndim
         self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -55,7 +55,7 @@ class LinearModel(object):
         for _ in six.moves.range(self.EPOCH):
             x, t = _make_dataset(self.BATCH_SIZE, self.UNIT_NUM, gpu,
                                  self.dtype)
-            model.zerograds()
+            model.cleargrads()
             y = model(x)
             loss = F.softmax_cross_entropy(y, t)
             loss.backward()

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -136,6 +136,11 @@ class TestLink(unittest.TestCase):
         numpy.testing.assert_array_equal(self.link.y.data, l.y.data)
         numpy.testing.assert_array_equal(self.link.y.grad, gy)
 
+    def test_cleargrads(self):
+        self.link.cleargrads()
+        self.assertIsNone(self.link.x.grad)
+        self.assertIsNone(self.link.y.grad)
+
     def test_zerograds(self):
         gx_expect = numpy.zeros_like(self.link.x.data)
         gy_expect = numpy.zeros_like(self.link.y.data)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -267,6 +267,29 @@ class TestVariable(unittest.TestCase):
         cp.testing.assert_array_equal(a.data, b)
         cp.testing.assert_array_equal(a.grad, gb)
 
+    def check_cleargrad(self, a_data, fill=False):
+        xp = cuda.get_array_module(a_data)
+        a = chainer.Variable(a_data)
+        if fill:
+            a.grad = xp.full_like(a_data, np.nan)
+
+        a.cleargrad()
+        self.assertIsNone(a.grad)
+
+    def test_cleargrad_cpu(self):
+        self.check_cleargrad(np.empty(3, dtype=np.float32))
+
+    def test_cleargrad_fill_cpu(self):
+        self.check_cleargrad(np.empty(3, dtype=np.float32), fill=True)
+
+    @attr.gpu
+    def test_cleargrad_gpu(self):
+        self.check_cleargrad(cuda.cupy.empty(3, dtype=np.float32))
+
+    @attr.gpu
+    def test_cleargrad_fill_gpu(self):
+        self.check_cleargrad(cuda.cupy.empty(3, dtype=np.float32), fill=True)
+
     def check_zerograd(self, a_data, fill=False):
         xp = cuda.get_array_module(a_data)
         a = chainer.Variable(a_data)


### PR DESCRIPTION
`Variable.zerograd` requires allocated memory and fills with zero, but [these operations are not necessary](https://github.com/pfnet/chainer/blob/v1.13.0/chainer/variable.py#L375).

TODOs:
- ~~write tests~~
- write docs (I will send another PR for docs)
