### PR TITLE
Change default behavior of accept_error

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -124,8 +124,12 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          type_check(bool): If ``True``, consistency of dtype is also checked.
-         accept_error(bool): If ``True``, errors are not raised as long as
-             the errors occurred are identical between NumPy and CuPy.
+         accept_error(bool, Exception or tuple of Exception): Sepcify
+             acceptable errors. When both NumPy test and CuPy test raises the
+             same type of errors, and the type of the errors is specified with
+             this argument, the errors are ignored and not raised.
+             If it is ``True`` all error types are acceptable.
+             If it is ``False`` no error is acceptable.
 
     Decorated test fixture is required to return the arrays whose values are
     close between ``numpy`` case and ``cupy`` case.
@@ -166,8 +170,12 @@ def numpy_cupy_array_almost_equal(decimal=6, err_msg='', verbose=True,
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          type_check(bool): If ``True``, consistency of dtype is also checked.
-         accept_error(bool): If ``True``, errors are not raised as long as
-             the errors occurred are identical between NumPy and CuPy.
+         accept_error(bool, Exception or tuple of Exception): Sepcify
+             acceptable errors. When both NumPy test and CuPy test raises the
+             same type of errors, and the type of the errors is specified with
+             this argument, the errors are ignored and not raised.
+             If it is ``True`` all error types are acceptable.
+             If it is ``False`` no error is acceptable.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`cupy.testing.assert_array_almost_equal`
@@ -190,8 +198,12 @@ def numpy_cupy_array_almost_equal_nulp(nulp=1, name='xp', type_check=True,
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          type_check(bool): If ``True``, consistency of dtype is also checked.
-         accept_error(bool): If ``True``, errors are not raised as long as
-             the errors occurred are identical between NumPy and CuPy.
+         accept_error(bool, Exception or tuple of Exception): Sepcify
+             acceptable errors. When both NumPy test and CuPy test raises the
+             same type of errors, and the type of the errors is specified with
+             this argument, the errors are ignored and not raised.
+             If it is ``True`` all error types are acceptable.
+             If it is ``False`` no error is acceptable.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`cupy.testing.assert_array_almost_equal_nulp`
@@ -216,8 +228,12 @@ def numpy_cupy_array_max_ulp(maxulp=1, dtype=None, name='xp', type_check=True,
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          type_check(bool): If ``True``, consistency of dtype is also checked.
-         accept_error(bool): If ``True``, errors are not raised as long as
-             the errors occurred are identical between NumPy and CuPy.
+         accept_error(bool, Exception or tuple of Exception): Sepcify
+             acceptable errors. When both NumPy test and CuPy test raises the
+             same type of errors, and the type of the errors is specified with
+             this argument, the errors are ignored and not raised.
+             If it is ``True`` all error types are acceptable.
+             If it is ``False`` no error is acceptable.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`assert_array_max_ulp`
@@ -242,8 +258,12 @@ def numpy_cupy_array_equal(err_msg='', verbose=True, name='xp',
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          type_check(bool): If ``True``, consistency of dtype is also checked.
-         accept_error(bool): If ``True``, errors are not raised as long as
-             the errors occurred are identical between NumPy and CuPy.
+         accept_error(bool, Exception or tuple of Exception): Sepcify
+             acceptable errors. When both NumPy test and CuPy test raises the
+             same type of errors, and the type of the errors is specified with
+             this argument, the errors are ignored and not raised.
+             If it is ``True`` all error types are acceptable.
+             If it is ``False`` no error is acceptable.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`numpy_cupy_array_equal`
@@ -296,8 +316,12 @@ def numpy_cupy_array_less(err_msg='', verbose=True, name='xp',
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          type_check(bool): If ``True``, consistency of dtype is also checked.
-         accept_error(bool): If ``True``, errors are not raised as long as
-             the errors occurred are identical between NumPy and CuPy.
+         accept_error(bool, Exception or tuple of Exception): Sepcify
+             acceptable errors. When both NumPy test and CuPy test raises the
+             same type of errors, and the type of the errors is specified with
+             this argument, the errors are ignored and not raised.
+             If it is ``True`` all error types are acceptable.
+             If it is ``False`` no error is acceptable.
 
     Decorated test fixture is required to return the smaller array
     when ``xp`` is ``cupy`` than the one when ``xp`` is ``numpy``.

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -31,6 +31,12 @@ def _call_func(self, impl, args, kw):
 
 def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
                             numpy_tb, accept_error=False):
+    # For backward compatibility
+    if accept_error == True:
+        accept_error = Exception
+    elif not accept_error:
+        accept_error = ()
+
     if cupy_error is None and numpy_error is None:
         self.fail('Both cupy and numpy are expected to raise errors, but not')
     elif cupy_error is None:
@@ -46,7 +52,7 @@ numpy
 %s
 ''' % (cupy_tb, numpy_tb)
         self.fail(msg)
-    elif not accept_error:
+    elif not isinstance(cupy_error, accept_error):
         msg = '''Both cupy and numpy raise exceptions
 
 cupy
@@ -338,7 +344,8 @@ def numpy_cupy_raises(name='xp'):
                 numpy_tb = traceback.format_exc()
 
             _check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                    numpy_error, numpy_tb, accept_error=True)
+                                    numpy_error, numpy_tb,
+                                    accept_error=Exception)
         return test_func
     return decorator
 

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -30,7 +30,7 @@ def _call_func(self, impl, args, kw):
 
 
 def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
-                            numpy_tb, accept_error=True):
+                            numpy_tb, accept_error=False):
     if cupy_error is None and numpy_error is None:
         self.fail('Both cupy and numpy are expected to raise errors, but not')
     elif cupy_error is None:
