### PR TITLE
Fixed min and max behavior for NaN values

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1340,7 +1340,10 @@ struct min_max_st{
     __device__ min_max_st(T v, int i) : value(v), index(i) { }
 };
 
-#define ISNAN(x) (x != x)
+template <typename T>
+inline __device__ bool is_nan(T x) {
+    return x != x;
+}
 
 template <typename T>
 __device__ min_max_st<T> my_min(
@@ -1354,8 +1357,8 @@ __device__ min_max_st<T> my_min_float(
         const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    if (ISNAN(a.value)) return a;
-    if (ISNAN(b.value)) return b;
+    if (is_nan(a.value)) return a;
+    if (is_nan(b.value)) return b;
     return min_max_st<T>(min(a.value, b.value));
 }
 
@@ -1371,8 +1374,8 @@ __device__ min_max_st<T> my_max_float(
         const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    if (ISNAN(a.value)) return a;
-    if (ISNAN(b.value)) return b;
+    if (is_nan(a.value)) return a;
+    if (is_nan(b.value)) return b;
     return min_max_st<T>(max(a.value, b.value));
 }
 
@@ -1392,8 +1395,8 @@ __device__ min_max_st<T> my_argmin_float(
     if (b.index == -1) return a;
     if (a.value == b.value)
         return min_max_st<T>(a.value, min(a.index, b.index));
-    if (ISNAN(a.value)) return a;
-    if (ISNAN(b.value)) return b;
+    if (is_nan(a.value)) return a;
+    if (is_nan(b.value)) return b;
     return (a.value <= b.value) ? a : b;
 }
 
@@ -1413,8 +1416,8 @@ __device__ min_max_st<T> my_argmax_float(
     if (b.index == -1) return a;
     if (a.value == b.value)
         return min_max_st<T>(a.value, min(a.index, b.index));
-    if (ISNAN(a.value)) return a;
-    if (ISNAN(b.value)) return b;
+    if (is_nan(a.value)) return a;
+    if (is_nan(b.value)) return b;
     return (a.value >= b.value) ? a : b;
 }
 '''

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1340,6 +1340,8 @@ struct min_max_st{
     __device__ min_max_st(T v, int i) : value(v), index(i) { }
 };
 
+#define ISNAN(x) (x != x)
+
 template <typename T>
 __device__ min_max_st<T> my_min(
         const min_max_st<T>& a, const min_max_st<T>& b) {
@@ -1352,8 +1354,8 @@ __device__ min_max_st<T> my_min_float(
         const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    if (isnan(a.value)) return a;
-    if (isnan(b.value)) return b;
+    if (ISNAN(a.value)) return a;
+    if (ISNAN(b.value)) return b;
     return min_max_st<T>(min(a.value, b.value));
 }
 
@@ -1369,8 +1371,8 @@ __device__ min_max_st<T> my_max_float(
         const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    if (isnan(a.value)) return a;
-    if (isnan(b.value)) return b;
+    if (ISNAN(a.value)) return a;
+    if (ISNAN(b.value)) return b;
     return min_max_st<T>(max(a.value, b.value));
 }
 
@@ -1390,8 +1392,8 @@ __device__ min_max_st<T> my_argmin_float(
     if (b.index == -1) return a;
     if (a.value == b.value)
         return min_max_st<T>(a.value, min(a.index, b.index));
-    if (isnan(a.value)) return a;
-    if (isnan(b.value)) return b;
+    if (ISNAN(a.value)) return a;
+    if (ISNAN(b.value)) return b;
     return (a.value <= b.value) ? a : b;
 }
 
@@ -1411,8 +1413,8 @@ __device__ min_max_st<T> my_argmax_float(
     if (b.index == -1) return a;
     if (a.value == b.value)
         return min_max_st<T>(a.value, min(a.index, b.index));
-    if (isnan(a.value)) return a;
-    if (isnan(b.value)) return b;
+    if (ISNAN(a.value)) return a;
+    if (ISNAN(b.value)) return b;
     return (a.value >= b.value) ? a : b;
 }
 '''

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1331,66 +1331,138 @@ divmod = create_ufunc(
 
 
 cdef _min_max_preamble = '''
+template <typename T>
 struct min_max_st{
-    type_in0_raw value;
+    T value;
     int index;
     __device__ min_max_st() : index(-1) { }
-    __device__ min_max_st(type_in0_raw v) : value(v), index(0) { }
-    __device__ min_max_st(type_in0_raw v, int i) : value(v), index(i) { }
+    __device__ min_max_st(T v) : value(v), index(0) { }
+    __device__ min_max_st(T v, int i) : value(v), index(i) { }
 };
-__device__ min_max_st my_min(const min_max_st& a, const min_max_st& b) {
+
+template <typename T>
+__device__ min_max_st<T> my_min(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    return min_max_st(min(a.value, b.value));
+    return min_max_st<T>(min(a.value, b.value));
 }
-__device__ min_max_st my_max(const min_max_st& a, const min_max_st& b) {
+template <typename T>
+__device__ min_max_st<T> my_min_float(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    return min_max_st(max(a.value, b.value));
+    if (isnan(a.value)) return a;
+    if (isnan(b.value)) return b;
+    return min_max_st<T>(min(a.value, b.value));
 }
-__device__ min_max_st my_argmin(const min_max_st& a, const min_max_st& b) {
+
+template <typename T>
+__device__ min_max_st<T> my_max(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    if (a.value == b.value) return min_max_st(a.value, min(a.index, b.index));
+    return min_max_st<T>(max(a.value, b.value));
+}
+template <typename T>
+__device__ min_max_st<T> my_max_float(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (isnan(a.value)) return a;
+    if (isnan(b.value)) return b;
+    return min_max_st<T>(max(a.value, b.value));
+}
+
+template <typename T>
+__device__ min_max_st<T> my_argmin(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (a.value == b.value)
+        return min_max_st<T>(a.value, min(a.index, b.index));
     return (a.value <= b.value) ? a : b;
 }
-__device__ min_max_st my_argmax(const min_max_st& a, const min_max_st& b) {
+template <typename T>
+__device__ min_max_st<T> my_argmin_float(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
     if (a.index == -1) return b;
     if (b.index == -1) return a;
-    if (a.value == b.value) return min_max_st(a.value, min(a.index, b.index));
+    if (a.value == b.value)
+        return min_max_st<T>(a.value, min(a.index, b.index));
+    if (isnan(a.value)) return a;
+    if (isnan(b.value)) return b;
+    return (a.value <= b.value) ? a : b;
+}
+
+template <typename T>
+__device__ min_max_st<T> my_argmax(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (a.value == b.value)
+        return min_max_st<T>(a.value, min(a.index, b.index));
     return (a.value >= b.value) ? a : b;
-}'''
+}
+template <typename T>
+__device__ min_max_st<T> my_argmax_float(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (a.value == b.value)
+        return min_max_st<T>(a.value, min(a.index, b.index));
+    if (isnan(a.value)) return a;
+    if (isnan(b.value)) return b;
+    return (a.value >= b.value) ? a : b;
+}
+'''
 
 
 cdef _amin = create_reduction_func(
     'cupy_min',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d'),
-    ('min_max_st(in0)', 'my_min(a, b)', 'out0 = a.value', 'min_max_st'),
+     'q->q', 'Q->Q',
+     ('e->e', (None, 'my_min_float(a, b)', None, None)),
+     ('f->f', (None, 'my_min_float(a, b)', None, None)),
+     ('d->d', (None, 'my_min_float(a, b)', None, None))),
+    ('min_max_st<type_in0_raw>(in0)', 'my_min(a, b)', 'out0 = a.value',
+     'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 
 
 cdef _amax = create_reduction_func(
     'cupy_max',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d'),
-    ('min_max_st(in0)', 'my_max(a, b)', 'out0 = a.value', 'min_max_st'),
+     'q->q', 'Q->Q',
+     ('e->e', (None, 'my_max_float(a, b)', None, None)),
+     ('f->f', (None, 'my_max_float(a, b)', None, None)),
+     ('d->d', (None, 'my_max_float(a, b)', None, None))),
+    ('min_max_st<type_in0_raw>(in0)', 'my_max(a, b)', 'out0 = a.value',
+     'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 
 
 cdef _argmin = create_reduction_func(
     'cupy_argmin',
     ('?->l', 'B->l', 'h->l', 'H->l', 'i->l', 'I->l', 'l->l', 'L->l',
-     'q->l', 'Q->l', 'e->l', 'f->l', 'd->l'),
-    ('min_max_st(in0, _J)', 'my_argmin(a, b)', 'out0 = a.index', 'min_max_st'),
+     'q->l', 'Q->l',
+     ('e->l', (None, 'my_argmin_float(a, b)', None, None)),
+     ('f->l', (None, 'my_argmin_float(a, b)', None, None)),
+     ('d->l', (None, 'my_argmin_float(a, b)', None, None))),
+    ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmin(a, b)', 'out0 = a.index',
+     'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 
 
 cdef _argmax = create_reduction_func(
     'cupy_argmax',
     ('?->l', 'B->l', 'h->l', 'H->l', 'i->l', 'I->l', 'l->l', 'L->l',
-     'q->l', 'Q->l', 'e->l', 'f->l', 'd->l'),
-    ('min_max_st(in0, _J)', 'my_argmax(a, b)', 'out0 = a.index', 'min_max_st'),
+     'q->l', 'Q->l',
+     ('e->l', (None, 'my_argmax_float(a, b)', None, None)),
+     ('f->l', (None, 'my_argmax_float(a, b)', None, None)),
+     ('d->l', (None, 'my_argmax_float(a, b)', None, None))),
+    ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmax(a, b)', 'out0 = a.index',
+     'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 
 

--- a/cupy/statistics/order.py
+++ b/cupy/statistics/order.py
@@ -1,6 +1,11 @@
 def amin(a, axis=None, out=None, keepdims=False, dtype=None):
     """Returns the minimum of an array or the minimum along an axis.
 
+    .. note::
+
+       When at least one element is NaN, the corresponding min value will be
+       NaN.
+
     Args:
         a (cupy.ndarray): Array to take the minimum.
         axis (int): Along which axis to take the minimum. The flattened array
@@ -22,6 +27,11 @@ def amin(a, axis=None, out=None, keepdims=False, dtype=None):
 
 def amax(a, axis=None, out=None, keepdims=False, dtype=None):
     """Returns the maximum of an array or the maximum along an axis.
+
+    .. note::
+
+       When at least one element is NaN, the corresponding min value will be
+       NaN.
 
     Args:
         a (cupy.ndarray): Array to take the maximum.

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -38,6 +38,12 @@ class TestArrayReduction(unittest.TestCase):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.max(axis=2)
 
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_max_nan(self, xp, dtype):
+        a = xp.array([float('nan'), 1, -1], dtype)
+        return a.max()
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_min_all(self, xp, dtype):
@@ -67,3 +73,9 @@ class TestArrayReduction(unittest.TestCase):
     def test_min_axis2(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.min(axis=2)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_min_nan(self, xp, dtype):
+        a = xp.array([float('nan'), 1, -1], dtype)
+        return a.min()

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -24,6 +24,12 @@ class TestSearch(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_argmax_nan(self, xp, dtype):
+        a = xp.array([float('nan'), -1, 1], dtype)
+        return a.argmax()
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_argmax_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.argmax(axis=0)
@@ -56,6 +62,12 @@ class TestSearch(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_argmin_all(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
+        return a.argmin()
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_argmin_nan(self, xp, dtype):
+        a = xp.array([float('nan'), -1, 1], dtype)
         return a.argmin()
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
Numpy's `min` and `max` return NaN when an array contains NaN value.
Note that `min` and `max` functions in CUDA ignore NaN values.
fix #1366 