### PR TITLE
Skip build when distutils raises an error

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -111,6 +111,9 @@ def check_library(compiler, includes=(), libraries=(),
 
         return True
 
+    except distutils.errors.DistutilsError:
+        return False
+
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
 

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -111,7 +111,8 @@ def check_library(compiler, includes=(), libraries=(),
 
         return True
 
-    except distutils.errors.DistutilsError:
+    except distutils.errors.DistutilsError as e:
+        print('distutils raises an error: %s' % e)
         return False
 
     finally:


### PR DESCRIPTION
In some environment, `distutils` raises an error. This patch ignores errors and skips installing cupy.