@@ -106,7 +106,7 @@ def _make_decorator(check_func, name, type_check, accept_error):
 
 
 def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
-                        name='xp', type_check=True, accept_error=True):
+                        name='xp', type_check=True, accept_error=False):
     """Decorator that checks NumPy results and CuPy ones are close.
 
     Args:
@@ -149,7 +149,7 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
 
 def numpy_cupy_array_almost_equal(decimal=6, err_msg='', verbose=True,
                                   name='xp', type_check=True,
-                                  accept_error=True):
+                                  accept_error=False):
     """Decorator that checks NumPy results and CuPy ones are almost equal.
 
     Args:
@@ -176,7 +176,7 @@ def numpy_cupy_array_almost_equal(decimal=6, err_msg='', verbose=True,
 
 
 def numpy_cupy_array_almost_equal_nulp(nulp=1, name='xp', type_check=True,
-                                       accept_error=True):
+                                       accept_error=False):
     """Decorator that checks results of NumPy and CuPy are equal w.r.t. spacing.
 
     Args:
@@ -199,7 +199,7 @@ def numpy_cupy_array_almost_equal_nulp(nulp=1, name='xp', type_check=True,
 
 
 def numpy_cupy_array_max_ulp(maxulp=1, dtype=None, name='xp', type_check=True,
-                             accept_error=True):
+                             accept_error=False):
     """Decorator that checks results of NumPy and CuPy ones are equal w.r.t. ulp.
 
     Args:
@@ -226,7 +226,7 @@ def numpy_cupy_array_max_ulp(maxulp=1, dtype=None, name='xp', type_check=True,
 
 
 def numpy_cupy_array_equal(err_msg='', verbose=True, name='xp',
-                           type_check=True, accept_error=True):
+                           type_check=True, accept_error=False):
     """Decorator that checks NumPy results and CuPy ones are equal.
 
     Args:
@@ -280,7 +280,7 @@ def numpy_cupy_array_list_equal(err_msg='', verbose=True, name='xp'):
 
 
 def numpy_cupy_array_less(err_msg='', verbose=True, name='xp',
-                          type_check=True, accept_error=True):
+                          type_check=True, accept_error=False):
     """Decorator that checks the CuPy result is less than NumPy result.
 
     Args:

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -32,7 +32,7 @@ def _call_func(self, impl, args, kw):
 def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
                             numpy_tb, accept_error=False):
     # For backward compatibility
-    if accept_error == True:
+    if accept_error is True:
         accept_error = Exception
     elif not accept_error:
         accept_error = ()

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -14,7 +14,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_scalar_op(self, op, xp, x_type, y_type, swap=False):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         if swap:
@@ -104,7 +104,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_scalar_op(operator.pow, swap=True)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(atol=1.0, accept_error=True)
+    @testing.numpy_cupy_allclose(atol=1.0, accept_error=TypeError)
     def check_ipow_scalar(self, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         return operator.ipow(a, y_type(3))
@@ -148,7 +148,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_scalar_op(operator.ne)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_array_op(self, op, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[6, 5, 4], [3, 2, 1]], y_type)
@@ -210,7 +210,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_array_op(operator.pow)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(atol=1.0, accept_error=True)
+    @testing.numpy_cupy_allclose(atol=1.0, accept_error=TypeError)
     def check_ipow_array(self, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[6, 5, 4], [3, 2, 1]], y_type)
@@ -247,7 +247,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_array_op(operator.ne)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_broadcasted_op(self, op, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[1], [2]], y_type)
@@ -310,7 +310,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(atol=1.0, accept_error=True)
+    @testing.numpy_cupy_allclose(atol=1.0, accept_error=TypeError)
     def check_broadcasted_ipow(self, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[1], [2]], y_type)
@@ -477,7 +477,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_scalar_op(self, op, xp, x_type, y_type, swap=False):
         a = xp.array([[0, 1, 2], [1, 0, 2]], dtype=x_type)
         if swap:
@@ -524,7 +524,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_scalar_op(operator.mod, swap=True)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_scalarzero_op(self, op, xp, x_type, y_type, swap=False):
         a = xp.array([[0, 1, 2], [1, 0, 2]], dtype=x_type)
         if swap:
@@ -571,7 +571,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_scalarzero_op(operator.mod, swap=True)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_array_op(self, op, xp, x_type, y_type):
         a = xp.array([[0, 1, 2], [1, 0, 2]], dtype=x_type)
         b = xp.array([[0, 0, 1], [0, 1, 2]], dtype=y_type)
@@ -622,7 +622,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_array_op(operator.imod)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_broadcasted_op(self, op, xp, x_type, y_type):
         a = xp.array([[0, 1, 2], [1, 0, 2], [2, 1, 0]], dtype=x_type)
         b = xp.array([[0, 0, 1]], dtype=y_type)
@@ -673,7 +673,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_broadcasted_op(operator.imod)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_doubly_broadcasted_op(self, op, xp, x_type, y_type):
         a = xp.array([[[0, 1, 2]], [[1, 0, 2]]], dtype=x_type)
         b = xp.array([[0], [0], [1]], dtype=y_type)

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -14,7 +14,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_scalar_op(self, op, xp, x_type, y_type, swap=False):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         if swap:
@@ -104,7 +104,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_scalar_op(operator.pow, swap=True)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(atol=1.0)
+    @testing.numpy_cupy_allclose(atol=1.0, accept_error=True)
     def check_ipow_scalar(self, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         return operator.ipow(a, y_type(3))
@@ -148,7 +148,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_scalar_op(operator.ne)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_array_op(self, op, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[6, 5, 4], [3, 2, 1]], y_type)
@@ -210,7 +210,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_array_op(operator.pow)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(atol=1.0)
+    @testing.numpy_cupy_allclose(atol=1.0, accept_error=True)
     def check_ipow_array(self, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[6, 5, 4], [3, 2, 1]], y_type)
@@ -247,7 +247,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_array_op(operator.ne)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_broadcasted_op(self, op, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[1], [2]], y_type)
@@ -310,7 +310,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose(atol=1.0)
+    @testing.numpy_cupy_allclose(atol=1.0, accept_error=True)
     def check_broadcasted_ipow(self, xp, x_type, y_type):
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[1], [2]], y_type)
@@ -477,7 +477,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_scalar_op(self, op, xp, x_type, y_type, swap=False):
         a = xp.array([[0, 1, 2], [1, 0, 2]], dtype=x_type)
         if swap:
@@ -524,7 +524,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_scalar_op(operator.mod, swap=True)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_scalarzero_op(self, op, xp, x_type, y_type, swap=False):
         a = xp.array([[0, 1, 2], [1, 0, 2]], dtype=x_type)
         if swap:
@@ -571,7 +571,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_scalarzero_op(operator.mod, swap=True)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_array_op(self, op, xp, x_type, y_type):
         a = xp.array([[0, 1, 2], [1, 0, 2]], dtype=x_type)
         b = xp.array([[0, 0, 1], [0, 1, 2]], dtype=y_type)
@@ -622,7 +622,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_array_op(operator.imod)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_broadcasted_op(self, op, xp, x_type, y_type):
         a = xp.array([[0, 1, 2], [1, 0, 2], [2, 1, 0]], dtype=x_type)
         b = xp.array([[0, 0, 1]], dtype=y_type)
@@ -673,7 +673,7 @@ class TestArrayIntElementwiseOp(unittest.TestCase):
             self.check_array_broadcasted_op(operator.imod)
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_array_doubly_broadcasted_op(self, op, xp, x_type, y_type):
         a = xp.array([[[0, 1, 2]], [[1, 0, 2]]], dtype=x_type)
         b = xp.array([[0], [0], [1]], dtype=y_type)

--- a/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
@@ -91,7 +91,7 @@ class TestArrayIntUnaryOp(unittest.TestCase):
         self.check_array_op(operator.invert)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_zerodim_op(self, op, xp, dtype):
         a = xp.array(-2, dtype)
         return op(a)

--- a/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
@@ -91,7 +91,7 @@ class TestArrayIntUnaryOp(unittest.TestCase):
         self.check_array_op(operator.invert)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def check_zerodim_op(self, op, xp, dtype):
         a = xp.array(-2, dtype)
         return op(a)

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -46,7 +46,7 @@ class TestDot(unittest.TestCase):
     @testing.for_float_dtypes(name='dtype_a')
     @testing.for_float_dtypes(name='dtype_b')
     @testing.for_float_dtypes(name='dtype_c')
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=ValueError)
     def test_dot_with_out(self, xp, dtype_a, dtype_b, dtype_c):
         shape_a, shape_b = self.shape
         if self.trans_a:

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -46,7 +46,7 @@ class TestDot(unittest.TestCase):
     @testing.for_float_dtypes(name='dtype_a')
     @testing.for_float_dtypes(name='dtype_b')
     @testing.for_float_dtypes(name='dtype_c')
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def test_dot_with_out(self, xp, dtype_a, dtype_b, dtype_c):
         shape_a, shape_b = self.shape
         if self.trans_a:
@@ -106,13 +106,13 @@ class TestProduct(unittest.TestCase):
         return c
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_raises()
     def test_transposed_dot_with_out2(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype).transpose(1, 0, 2)
         b = testing.shaped_arange((4, 2, 3), xp, dtype).transpose(2, 0, 1)
         c = xp.ndarray((3, 2, 3, 2)[::-1], dtype=dtype).T
+        # Only C-contiguous array is acceptable
         xp.dot(a, b, out=c)
-        return c
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -9,7 +9,7 @@ class TestRearrange(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_equal(accept_error=True)
     def test_roll(self, xp, dtype):
         x = xp.arange(10, dtype)
         return xp.roll(x, 2)

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -9,7 +9,7 @@ class TestRearrange(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal(accept_error=True)
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
     def test_roll(self, xp, dtype):
         x = xp.arange(10, dtype)
         return xp.roll(x, 2)

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -23,7 +23,7 @@ class TestSearch(unittest.TestCase):
         return xp.argmax(a)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def test_argmax_nan(self, xp, dtype):
         a = xp.array([float('nan'), -1, 1], dtype)
         return a.argmax()
@@ -65,7 +65,7 @@ class TestSearch(unittest.TestCase):
         return a.argmin()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def test_argmin_nan(self, xp, dtype):
         a = xp.array([float('nan'), -1, 1], dtype)
         return a.argmin()

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -23,7 +23,7 @@ class TestSearch(unittest.TestCase):
         return xp.argmax(a)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=ValueError)
     def test_argmax_nan(self, xp, dtype):
         a = xp.array([float('nan'), -1, 1], dtype)
         return a.argmax()
@@ -65,7 +65,7 @@ class TestSearch(unittest.TestCase):
         return a.argmin()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=ValueError)
     def test_argmin_nan(self, xp, dtype):
         a = xp.array([float('nan'), -1, 1], dtype)
         return a.argmin()

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -41,26 +41,26 @@ class TestHistogram(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def test_bincount(self, xp, dtype):
         x = testing.shaped_arange((3,), xp, dtype)
         return xp.bincount(x)
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def test_bincount_duplicated_value(self, xp, dtype):
         x = xp.array([1, 2, 2, 1, 2, 4], dtype)
         return xp.bincount(x)
 
     @for_all_dtypes_combination_bincount(names=['x_type', 'w_type'])
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def test_bincount_with_weight(self, xp, x_type, w_type):
         x = testing.shaped_arange((3,), xp, x_type)
         w = testing.shaped_arange((3,), xp, w_type)
         return xp.bincount(x, weights=w)
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_allclose(accept_error=True)
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
     def test_bincount_with_minlength(self, xp, dtype):
         x = testing.shaped_arange((3,), xp, dtype)
         return xp.bincount(x, minlength=5)

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -41,26 +41,26 @@ class TestHistogram(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def test_bincount(self, xp, dtype):
         x = testing.shaped_arange((3,), xp, dtype)
         return xp.bincount(x)
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def test_bincount_duplicated_value(self, xp, dtype):
         x = xp.array([1, 2, 2, 1, 2, 4], dtype)
         return xp.bincount(x)
 
     @for_all_dtypes_combination_bincount(names=['x_type', 'w_type'])
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def test_bincount_with_weight(self, xp, x_type, w_type):
         x = testing.shaped_arange((3,), xp, x_type)
         w = testing.shaped_arange((3,), xp, w_type)
         return xp.bincount(x, weights=w)
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(accept_error=True)
     def test_bincount_with_minlength(self, xp, dtype):
         x = testing.shaped_arange((3,), xp, dtype)
         return xp.bincount(x, minlength=5)

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -69,7 +69,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         # Nothing happens
         helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
                                        numpy_error, numpy_tb,
-                                       accept_error=True)
+                                       accept_error=Exception)
 
     def test_forbidden_error(self):
         cupy_error = Exception()

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -68,7 +68,8 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         numpy_tb = 'yyyy'
         # Nothing happens
         helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                       numpy_error, numpy_tb)
+                                       numpy_error, numpy_tb,
+                                       accept_error=True)
 
     def test_forbidden_error(self):
         cupy_error = Exception()


### PR DESCRIPTION
I fixed default argument of numpy-cupy comparison. And, I set `accept_error=True` for only tests which raises errors.
fix #1419 