### PR TITLE
Support N-dimensional convolution function and link

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -459,6 +459,18 @@ def memoize(for_each_device=False):
     return dummy_decorator
 
 
+def clear_memo():
+    """Clears the memoized results for all functions decorated by memoize.
+
+    This function works like :func:`cupy.clear_memo` as a counterpart for
+    :func:`chainer.cuda.memoize`. It can be used even if CUDA is not available.
+    In such a case, this function does nothing.
+
+    """
+    if available:
+        cupy.clear_memo()
+
+
 # ------------------------------------------------------------------------------
 # Kernel definition utility
 # ------------------------------------------------------------------------------

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -35,6 +35,7 @@ from chainer.functions.array import transpose_sequence
 from chainer.functions.array import where
 from chainer.functions.connection import bilinear
 from chainer.functions.connection import convolution_2d
+from chainer.functions.connection import convolution_nd
 from chainer.functions.connection import deconvolution_2d
 from chainer.functions.connection import embed_id
 from chainer.functions.connection import linear
@@ -169,6 +170,7 @@ where = where.where
 
 bilinear = bilinear.bilinear
 convolution_2d = convolution_2d.convolution_2d
+convolution_nd = convolution_nd.convolution_nd
 deconvolution_2d = deconvolution_2d.deconvolution_2d
 embed_id = embed_id.embed_id
 linear = linear.linear

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -98,7 +98,7 @@ class Convolution2DFunction(function.Function):
 
             self.filter_desc = cudnn.create_filter_descriptor(W)
             self.conv_desc = cudnn.create_convolution_descriptor(
-                (self.ph, self.pw), (self.sy, self.sx))
+                (self.ph, self.pw), (self.sy, self.sx), x.dtype)
             if b is not None:
                 self.bias_desc = cudnn.create_tensor_descriptor(
                     b[None, :, None, None])

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -1,0 +1,335 @@
+import numpy
+
+from six import moves
+
+from chainer import cuda
+from chainer import function
+from chainer.functions.connection import convolution_2d
+from chainer.utils import conv
+from chainer.utils import conv_nd
+from chainer.utils import type_check
+
+
+if cuda.cudnn_enabled:
+    cudnn = cuda.cudnn
+    libcudnn = cuda.cudnn.cudnn
+    _cudnn_version = libcudnn.getVersion()
+    _fwd_pref = libcudnn.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT
+    if _cudnn_version >= 4000:
+        _bwd_filter_pref = \
+            libcudnn.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT
+        _bwd_data_pref = \
+            libcudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT
+
+
+_check_cudnn_acceptable_type = convolution_2d._check_cudnn_acceptable_type
+
+
+class ConvolutionND(function.Function):
+
+    def __init__(self, ndim, stride=1, pad=0, use_cudnn=True, cover_all=False):
+        self.ndim = ndim
+        self.stride = conv_nd.as_tuple(stride, ndim)
+        self.pad = conv_nd.as_tuple(pad, ndim)
+        self.use_cudnn = use_cudnn
+        self.cover_all = cover_all
+
+    def check_type_forward(self, in_types):
+        n_in = in_types.size()
+        type_check.expect(2 <= n_in, n_in <= 3)
+
+        x_type = in_types[0]
+        w_type = in_types[1]
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            w_type.dtype.kind == 'f',
+            x_type.ndim == self.ndim + 2,
+            w_type.ndim == self.ndim + 2,
+            x_type.shape[1] == w_type.shape[1],
+        )
+
+        if n_in.eval() == 3:
+            b_type = in_types[2]
+            type_check.expect(
+                b_type.dtype == x_type.dtype,
+                b_type.ndim == 1,
+                b_type.shape[0] == w_type.shape[0],
+            )
+
+    def _use_cudnn(self, x, W):
+        return (not self.cover_all and
+                cuda.cudnn_enabled and
+                self.use_cudnn and
+                self.ndim > 1 and
+                _check_cudnn_acceptable_type(x.dtype, W.dtype))
+
+    def _forward_xp(self, x, W, b, xp):
+        ndim = self.ndim
+        ksize = W.shape[2:]
+        stride = self.stride
+        pad = self.pad
+
+        # Make patch array.
+        if xp is numpy:
+            self.col = conv_nd.im2col_nd_cpu(
+                x, ksize, stride, pad, cover_all=self.cover_all)
+        else:
+            self.col = conv_nd.im2col_nd_gpu(
+                x, ksize, stride, pad, cover_all=self.cover_all)
+
+        # Compute correlation.
+        axes = tuple(moves.range(1, ndim + 2))  # (1, 2, ..., N+1)
+        y = xp.tensordot(self.col, W, (axes, axes)).astype(x.dtype)
+
+        # Apply bias if given.
+        if b is not None:
+            y += b
+
+        # Roll c_O before the second in (n, y_1, y_2, ..., y_N, c_O).
+        return xp.rollaxis(y, ndim + 1, 1),
+
+    def _forward_cudnn(self, x, W, b):
+        out_c = W.shape[0]      # (c_O, _, k_1, k_2, ..., k_N)
+        ksize = W.shape[2:]
+        n, c = x.shape[:2]      # (n, c_I, d_1, d_2, ..., d_N)
+        dims = x.shape[2:]
+        stride = self.stride
+        pad = self.pad
+        ndim = self.ndim
+        colon = slice(None)
+
+        # Make empty array for result.
+        outs = tuple(
+            conv.get_conv_outsize(d, k, s, p, cover_all=self.cover_all)
+            for (d, k, s, p) in zip(dims, ksize, stride, pad))
+        y_shape = (n, out_c) + outs  # (n, c_O, out_1, out_2, ..., out_N)
+        y = cuda.cupy.empty(y_shape, dtype=x.dtype)
+
+        # Convert to C-contiguous arrays.
+        x = cuda.cupy.ascontiguousarray(x)
+        W = cuda.cupy.ascontiguousarray(W)
+        if b is not None:
+            b = cuda.cupy.ascontiguousarray(b)
+
+        # Get cuDNN handler and descriptors.
+        handle = cudnn.get_handle()
+        x_desc = cudnn.create_tensor_descriptor(x)
+        y_desc = cudnn.create_tensor_descriptor(y)
+
+        self.filter_desc = cudnn.create_filter_descriptor(W)
+        self.conv_desc = cudnn.create_convolution_descriptor(pad, stride)
+        if b is not None:
+            b_index = (None, colon) + (None,) * ndim
+            self.bias_desc = cudnn.create_tensor_descriptor(b[b_index])
+
+        # Find cuDNN algorithm to be used.
+        workspace_size = cuda.get_max_workspace_size()
+        workspace = cuda.cupy.empty((workspace_size,), dtype='b')
+        algo = libcudnn.getConvolutionForwardAlgorithm(
+            handle, x_desc.value, self.filter_desc.value,
+            self.conv_desc.value, y_desc.value, _fwd_pref,
+            workspace_size)
+
+        # cuDNN forward computation.
+        oz_dtype = 'd' if x.dtype == 'd' else 'f'
+        one = numpy.array(1, dtype=oz_dtype).ctypes
+        zero = numpy.array(0, dtype=oz_dtype).ctypes
+        libcudnn.convolutionForward(
+            handle, one.data, x_desc.value, x.data.ptr,
+            self.filter_desc.value, W.data.ptr, self.conv_desc.value,
+            algo, workspace.data.ptr, workspace_size, zero.data,
+            y_desc.value, y.data.ptr)
+
+        # Add bias if given.
+        # TODO(takagi) Support unshared bias
+        if b is not None:
+            cudnn.add_tensor(
+                handle, one.data, self.bias_desc.value, b.data.ptr,
+                one.data, y_desc.value, y.data.ptr)
+
+        return y,
+
+    def forward(self, inputs):
+        x, W = inputs[:2]
+        b = inputs[2] if len(inputs) == 3 else None
+
+        xp = cuda.get_array_module(*inputs)
+        if xp is numpy:
+            return self._forward_xp(x, W, b, numpy)
+        elif not self._use_cudnn(x, W):
+            return self._forward_xp(x, W, b, cuda.cupy)
+        else:
+            return self._forward_cudnn(x, W, b)
+
+    def _backward_xp(self, x, W, b, gy, xp):
+        dims = x.shape[2:]     # (n, c_I, d_1, d_2, ..., d_N)
+        stride = self.stride
+        pad = self.pad
+        ndim = self.ndim
+
+        # Compute filter weight gradient.
+        # (n, _, out_1, out_2, ..., out_N)
+        out_axes = (0,) + tuple(moves.range(2, ndim + 2))
+        # (n, _, _, ..., _, out_1, out_2, ..., out_N)
+        col_axes = (0,) + tuple(moves.range(ndim + 2, ndim * 2 + 2))
+        gW = xp.tensordot(gy, self.col, (out_axes, col_axes)).astype(W.dtype)
+
+        # Compute patch array gradient.
+        gcol = xp.tensordot(W, gy, (0, 1)).astype(x.dtype)
+        gcol = xp.rollaxis(gcol, ndim + 1)
+
+        # Compute input gradient.
+        if xp is numpy:
+            gx = conv_nd.col2im_nd_cpu(gcol, stride, pad, dims)
+        else:
+            gx = conv_nd.col2im_nd_gpu(gcol, stride, pad, dims)
+
+        # Compute bias gradient if given and return gradients.
+        if b is None:
+            return gx, gW
+        else:
+            # (n, _, out_1, out_2, ..., out_N)
+            axis = (0,) + tuple(moves.range(2, ndim + 2))
+            gb = gy.sum(axis=axis)
+            return gx, gW, gb
+
+    def _backward_cudnn(self, x, W, b, gy):
+        # Convert to C-contiguous arrays.
+        x = cuda.cupy.ascontiguousarray(x)
+        W = cuda.cupy.ascontiguousarray(W)
+        gy = cuda.cupy.ascontiguousarray(gy)
+
+        # Make empty arrays for result.
+        gx = cuda.cupy.empty_like(x)
+        gW = cuda.cupy.empty_like(W)
+
+        # Get cuDNN handler and descriptors.
+        handle = cudnn.get_handle()
+        x_desc = cudnn.create_tensor_descriptor(x)
+        gy_desc = cudnn.create_tensor_descriptor(gy)
+
+        # Compute gradients.
+        oz_dtype = 'd' if x.dtype == 'd' else 'f'
+        one = numpy.array(1, dtype=oz_dtype).ctypes
+        zero = numpy.array(0, dtype=oz_dtype).ctypes
+        if _cudnn_version >= 4000:
+            workspace_size = cuda.get_max_workspace_size()
+            workspace = cuda.cupy.empty((workspace_size,), dtype='b')
+
+            # Compute filter weight gradient.
+            algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
+                handle, x_desc.value, gy_desc.value,
+                self.conv_desc.value, self.filter_desc.value,
+                _bwd_filter_pref, workspace_size)
+            libcudnn.convolutionBackwardFilter_v3(
+                handle, one.data, x_desc.value, x.data.ptr,
+                gy_desc.value, gy.data.ptr, self.conv_desc.value,
+                algo, workspace.data.ptr, workspace_size,
+                zero.data, self.filter_desc.value, gW.data.ptr)
+
+            # Compute input gradient.
+            algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                handle, self.filter_desc.value, gy_desc.value,
+                self.conv_desc.value, x_desc.value, _bwd_data_pref,
+                workspace_size)
+            libcudnn.convolutionBackwardData_v3(
+                handle, one.data, self.filter_desc.value, W.data.ptr,
+                gy_desc.value, gy.data.ptr, self.conv_desc.value,
+                algo, workspace.data.ptr, workspace_size,
+                zero.data, x_desc.value, gx.data.ptr)
+        else:
+            # Compute input and filter weight gradients.
+            libcudnn.convolutionBackwardFilter_v2(
+                handle, one.data, x_desc.value, x.data.ptr,
+                gy_desc.value, gy.data.ptr, self.conv_desc.value,
+                zero.data, self.filter_desc.value, gW.data.ptr)
+            libcudnn.convolutionBackwardData_v2(
+                handle, one.data, self.filter_desc.value, W.data.ptr,
+                gy_desc.value, gy.data.ptr, self.conv_desc.value,
+                zero.data, x_desc.value, gx.data.ptr)
+
+        # Compute bias gradient if given and return gradients.
+        if b is None:
+            return gx, gW
+        else:
+            gb = cuda.cupy.empty_like(b)
+            libcudnn.convolutionBackwardBias(
+                handle, one.data, gy_desc.value, gy.data.ptr,
+                zero.data, self.bias_desc.value, gb.data.ptr)
+            return gx, gW, gb
+
+    def backward(self, inputs, grad_outputs):
+        x, W = inputs[:2]
+        b = inputs[2] if len(inputs) == 3 else None
+        gy = grad_outputs[0]    # (n, c_O, out_1, out_2, ..., out_N)
+
+        xp = cuda.get_array_module(*inputs)
+        if xp is numpy:
+            return self._backward_xp(x, W, b, gy, numpy)
+        elif not self._use_cudnn(x, W):
+            return self._backward_xp(x, W, b, gy, cuda.cupy)
+        else:
+            return self._backward_cudnn(x, W, b, gy)
+
+
+def convolution_nd(x, W, b=None, stride=1, pad=0, use_cudnn=True,
+                   cover_all=False):
+    """N-dimensional convolution function.
+
+    This is an implementation of N-dimensional convolution which is generalized
+    two-dimensional convolution in ConvNets. It takes three variables: the
+    input ``x``, the filter weight ``W`` and the bias vector ``b``.
+
+    Notation: here is a notation for dimensionalities.
+
+    - :math:`N` is the number of spatial dimensions.
+    - :math:`n` is the batch size.
+    - :math:`c_I` and :math:`c_O` are the number of the input and output
+      channels, respectively.
+    - :math:`d_1, d_2, ..., d_N` are the size of each axis of the input's
+      spatial dimensions, respectively.
+    - :math:`k_1, k_2, ..., k_N` are the size of each axis of the filters,
+      respectively.
+
+    Args:
+        x (~chainer.Variable): Input variable of shape
+            :math:`(n, c_I, d_1, d_2, ..., d_N)`.
+        W (~chainer.Variable): Weight variable of shape
+            :math:`(c_O, c_I, k_1, k_2, ..., k_N)`.
+        b (~chainer.Variable): One-dimensional bias variable with length
+            :math:`c_O` (optional).
+        stride (int or tuple of ints): Stride of filter applications
+            :math:`(s_1, s_2, ..., s_N)`. ``stride=s`` is equivalent to
+            ``(s, s, ..., s)``.
+        pad (int or tuple of ints): Spatial padding width for input arrays
+            :math:`(p_1, p_2, ..., p_N)`. ``pad=p`` is equivalent to
+            ``(p, p, ..., p)``.
+        use_cudnn (bool): If ``True``, then this function uses cuDNN if
+            available. See below for the excact conditions.
+        cover_all (bool): If ``True``, all spatial locations are convoluted
+            into some output pixels. It may make the output size larger.
+            `cover_all` needs to be ``False`` if you want to use cuDNN.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+
+    This function uses cuDNN implementation for its forward and backward
+    computation if ALL of the following conditions are satisfied:
+
+    - ``cuda.cudnn_enabled`` is ``True``
+    - ``use_cudnn`` is ``True``
+    - The number of spatial dimensions is more than one.
+    - ``cover_all`` is ``False``
+    - The input's ``dtype`` is equal to the filter weight's.
+    - The ``dtype`` is FP32, FP64 or FP16(cuDNN version is equal to or greater
+      than v3)
+
+
+    .. seealso:: :class:`ConvolutionND`, :func:`convolution_2d`
+    """
+    ndim = len(x.data.shape[2:])
+    func = ConvolutionND(ndim, stride, pad, use_cudnn, cover_all)
+    if b is None:
+        return func(x, W)
+    else:
+        return func(x, W, b)

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -149,7 +149,7 @@ class ConvolutionND(function.Function):
                     handle, one.data, self.bias_desc.value, b.data.ptr,
                     one.data, y_desc.value, y.data.ptr)
             else:
-                # cuDNN v2 seems not to support bias addition in spatial
+                # cuDNN v2 does not seem to support bias addition in spatial
                 # dimensions other than two.
                 b_index = (None, colon) + (None,) * ndim
                 y += b[b_index]
@@ -265,8 +265,8 @@ class ConvolutionND(function.Function):
                 zero.data, self.bias_desc.value, gb.data.ptr)
             return gx, gW, gb
         else:
-            # cuDNN v2 seems not to support bias backward in spatial dimensions
-            # other than two.
+            # cuDNN v2 does not seem to support bias backward in spatial
+            # dimensions other than two.
 
             # (n, _, out_1, out_2, ..., out_N)
             axis = (0,) + tuple(moves.range(2, self.ndim + 2))

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -117,7 +117,8 @@ class ConvolutionND(function.Function):
         y_desc = cudnn.create_tensor_descriptor(y)
 
         self.filter_desc = cudnn.create_filter_descriptor(W)
-        self.conv_desc = cudnn.create_convolution_descriptor(pad, stride)
+        self.conv_desc = cudnn.create_convolution_descriptor(
+            pad, stride, x.dtype)
         if b is not None:
             b_index = (None, colon) + (None,) * ndim
             self.bias_desc = cudnn.create_tensor_descriptor(b[b_index])

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -117,7 +117,7 @@ class Deconvolution2DFunction(function.Function):
 
             self.filter_desc = cudnn.create_filter_descriptor(W)
             self.conv_desc = cudnn.create_convolution_descriptor(
-                (self.ph, self.pw), (self.sy, self.sx))
+                (self.ph, self.pw), (self.sy, self.sx), x.dtype)
             if b is not None:
                 self.bias_desc = cudnn.create_tensor_descriptor(
                     b[None, :, None, None])

--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -5,6 +5,7 @@ from chainer.links.activation import prelu
 from chainer.links.connection import bias
 from chainer.links.connection import bilinear
 from chainer.links.connection import convolution_2d
+from chainer.links.connection import convolution_nd
 from chainer.links.connection import deconvolution_2d
 from chainer.links.connection import embed_id
 from chainer.links.connection import gru
@@ -30,6 +31,7 @@ PReLU = prelu.PReLU
 Bias = bias.Bias
 Bilinear = bilinear.Bilinear
 Convolution2D = convolution_2d.Convolution2D
+ConvolutionND = convolution_nd.ConvolutionND
 Deconvolution2D = deconvolution_2d.Deconvolution2D
 EmbedID = embed_id.EmbedID
 GRU = gru.GRU

--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -1,0 +1,86 @@
+from chainer.functions.connection import convolution_nd
+from chainer import initializers
+from chainer import link
+from chainer.utils import conv_nd
+
+
+class ConvolutionND(link.Link):
+    """N-dimensional convolution layer.
+
+    This link wraps the :func:`~chainer.functions.convolution_nd` function and
+    holds the filter weight and bias vector as parameters.
+
+    Args:
+        ndim (int): Number of spatial dimensions.
+        in_channels (int): Number of channels of input arrays.
+        out_channels (int): Number of channels of output arrays.
+        ksize (int or tuple of ints): Size of filters (a.k.a. kernels).
+            ``ksize=k`` and ``ksize=(k, k, ..., k)`` are equivalent.
+        stride (int or tuple of ints): Stride of filter application.
+            ``stride=s`` and ``stride=(s, s, ..., s)`` are equivalent.
+        pad (int or tuple of ints): Spatial padding width for input arrays.
+            ``pad=p`` and ``pad=(p, p, ..., p)`` are equivalent.
+        initialW: Value used to initialize the filter weight. May be an
+            initializer instance or another value that
+            :func:`~chainer.init_weight` helper function can take. This link
+            uses :func:`~chainer.init_weight` to initialize the filter weight
+            and passes the value of ``initialW`` to it as it is.
+        initial_bias: Value used to initialize the bias vector. May be an
+            initializer instance or another value except ``None`` that
+            :func:`~chainer.init_weight` helper function can take. If ``None``
+            is given, this link does not use the bias vector. This link uses
+            :func:`~chainer.init_weight` to initialize the bias vector and
+            passes the value of ``initial_bias`` other than ``None`` to it as
+            it is.
+        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
+            See :func:`~chainer.functions.convolution_nd` for exact conditions
+            of cuDNN availability.
+        cover_all (bool): If ``True``, all spatial locations are convoluted
+            into some output pixels. It may make the output size larger.
+            ``cover_all`` needs to be ``False`` if you want to use cuDNN.
+
+    .. seealso::
+        See :func:`~chainer.functions.convolution_nd` for the definition of
+        N-dimensional convolution. See
+        :func:`~chainer.functions.convolution_2d` for the definition of
+        two-dimensional convolution.
+
+    Attributes:
+        W (~chainer.Variable): Weight parameter.
+        b (~chainer.Variable): Bias parameter. If ``initial_bias`` is ``None``,
+            set to ``None``.
+
+    """
+
+    def __init__(self, ndim, in_channels, out_channels, ksize, stride=1, pad=0,
+                 initialW=None, initial_bias=None, use_cudnn=True,
+                 cover_all=False):
+        ksize = conv_nd.as_tuple(ksize, ndim)
+        self.stride = stride
+        self.pad = pad
+        self.use_cudnn = use_cudnn
+        self.cover_all = cover_all
+
+        W_shape = (out_channels, in_channels) + ksize
+        super(ConvolutionND, self).__init__(W=W_shape)
+        initializers.init_weight(self.W.data, initialW)
+
+        if initial_bias is None:
+            self.b = None
+        else:
+            self.add_param('b', out_channels)
+            initializers.init_weight(self.b.data, initial_bias)
+
+    def __call__(self, x):
+        """Applies N-dimensional convolution layer.
+
+        Args:
+            x (~chainer.Variable): Input image.
+
+        Returns:
+            ~chainer.Variable: Output of convolution.
+
+        """
+        return convolution_nd.convolution_nd(
+            x, self.W, self.b, self.stride, self.pad,
+            use_cudnn=self.use_cudnn, cover_all=self.cover_all)

--- a/chainer/utils/conv_nd.py
+++ b/chainer/utils/conv_nd.py
@@ -1,0 +1,120 @@
+import itertools
+import numpy
+import six
+
+from chainer import cuda
+from chainer.utils.conv import get_conv_outsize
+from chainer.utils import conv_nd_kernel
+
+
+def as_tuple(x, n):
+    if hasattr(x, '__getitem__'):
+        assert len(x) == n
+        return tuple(x)
+    return (x,) * n
+
+
+def im2col_nd_cpu(img, ksize, stride, pad, pval=0, cover_all=False):
+    n, c = img.shape[0:2]       # (n, c, d_1, d_2, ..., d_N)
+    dims = img.shape[2:]
+    ndim = len(dims)
+    assert ndim == len(ksize) == len(stride) == len(pad)
+    outs = tuple(get_conv_outsize(d, k, s, p, cover_all)
+                 for (d, k, s, p) in zip(dims, ksize, stride, pad))
+
+    # Pad around image.
+    pad_width = ((0, 0), (0, 0)) + tuple(
+        (p, p + s - 1) for (s, p) in zip(stride, pad))
+    img = numpy.pad(img, pad_width, mode='constant', constant_values=(pval,))
+
+    # Make patch array with which we will compute correlation with filter.
+    # shape: (n, c, k_1, k_2, ..., k_N, out_1, out_2, ..., out_N)
+    shape = (n, c) + ksize + outs
+    col = numpy.ndarray(shape, dtype=img.dtype)
+
+    # Fill the patch array.
+    colon = slice(None)
+    for kxs in itertools.product(*[six.moves.range(k) for k in ksize]):
+        # col[:, :, kx_1, kx_2, ..., kx_N, :, :, ..., :]
+        col_index = (colon, colon) + kxs + (colon,) * ndim
+        # img[:, :, kx_1:kx_lim_1:s_1, ..., kx_N:kx_lim_N:s_N]
+        kx_lims = tuple(kx + s * out
+                        for (kx, s, out) in zip(kxs, stride, outs))
+        img_index = (colon, colon) + tuple(
+            slice(kx, kx_lim, s)
+            for (kx, kx_lim, s) in zip(kxs, kx_lims, stride))
+        col[col_index] = img[img_index]
+
+    return col
+
+
+def im2col_nd_gpu(img, ksize, stride, pad, cover_all=False):
+    n, c = img.shape[0:2]       # (n, c, d_1, d_2, ..., d_N)
+    dims = img.shape[2:]
+    ndim = len(dims)
+    assert ndim == len(ksize) == len(stride) == len(pad)
+    outs = tuple(get_conv_outsize(d, k, s, p, cover_all)
+                 for (d, k, s, p) in zip(dims, ksize, stride, pad))
+
+    # col_shape: (n, c, k_1, k_2, ..., k_N, out_1, out_2, ..., out_N)
+    shape = (n, c) + ksize + outs
+    col = cuda.cupy.empty(shape, dtype=img.dtype)
+
+    in_params, out_params, operation, name = \
+        conv_nd_kernel.Im2colNDKernel.generate(ndim)
+
+    cuda.elementwise(in_params, out_params, operation, name)(
+        img.reduced_view(), *(dims + outs + ksize + stride + pad + (col,)))
+
+    return col
+
+
+def col2im_nd_cpu(col, stride, pad, dims):
+    # Assured consistency of dimensions of parameters by caller.
+    n, c = col.shape[:2]  # (n, c, kx_1, ..., kx_N, out_1, ..., out_N)
+    mid = (len(col.shape) - 2) // 2 + 2
+    ksize = col.shape[2:mid]
+    outs = col.shape[mid:]
+    colon = slice(None)
+    assert len(outs) == len(ksize) == len(stride) == len(pad) == len(dims)
+
+    # Image with padded size.
+    img_shape = (n, c) + tuple(d + 2 * p + s - 1
+                               for (d, p, s) in zip(dims, pad, stride))
+    img = numpy.zeros(img_shape, dtype=col.dtype)
+    for kxs in itertools.product(*[six.moves.range(k) for k in ksize]):
+        # (:, :, kx_1:kx_lim_1:s_1, ..., kx_N:kx_lim_N:s_N)
+        kx_lims = tuple(kx + s * out
+                        for (kx, s, out) in zip(kxs, stride, outs))
+        img_index = (colon, colon) + tuple(
+            slice(kx, kx_lim, s)
+            for (kx, kx_lim, s) in zip(kxs, kx_lims, stride))
+        # (:, :, kx_1, kx_2, ..., kx_N, :, :, ..., :)
+        col_index = (colon, colon) + kxs + (colon,) * len(outs)
+        img[img_index] += col[col_index]
+
+    # (:, :, p_1:d_1 + p_1, p_2:d_2 + p_2, ..., p_N:d_N + p_N]
+    img_index = (colon, colon) + tuple(
+        slice(p, d + p) for (p, d) in zip(pad, dims))
+    return img[img_index]
+
+
+def col2im_nd_gpu(col, stride, pad, dims):
+    # Assured consistency of dimensions of parameters by caller.
+    n, c = col.shape[:2]        # (n, c, k_1, ..., k_N, out_1, ..., out_N)
+    mid = (len(col.shape) - 2) // 2 + 2
+    ksize = col.shape[2:mid]
+    outs = col.shape[mid:]
+    ndim = len(dims)
+    assert len(outs) == len(ksize) == len(stride) == len(pad) == ndim
+
+    img_shape = (n, c) + dims   # (n, c, d_1, d_2, ..., d_N)
+    img = cuda.cupy.empty(img_shape, dtype=col.dtype)
+
+    in_params, out_params, operation, name = \
+        conv_nd_kernel.Col2imNDKernel.generate(ndim)
+
+    cuda.elementwise(in_params, out_params, operation, name)(
+        col.reduced_view(), *(dims + outs + ksize + stride + pad + (img,)))
+
+    return img

--- a/chainer/utils/conv_nd_kernel.py
+++ b/chainer/utils/conv_nd_kernel.py
@@ -1,0 +1,288 @@
+import functools
+import six
+
+import chainer
+
+
+def mulexp(xs, init=None):
+    if init is not None:
+        return functools.reduce('{} * {}'.format, xs, init)
+    else:
+        return functools.reduce('{} * {}'.format, xs)
+
+
+def andexp(xs, init=None):
+    if init is not None:
+        return functools.reduce('{} && {}'.format, xs, init)
+    else:
+        return functools.reduce('{} && {}'.format, xs)
+
+
+def muladdexp(xs, ys, init=None):
+    def aux(exp, arg):
+        x, y = arg
+        return '({} + {} * {})'.format(y, x, exp)
+    if init is not None:
+        return functools.reduce(aux, zip(xs, ys), init)
+    else:
+        return functools.reduce(aux, zip(xs, ys))
+
+
+def _succ_sublists(xs):
+    # Returns successive sublists of xs.
+    return [xs[i:] for i in six.moves.range(len(xs))]
+
+
+def _vars(prefix, n):
+    return ['{}_{}'.format(prefix, i) for i in six.moves.range(n)]
+
+
+class _Writer(object):
+
+    def __init__(self):
+        self._indent = 0
+        self._lines = []
+
+    def write(self, line, indent=None):
+        if indent == 'dec' or indent == 'decinc':
+            self._indent -= 1
+        self._lines.append('  ' * self._indent + line)
+        if indent == 'inc' or indent == 'decinc':
+            self._indent += 1
+
+    def get(self):
+        return '\n'.join(self._lines)
+
+
+#
+# im2col
+
+class Im2colNDKernel(object):
+
+    def _in_params(self, ds, outs, ks, ss, ps):
+        # 2D: raw T img, int32 d_0, int32 d_1, int32 out_0, int32 out_1,
+        #     int32 k_0, int32 k_1, int32 s_0, int32 s_1, int32 p_0, int32 p_1
+        def aux(x):
+            return 'int32 {}'.format(x)
+        return ', '.join(['raw T img'] + map(aux, ds + outs + ks + ss + ps))
+
+    def _out_params(self):
+        return 'T col'
+
+    def _compile_c0(self, outs, ks):
+        # 2D: int c0 = i / (k_0 * k_1 * out_0 * out_1)
+        return ['int c0 = i / ({});'.format(mulexp(ks + outs))]
+
+    def _compile_kx(self, ndim, outs, ks):
+        # 2D: int kx_0 = i / (k_1 * out_0 * out_1) % k_0;
+        #     int kx_1 = i / (out_0 * out_1) % k_1;
+        def aux(kx, xs):
+            head = xs[0]
+            tail = xs[1:] + outs
+            if tail:
+                return 'int {} = i / ({}) % {};'.format(kx, mulexp(tail), head)
+            else:
+                return 'int {} = i % {};'.format(kx, head)
+        kxs = _vars('kx', ndim)
+        kx_decls = map(aux, kxs, _succ_sublists(ks))
+        return kx_decls, kxs
+
+    def _compile_out_x(self, ndim, outs):
+        # 2D: int out_x0 = i / (out_1) % out_0;
+        #     int out_x1 = i % out_1;
+        def aux(out_x, xs):
+            head = xs[0]
+            tail = xs[1:]
+            if tail:
+                return 'int {} = i / ({}) % {};'.format(
+                    out_x, mulexp(tail), head)
+            else:
+                return 'int {} = i % {};'.format(out_x, head)
+        out_xs = _vars('out_x', ndim)
+        out_x_decls = map(aux, out_xs, _succ_sublists(outs))
+        return out_x_decls, out_xs
+
+    def _compile_main(self, ndim, ds, ks, ss, ps, kxs, out_xs):
+        # 2D: int in_0 = kx_0 + out_x_0 * s_0 - p_0;
+        #     int in_1 = kx_1 + out_x_1 * s_1 - p_1;
+        #     if (0 <= in_0 && in_0 < d_0 && 0 <= in_1 && in_1 < d_1) {
+        #       int idx_0 = in_0 + d_0 * c0;
+        #       int idx_1 = in_1 + d_1 * idx_0;
+        #       col = img[idx_1];
+        #     } else {
+        #       col = (T)0;
+        #     }
+        w = _Writer()
+
+        ins = _vars('in', ndim)
+        for (_in, kx, out_x, s, p) in zip(ins, kxs, out_xs, ss, ps):
+            w.write(
+                'int {} = {} + {} * {} - {};'.format(_in, kx, out_x, s, p))
+
+        def rel_aux(_in, d):
+            return '0 <= {} && {} < {}'.format(_in, _in, d)
+        w.write(
+            'if ({}) {{'.format(andexp(map(rel_aux, ins, ds))), indent='inc')
+
+        idxs = _vars('idx', ndim)
+        idx0s = ['c0'] + idxs[:-1]
+        for (idx, _in, d, idx0) in zip(idxs, ins, ds, idx0s):
+            w.write('int {} = {} + {} * {};'.format(idx, _in, d, idx0))
+
+        w.write('col = img[{}];'.format(idxs[-1]))
+        w.write('} else {', indent='decinc')
+        w.write('col = (T)0;')
+        w.write('}', indent='dec')
+
+        return [w.get()]
+
+    def _operation(self, ndim, ds, outs, ks, ss, ps):
+        c0 = self._compile_c0(outs, ks)
+        kx, kxs = self._compile_kx(ndim, outs, ks)
+        out_x, out_xs = self._compile_out_x(ndim, outs)
+        main = self._compile_main(ndim, ds, ks, ss, ps, kxs, out_xs)
+        return '\n'.join(c0 + kx + out_x + main)
+
+    def _generate(self, ndim):
+        ds = _vars('d', ndim)
+        outs = _vars('out', ndim)
+        ks = _vars('k', ndim)
+        ss = _vars('s', ndim)
+        ps = _vars('p', ndim)
+
+        in_params = self._in_params(ds, outs, ks, ss, ps)
+        out_params = self._out_params()
+        operation = self._operation(ndim, ds, outs, ks, ss, ps)
+        name = name = 'im2col_{}d'.format(ndim)
+        return in_params, out_params, operation, name
+
+    @staticmethod
+    @chainer.cuda.memoize()
+    def generate(ndim):
+        return _im2col_nd_kernel._generate(ndim)
+
+_im2col_nd_kernel = Im2colNDKernel()
+
+
+#
+# col2im
+
+class Col2imNDKernel(object):
+
+    def _in_params(self, ds, outs, ks, ss, ps):
+        # 2D: raw T col, int32 d_0, int32 d_1, int32 out_0, int32 out_1,
+        #     int32 k_0, int32 k_1, int32 s_0, int32 s_1, int32 p_0, int32 p_1
+        def aux(x):
+            return 'int32 {}'.format(x)
+        return ', '.join(['raw T col'] + map(aux, ds + outs + ks + ss + ps))
+
+    def _out_params(self):
+        return 'T img'
+
+    def _compile_c0(self, ds):
+        # 2D: int c0 = i / (d_0 * d_1);
+        return ['int c0 = i / ({});'.format(mulexp(ds))]
+
+    def _compile_x(self, ndim, ds, ps):
+        # 2D: int x_0 = i / (d_1) % d_0 + p_0;
+        #     int x_1 = i % d_1 + p_1;
+        def aux(x, ds, p):
+            head = ds[0]
+            tail = ds[1:]
+            if tail:
+                return 'int {} = i / ({}) % {} + {};'.format(
+                    x, mulexp(tail), head, p)
+            else:
+                return 'int {} = i % {} + {};'.format(x, head, p)
+        xs = _vars('x', ndim)
+        x_decls = map(aux, xs, _succ_sublists(ds), ps)
+        return x_decls, xs
+
+    def _compile_loop(self, ndim, outs, ks, ss, xs):
+        # 2D: int out_x0_0 = max(0,     (x_0 - k_0 + s_0) / s_0);
+        #     int out_x1_0 = min(out_0, (x_0       + s_0) / s_0);
+        #     int out_x0_1 = max(0,     (x_1 - k_1 + s_1) / s_1);
+        #     int out_x1_1 = min(out_1, (x_1       + s_1) / s_1);
+        #     ... Before-part here ...
+        #     for (int out_x_0 = out_x0_0; out_x_0 < out_x1_0; ++out_x_0) {
+        #       int kx_0 = x_0 - out_x_0 * s_0 + k_0 * c0;
+        #       for (int out_x_1 = out_x0_1; out_x_1 < out_x1_1; ++out_x_1) {
+        #         int kx_1 = x_1 - out_x_1 * s_1 + k_1 * kx_0;
+        #         ... Main-part here ...
+        #       }
+        #     }
+        #     ... After-part here ...
+        def aux(out_x0, out_x1, out, x, k, s):
+            return [
+                'int {} = max(0, ({} - {} + {}) / {});'.format(
+                    out_x0, x, k, s, s),
+                'int {} = min({}, ({} + {}) / {});'.format(
+                    out_x1, out, x, s, s)]
+        out_x0s = _vars('out_x0', ndim)
+        out_x1s = _vars('out_x1', ndim)
+        bounds = sum(map(aux, out_x0s, out_x1s, outs, xs, ks, ss), [])
+
+        def _loop_main(main, ndim, ks, ss):
+            w = _Writer()
+
+            # Loop openings.
+            out_xs = _vars('out_x', ndim)
+            kxs = _vars('kx', ndim)
+            kxs1 = ['c0'] + kxs[:-1]
+            for (out_x, out_x0, out_x1, kx, s, x, k, kx1) in zip(
+                    out_xs, out_x0s, out_x1s, kxs, ss, xs, ks, kxs1):
+                w.write('for (int {} = {}; {} < {}; ++{}) {{'.format(
+                    out_x, out_x0, out_x, out_x1, out_x), indent='inc')
+                w.write('int {} = {} - {} * {} + {} * {};'.format(
+                    kx, x, out_x, s, k, kx1))
+
+            # Main-part.
+            kx = kxs[-1]
+            for l in main(kx, out_xs).split('\n'):
+                w.write(l)
+
+            # Loop closings.
+            for _ in out_xs:
+                w.write('}', indent='dec')
+
+            return [w.get()]
+
+        return bounds, _loop_main
+
+    def _compile_procedure(self, outs, xs):
+        # 2D: val = val + col[(out_x_1 + out_1 * (out_x_0 + out_0 * kx_1))];
+        def _main(kx, out_xs):
+            index = muladdexp(outs, out_xs, kx)
+            return 'val = val + col[{}];'.format(index)
+        before = ['T val = 0;']
+        after = ['img = val;']
+        return before, _main, after
+
+    def _operation(self, ndim, ds, outs, ks, ss, ps):
+        c0 = self._compile_c0(ds)
+        x, xs = self._compile_x(ndim, ds, ps)
+        loop_bounds, loop_main = self._compile_loop(ndim, outs, ks, ss, xs)
+        before, main, after = self._compile_procedure(outs, xs)
+        return '\n'.join(
+            c0 + x + loop_bounds + before + loop_main(
+                main, ndim, ks, ss) + after)
+
+    def _generate(self, ndim):
+        ds = _vars('d', ndim)
+        outs = _vars('out', ndim)
+        ks = _vars('k', ndim)
+        ss = _vars('s', ndim)
+        ps = _vars('p', ndim)
+
+        in_params = self._in_params(ds, outs, ks, ss, ps)
+        out_params = self._out_params()
+        operation = self._operation(ndim, ds, outs, ks, ss, ps)
+        name = 'col2im_{}d'.format(ndim)
+        return in_params, out_params, operation, name
+
+    @staticmethod
+    @chainer.cuda.memoize()
+    def generate(ndim):
+        return _col2im_nd_kernel._generate(ndim)
+
+_col2im_nd_kernel = Col2imNDKernel()

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -135,7 +135,7 @@ def create_convolution_descriptor(pad, stride, dtype,
             #     storing precision of FP16 in spatial dimensions of three or
             #     more.
             if ndim > 2 and dtype == numpy.float16:
-                data_type = get_data_type(numpy.float32)
+                data_type = cudnn.CUDNN_DATA_FLOAT
             cudnn.setConvolutionNdDescriptor_v3(
                 desc.value, ndim, c_pad.data, c_stride.data, c_upscale.data,
                 mode, data_type)

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -114,8 +114,10 @@ def create_filter_descriptor(arr, mode=cudnn.CUDNN_CROSS_CORRELATION):
     return desc
 
 
-def create_convolution_descriptor(pad, stride,
+def create_convolution_descriptor(pad, stride, dtype,
                                   mode=cudnn.CUDNN_CROSS_CORRELATION):
+    # dtype is used when ndim != 2 and cuDNN is newer than cuDNN 2, otherwise
+    # it is ignored.
     desc = Descriptor(cudnn.createConvolutionDescriptor(),
                       cudnn.destroyConvolutionDescriptor)
     ndim = len(pad)
@@ -129,8 +131,15 @@ def create_convolution_descriptor(pad, stride,
         c_pad = _to_ctypes_array(pad)
         c_stride = _to_ctypes_array(stride)
         c_upscale = _to_ctypes_array((1,) * ndim)
-        cudnn.setConvolutionNdDescriptor_v2(
-            desc.value, ndim, c_pad.data, c_stride.data, c_upscale.data, mode)
+        if _cudnn_version >= 3000:
+            data_type = get_data_type(dtype)
+            cudnn.setConvolutionNdDescriptor_v3(
+                desc.value, ndim, c_pad.data, c_stride.data, c_upscale.data,
+                mode, data_type)
+        else:
+            cudnn.setConvolutionNdDescriptor_v2(
+                desc.value, ndim, c_pad.data, c_stride.data, c_upscale.data,
+                mode)
 
     return desc
 

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -1,6 +1,8 @@
 import atexit
 
+import functools
 import numpy
+import operator
 import six
 
 import cupy
@@ -60,17 +62,30 @@ def _to_ctypes_array(tup, dtype=numpy.intc):
     return numpy.array(tup, dtype=dtype).ctypes
 
 
+def _succ_sublists(xs):
+    # Returns successive sublists of xs.
+    return [xs[i:] for i in six.moves.range(len(xs))]
+
+
+def _compute_strides(shape):
+    def aux(xs):
+        return functools.reduce(operator.mul, xs[1:], 1)
+    return tuple(map(aux, _succ_sublists(shape)))
+
+
 def create_tensor_descriptor(arr, format=cudnn.CUDNN_TENSOR_NCHW):
     desc = Descriptor(cudnn.createTensorDescriptor(),
                       cudnn.destroyTensorDescriptor)
-    if arr.ndim != 4:
-        raise ValueError('cupy.cudnn supports 4-dimensional arrays only')
     if not arr.flags.c_contiguous:
         raise ValueError('cupy.cudnn supports c-contiguous arrays only')
     data_type = get_data_type(arr.dtype)
-    cudnn.setTensor4dDescriptor(desc.value, format, data_type,
-                                *arr.shape)
-
+    if arr.ndim == 4:
+        cudnn.setTensor4dDescriptor(desc.value, format, data_type, *arr.shape)
+    else:
+        c_shape = _to_ctypes_array(arr.shape)
+        c_strides = _to_ctypes_array(_compute_strides(arr.shape))
+        cudnn.setTensorNdDescriptor(desc.value, data_type, arr.ndim,
+                                    c_shape.data, c_strides.data)
     return desc
 
 

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -131,7 +131,7 @@ def create_convolution_descriptor(pad, stride, dtype,
         c_upscale = _to_ctypes_array((1,) * ndim)
         if _cudnn_version >= 3000:
             data_type = get_data_type(dtype)
-            # TODO(takag) Temporarily use computing precision of FP32 for
+            # TODO(takagi) Temporarily use computing precision of FP32 for
             #     storing precision of FP16.
             if dtype == numpy.float16:
                 data_type = cudnn.CUDNN_DATA_FLOAT

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -132,9 +132,8 @@ def create_convolution_descriptor(pad, stride, dtype,
         if _cudnn_version >= 3000:
             data_type = get_data_type(dtype)
             # TODO(takag) Temporarily use computing precision of FP32 for
-            #     storing precision of FP16 in spatial dimensions of three or
-            #     more.
-            if ndim > 2 and dtype == numpy.float16:
+            #     storing precision of FP16.
+            if dtype == numpy.float16:
                 data_type = cudnn.CUDNN_DATA_FLOAT
             cudnn.setConvolutionNdDescriptor_v3(
                 desc.value, ndim, c_pad.data, c_stride.data, c_upscale.data,

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -179,6 +179,10 @@ convolution_2d
 ~~~~~~~~~~~~~~
 .. autofunction:: convolution_2d
 
+convolution_nd
+~~~~~~~~~~~~~~
+.. autofunction:: convolution_nd
+
 deconvolution_2d
 ~~~~~~~~~~~~~~~~
 .. autofunction:: deconvolution_2d

--- a/docs/source/reference/links.rst
+++ b/docs/source/reference/links.rst
@@ -32,6 +32,11 @@ Convolution2D
 .. autoclass:: Convolution2D
    :members:
 
+ConvolutionND
+~~~~~~~~~~~~~
+.. autoclass:: ConvolutionND
+   :members:
+
 Deconvolution2D
 ~~~~~~~~~~~~~~~
 .. autoclass:: Deconvolution2D

--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -35,6 +35,7 @@ CuPy array allocation and copy
 Kernel definition utilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: memoize
+.. autofunction:: clear_memo
 .. autofunction:: elementwise
 .. autofunction:: reduce
 

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -50,7 +50,7 @@ class TestConvolutionND(unittest.TestCase):
         if self.x_dtype == numpy.float16 or self.W_dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+                'dtype': numpy.float64, 'atol': 2 ** -4, 'rtol': 2 ** -4}
 
     def check_forward_consistency(self, nobias=False, use_cudnn=False):
         x_cpu = chainer.Variable(self.x)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -1,0 +1,228 @@
+import unittest
+
+import functools
+import mock
+import numpy
+from operator import mul
+
+import chainer
+from chainer import cuda
+from chainer import functions
+from chainer.functions.connection import convolution_nd
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+from chainer.utils import conv
+
+
+@testing.parameterize(*testing.product({
+    'dims': [(10,), (10, 8), (10, 8, 6)],
+    'c_contiguous': [True, False],
+    'cover_all': [True, False],
+    'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestConvolutionND(unittest.TestCase):
+
+    def setUp(self):
+        in_channels = 3
+        out_channels = 2
+        ndim = len(self.dims)
+        ksize = (3,) * ndim
+        self.stride = (2,) * ndim
+        self.pad = (1,) * ndim
+
+        W_scale = numpy.sqrt(1. / functools.reduce(mul, ksize, in_channels))
+        W_shape = (out_channels, in_channels) + ksize
+        self.W = numpy.random.normal(0, W_scale, W_shape).astype(self.W_dtype)
+        self.b = numpy.random.uniform(-1, 1, out_channels).astype(self.x_dtype)
+
+        x_shape = (2, 3) + self.dims
+        self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.x_dtype)
+        gy_shape = (2, 2) + tuple(
+            conv.get_conv_outsize(d, k, s, p, cover_all=self.cover_all)
+            for (d, k, s, p) in zip(self.dims, ksize, self.stride, self.pad))
+        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.x_dtype)
+
+        self.check_forward_options = {}
+        self.check_backward_options = {'dtype': numpy.float64}
+        if self.x_dtype == numpy.float16 or self.W_dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+
+    def check_forward_consistency(self, nobias=False, use_cudnn=False):
+        x_cpu = chainer.Variable(self.x)
+        W_cpu = chainer.Variable(self.W)
+        b_cpu = None if nobias else chainer.Variable(self.b)
+        y_cpu = functions.convolution_nd(
+            x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
+            use_cudnn=use_cudnn, cover_all=self.cover_all)
+
+        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
+        W_gpu = chainer.Variable(cuda.to_gpu(self.W))
+        b_gpu = None if nobias else chainer.Variable(cuda.to_gpu(self.b))
+        y_gpu = functions.convolution_nd(
+            x_gpu, W_gpu, b_gpu, stride=self.stride, pad=self.pad,
+            use_cudnn=use_cudnn, cover_all=self.cover_all)
+
+        testing.assert_allclose(
+            y_cpu.data, y_gpu.data, **self.check_forward_options)
+
+    @attr.cudnn
+    def test_forward_consistency(self):
+        self.check_forward_consistency(nobias=False, use_cudnn=True)
+
+    @attr.cudnn
+    def test_forward_consistency_nobias(self):
+        self.check_forward_consistency(nobias=True, use_cudnn=True)
+
+    @attr.gpu
+    def test_forward_consistency_im2col(self):
+        self.check_forward_consistency(nobias=False, use_cudnn=False)
+
+    @attr.gpu
+    def test_forward_consistency_im2col_nobias(self):
+        self.check_forward_consistency(nobias=True, use_cudnn=False)
+
+    def check_forward_consistency_regression(self, nobias=False):
+        x = chainer.Variable(self.x)
+        W = chainer.Variable(self.W)
+        b = None if nobias else chainer.Variable(self.b)
+
+        y_nd = functions.convolution_nd(
+            x, W, b, stride=self.stride, pad=self.pad,
+            use_cudnn=False, cover_all=self.cover_all)
+        y_2d = functions.convolution_2d(
+            x, W, b, stride=self.stride, pad=self.pad,
+            use_cudnn=False, cover_all=self.cover_all)
+
+        testing.assert_allclose(
+            y_nd.data, y_2d.data, **self.check_forward_options)
+
+    def test_forward_consistency_regression(self):
+        # Regression test to convolution_2d.
+        if len(self.dims) == 2:
+            self.check_forward_consistency_regression(nobias=False)
+
+    def test_forward_consistency_regression_nobias(self):
+        # Regression test to convolution_2d.
+        if len(self.dims) == 2:
+            self.check_forward_consistency_regression(nobias=True)
+
+    def check_backward(self, x_data, W_data, b_data, y_grad, use_cudnn=False):
+        xp = cuda.get_array_module(x_data)
+        if not self.c_contiguous:
+            x_data = xp.asfortranarray(x_data)
+            W_data = xp.asfortranarray(W_data)
+            y_grad = xp.asfortranarray(y_grad)
+            self.assertTrue(x_data.flags.f_contiguous)
+            self.assertTrue(W_data.flags.f_contiguous)
+            self.assertTrue(y_grad.flags.f_contiguous)
+            if b_data is not None:
+                b = xp.empty((len(b_data) * 2,), dtype=b_data.dtype)
+                b[::2] = b_data
+                b_data = b[::2]
+                self.assertFalse(b_data.flags.c_contiguous)
+
+        args = (x_data, W_data)
+        if b_data is not None:
+            args = args + (b_data,)
+
+        ndim = len(self.dims)
+        gradient_check.check_backward(
+            convolution_nd.ConvolutionND(
+                ndim, self.stride, self.pad, use_cudnn, self.cover_all),
+            args, y_grad, **self.check_backward_options)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.W, self.b, self.gy)
+
+    @condition.retry(3)
+    def test_backward_cpu_nobias(self):
+        self.check_backward(self.x, self.W, None, self.gy)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
+                            cuda.to_gpu(self.b), cuda.to_gpu(self.gy),
+                            use_cudnn=True)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_backward_gpu_nobias(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
+                            None, cuda.to_gpu(self.gy),
+                            use_cudnn=True)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu_im2col(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
+                            cuda.to_gpu(self.b), cuda.to_gpu(self.gy),
+                            use_cudnn=False)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu_im2col_nobias(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
+                            None, cuda.to_gpu(self.gy),
+                            use_cudnn=False)
+
+
+@testing.parameterize(*testing.product({
+    'dims': [(10,), (10, 8), (10, 8, 6)],
+    'use_cudnn': [True, False],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+@attr.cudnn
+class TestConvolutionNDCudnnCall(unittest.TestCase):
+
+    def setUp(self):
+        in_channels = 3
+        out_channels = 2
+        ndim = len(self.dims)
+        ksize = (3,) * ndim
+        self.stride = (2,) * ndim
+        self.pad = (1,) * ndim
+        x_shape = (2, 3) + self.dims
+        self.x = cuda.cupy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+        W_scale = numpy.sqrt(1. / functools.reduce(mul, ksize, in_channels))
+        W_shape = (out_channels, in_channels) + ksize
+        self.W = cuda.cupy.random.normal(
+            0, W_scale, W_shape).astype(self.dtype)
+        gy_shape = (2, 2) + tuple(
+            conv.get_conv_outsize(d, k, s, p) for (d, k, s, p) in zip(
+                self.dims, ksize, self.stride, self.pad))
+        self.gy = cuda.cupy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
+        self.expect = self.use_cudnn and ndim > 1 and (
+            cuda.cudnn.cudnn.getVersion() >= 3000 or
+            self.dtype != numpy.float16)
+
+    def forward(self):
+        x = chainer.Variable(cuda.to_gpu(self.x))
+        W = chainer.Variable(cuda.to_gpu(self.W))
+        return functions.convolution_nd(
+            x, W, None, stride=self.stride, pad=self.pad,
+            use_cudnn=self.use_cudnn)
+
+    def test_call_cudnn_forward(self):
+        with mock.patch('cupy.cudnn.cudnn.convolutionForward') as func:
+            self.forward()
+            self.assertEqual(func.called, self.expect)
+
+    def test_call_cudnn_backward(self):
+        y = self.forward()
+        y.grad = self.gy
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            name = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
+        else:
+            name = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
+        with mock.patch(name) as func:
+            y.backward()
+            self.assertEqual(func.called, self.expect)
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -1,0 +1,138 @@
+import unittest
+
+import numpy
+import six.moves.cPickle as pickle
+
+import chainer
+from chainer import cuda
+from chainer import gradient_check
+from chainer import initializers
+from chainer.links import convolution_nd
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+from chainer.utils import conv
+from chainer.utils import conv_nd
+
+
+@testing.parameterize(*testing.product({
+    'dims': [(10,), (10, 8), (10, 8, 6)],
+}))
+class TestConvolutionND(unittest.TestCase):
+
+    def setUp(self):
+        ndim = len(self.dims)
+        self.ksize = (3,) * ndim
+        self.stride = (2,) * ndim
+        self.pad = (1,) * ndim
+
+        self.link = convolution_nd.ConvolutionND(
+            ndim, 3, 2, self.ksize, stride=self.stride, pad=self.pad,
+            initial_bias=initializers.Uniform(1))
+        self.link.zerograds()
+
+        x_shape = (2, 3) + self.dims
+        self.x = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
+        gy_shape = (2, 2) + tuple(
+            conv.get_conv_outsize(d, k, s, p) for (d, k, s, p) in zip(
+                self.dims, self.ksize, self.stride, self.pad))
+        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(numpy.float32)
+
+    @attr.gpu
+    def test_im2col_consistency(self):
+        col_cpu = conv_nd.im2col_nd_cpu(
+            self.x, self.ksize, self.stride, self.pad)
+        col_gpu = conv_nd.im2col_nd_gpu(
+            cuda.to_gpu(self.x), self.ksize, self.stride, self.pad)
+        testing.assert_allclose(col_cpu, col_gpu.get(), atol=0, rtol=0)
+
+    @attr.gpu
+    def test_col2im_consistency(self):
+        col = conv_nd.im2col_nd_cpu(self.x, self.ksize, self.stride, self.pad)
+        im_cpu = conv_nd.col2im_nd_cpu(col, self.stride, self.pad, self.dims)
+        im_gpu = conv_nd.col2im_nd_gpu(
+            cuda.to_gpu(col), self.stride, self.pad, self.dims)
+        testing.assert_allclose(im_cpu, im_gpu.get())
+
+    def check_forward_consistency(self):
+        x_cpu = chainer.Variable(self.x)
+        y_cpu = self.link(x_cpu)
+        self.assertEqual(y_cpu.data.dtype, numpy.float32)
+
+        self.link.to_gpu()
+        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
+        y_gpu = self.link(x_gpu)
+        self.assertEqual(y_gpu.data.dtype, numpy.float32)
+
+        testing.assert_allclose(y_cpu.data, y_gpu.data.get())
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_forward_consistency(self):
+        self.check_forward_consistency()
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_consistency_im2col(self):
+        self.link.use_cudnn = False
+        self.check_forward_consistency()
+
+    def check_backward(self, x_data, y_grad):
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, (self.link.W, self.link.b),
+            eps=1e-2, atol=1e-3, rtol=1e-3)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.link.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu_im2col(self):
+        self.link.use_cudnn = False
+        self.link.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    def check_pickling(self, x_data):
+        x = chainer.Variable(x_data)
+        y = self.link(x)
+        y_data1 = y.data
+
+        del x, y
+
+        pickled = pickle.dumps(self.link, -1)
+        del self.link
+        self.link = pickle.loads(pickled)
+
+        x = chainer.Variable(x_data)
+        y = self.link(x)
+        y_data2 = y.data
+
+        testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
+
+    def test_pickling_cpu(self):
+        self.check_pickling(self.x)
+
+    @attr.gpu
+    def test_pickling_gpu(self):
+        self.link.to_gpu()
+        self.check_pickling(cuda.to_gpu(self.x))
+
+
+class TestConvolutionNDNoInitialBias(unittest.TestCase):
+
+    def test_no_initial_bias(self):
+        ndim = 3
+        ksize = 3
+        link = convolution_nd.ConvolutionND(
+            ndim, 3, 2, ksize, initial_bias=None)
+        self.assertIsNone(link.b)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_conv.py
+++ b/tests/chainer_tests/utils_tests/test_conv.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+from six import moves
 
 from chainer import cuda
 from chainer import testing
@@ -61,12 +62,12 @@ class TestIm2Col(unittest.TestCase):
 
         col = cuda.to_cpu(col)
 
-        for n in range(2):
-            for c in range(3):
-                for y in range(col_h):
-                    for x in range(col_w):
-                        for dy in range(kh):
-                            for dx in range(kw):
+        for n in moves.range(2):
+            for c in moves.range(3):
+                for y in moves.range(col_h):
+                    for x in moves.range(col_w):
+                        for dy in moves.range(kh):
+                            for dx in moves.range(kw):
                                 oy = y * sy - ph + dy
                                 ox = x * sx - pw + dx
                                 if 0 <= oy < self.h and 0 <= ox < self.w:
@@ -121,13 +122,13 @@ class TestCol2Im(unittest.TestCase):
         img = col2im(col_data, sy, sx, ph, pw, self.h, self.w)
         img = cuda.to_cpu(img)
         self.assertEqual(img.shape, (2, 3, self.h, self.w))
-        for n in range(2):
-            for c in range(3):
-                for y in range(self.h):
-                    for x in range(self.w):
+        for n in moves.range(2):
+            for c in moves.range(3):
+                for y in moves.range(self.h):
+                    for x in moves.range(self.w):
                         v = numpy.float32(0.0)
-                        for dy in range(kh):
-                            for dx in range(kw):
+                        for dy in moves.range(kh):
+                            for dx in moves.range(kw):
                                 oy = (y + ph - dy) // sy
                                 ox = (x + pw - dx) // sx
                                 if (y + ph - dy) % sy == 0 and \

--- a/tests/chainer_tests/utils_tests/test_conv_nd.py
+++ b/tests/chainer_tests/utils_tests/test_conv_nd.py
@@ -1,0 +1,309 @@
+import unittest
+
+import itertools
+import numpy
+from six import moves
+
+from chainer import cuda
+from chainer import testing
+from chainer.testing import attr
+from chainer.utils import conv_nd
+
+
+class TestAsTuple(unittest.TestCase):
+
+    def test_scalar(self):
+        actual = conv_nd.as_tuple(1, 3)
+        expected = (1, 1, 1)
+        self.assertEqual(actual, expected)
+
+    def test_tuple(self):
+        actual = conv_nd.as_tuple((1, 2, 3), 3)
+        expected = (1, 2, 3)
+        self.assertEqual(actual, expected)
+
+    def test_list(self):
+        actual = conv_nd.as_tuple([1, 2, 3], 3)
+        expected = (1, 2, 3)
+        self.assertEqual(actual, expected)
+
+    def test_tuple_invalid_length(self):
+        with self.assertRaises(AssertionError):
+            conv_nd.as_tuple((1,), 3)
+
+
+@testing.parameterize(*testing.product({
+    'dims': [(10,), (10, 8), (10, 8, 6)],
+}))
+class TestIm2ColND(unittest.TestCase):
+
+    def setUp(self):
+        shape = (2, 3) + self.dims
+        self.img = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+
+    def check_im2col_nd(self, ksize, stride, pad, gpu):
+        dims = self.dims
+        if gpu:
+            im2col = conv_nd.im2col_nd_gpu
+            img = cuda.to_gpu(self.img)
+        else:
+            im2col = conv_nd.im2col_nd_cpu
+            img = self.img
+
+        col = im2col(img, ksize, stride, pad)
+        outs = tuple(conv_nd.get_conv_outsize(d, k, s, p)
+                     for (d, k, s, p) in zip(dims, ksize, stride, pad))
+        expected_shape = (2, 3) + ksize + outs
+        self.assertEqual(col.shape, expected_shape)
+
+        col = cuda.to_cpu(col)
+
+        for n in moves.range(2):
+            for c in moves.range(3):
+                for xs in itertools.product(
+                        *[moves.range(out) for out in outs]):
+                    for dxs in itertools.product(
+                            *[moves.range(k) for k in ksize]):
+                        oxs = tuple(x * s - p + dx
+                                    for (x, s, p, dx)
+                                    in zip(xs, stride, pad, dxs))
+                        if all(0 <= ox < d for (ox, d) in zip(oxs, dims)):
+                            col_index = (n, c) + dxs + xs
+                            img_index = (n, c) + oxs
+                            self.assertEqual(
+                                col[col_index], self.img[img_index])
+                        else:
+                            col_index = (n, c) + dxs + xs
+                            self.assertEqual(col[col_index], 0)
+
+    def test_im2col_nd_1_cpu(self):
+        ndim = len(self.dims)
+        ksize = (1,) * ndim
+        stride = (1,) * ndim
+        pad = (1,) * ndim
+        self.check_im2col_nd(ksize, stride, pad, gpu=False)
+
+    def test_im2col_nd_2_cpu(self):
+        ndim = len(self.dims)
+        ksize = (2,) * ndim
+        stride = (2,) * ndim
+        pad = (2,) * ndim
+        self.check_im2col_nd(ksize, stride, pad, gpu=False)
+
+    def test_im2col_nd_3_cpu(self):
+        ndim = len(self.dims)
+        ksize = (1, 2, 1)[:ndim]
+        stride = (2, 1, 2)[:ndim]
+        pad = (1, 2, 1)[:ndim]
+        self.check_im2col_nd(ksize, stride, pad, gpu=False)
+
+    @attr.gpu
+    def test_im2col_nd_1_gpu(self):
+        ndim = len(self.dims)
+        ksize = (1,) * ndim
+        stride = (1,) * ndim
+        pad = (1,) * ndim
+        self.check_im2col_nd(ksize, stride, pad, gpu=True)
+
+    @attr.gpu
+    def test_im2col_nd_2_gpu(self):
+        ndim = len(self.dims)
+        ksize = (2,) * ndim
+        stride = (2,) * ndim
+        pad = (2,) * ndim
+        self.check_im2col_nd(ksize, stride, pad, gpu=True)
+
+    @attr.gpu
+    def test_im2col_nd_3_gpu(self):
+        ndim = len(self.dims)
+        ksize = (1, 2, 1)[:ndim]
+        stride = (2, 1, 2)[:ndim]
+        pad = (1, 2, 1)[:ndim]
+        self.check_im2col_nd(ksize, stride, pad, gpu=True)
+
+
+class TestIm2ColNDParameterRanks(unittest.TestCase):
+
+    def setUp(self):
+        shape = (2, 3, 4, 3)
+        self.ksize = (2, 2)
+        self.stride = (1, 1)
+        self.pad = (0, 0)
+        self.img = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+
+    def test_im2col_nd_cpu_parameter_ranks(self):
+        # Invalid ksize length.
+        with self.assertRaises(AssertionError):
+            conv_nd.im2col_nd_cpu(self.img, (2,), self.stride, self.pad)
+
+        # Invalid stride length.
+        with self.assertRaises(AssertionError):
+            conv_nd.im2col_nd_cpu(self.img, self.ksize, (1,), self.pad)
+
+        # Invalid pad length.
+        with self.assertRaises(AssertionError):
+            conv_nd.im2col_nd_cpu(self.img, self.ksize, self.stride, (0,))
+
+    @attr.gpu
+    def test_im2col_nd_gpu_parameter_ranks(self):
+        img_gpu = cuda.to_gpu(self.img)
+
+        # Invalid ksize length.
+        with self.assertRaises(AssertionError):
+            conv_nd.im2col_nd_gpu(img_gpu, (2,), self.stride, self.pad)
+
+        # Invalid stride length.
+        with self.assertRaises(AssertionError):
+            conv_nd.im2col_nd_gpu(img_gpu, self.ksize, (1,), self.pad)
+
+        # Invalid pad length.
+        with self.assertRaises(AssertionError):
+            conv_nd.im2col_nd_gpu(img_gpu, self.ksize, self.stride, (0,))
+
+
+@testing.parameterize(*testing.product({
+    'dims': [(10,), (10, 8), (10, 8, 6)],
+}))
+class TestCol2ImND(unittest.TestCase):
+
+    def check_col2im_nd(self, ksize, stride, pad, gpu):
+        dims = self.dims
+        outs = tuple(conv_nd.get_conv_outsize(d, k, s, p)
+                     for (d, k, s, p) in zip(dims, ksize, stride, pad))
+        col_shape = (2, 3) + ksize + outs
+        col = numpy.random.uniform(-1, 1, col_shape).astype(numpy.float32)
+
+        if gpu:
+            col2im = conv_nd.col2im_nd_gpu
+            col_data = cuda.to_gpu(col)
+        else:
+            col2im = conv_nd.col2im_nd_cpu
+            col_data = col
+
+        img = col2im(col_data, stride, pad, dims)
+        img = cuda.to_cpu(img)
+        img_shape = (2, 3) + dims
+        self.assertEqual(img.shape, img_shape)
+        for n in moves.range(2):
+            for c in moves.range(3):
+                for xs in itertools.product(
+                        *[moves.range(d) for d in dims]):
+                    v = numpy.float32(0.0)
+                    for dxs in itertools.product(
+                            *[moves.range(k) for k in ksize]):
+                        oxs = tuple((x + p - dx) // s
+                                    for (x, p, dx, s)
+                                    in zip(xs, pad, dxs, stride))
+                        if all((x + p - dx) % s == 0
+                               for (x, p, dx, s)
+                               in zip(xs, pad, dxs, stride)) and \
+                            all(0 <= ox < out
+                                for (ox, out) in zip(oxs, outs)):
+                            col_index = (n, c) + dxs + oxs
+                            v += col[col_index]
+                    img_index = (n, c) + xs
+                    self.assertAlmostEqual(img[img_index], v)
+
+    def test_col2im_1_cpu(self):
+        ndim = len(self.dims)
+        ksize = (1,) * ndim
+        stride = (1,) * ndim
+        pad = (1,) * ndim
+        self.check_col2im_nd(ksize, stride, pad, gpu=False)
+
+    def test_col2im_2_cpu(self):
+        ndim = len(self.dims)
+        ksize = (2,) * ndim
+        stride = (2,) * ndim
+        pad = (2,) * ndim
+        self.check_col2im_nd(ksize, stride, pad, gpu=False)
+
+    def test_col2im_3_cpu(self):
+        ndim = len(self.dims)
+        ksize = (1, 2, 1)[:ndim]
+        stride = (2, 1, 2)[:ndim]
+        pad = (1, 2, 1)[:ndim]
+        self.check_col2im_nd(ksize, stride, pad, gpu=False)
+
+    @attr.gpu
+    def test_col2im_1_gpu(self):
+        ndim = len(self.dims)
+        ksize = (1,) * ndim
+        stride = (1,) * ndim
+        pad = (1,) * ndim
+        self.check_col2im_nd(ksize, stride, pad, gpu=True)
+
+    @attr.gpu
+    def test_col2im_2_gpu(self):
+        ndim = len(self.dims)
+        ksize = (2,) * ndim
+        stride = (2,) * ndim
+        pad = (2,) * ndim
+        self.check_col2im_nd(ksize, stride, pad, gpu=True)
+
+    @attr.gpu
+    def test_col2im_3_gpu(self):
+        ndim = len(self.dims)
+        ksize = (1, 2, 1)[:ndim]
+        stride = (2, 1, 2)[:ndim]
+        pad = (1, 2, 1)[:ndim]
+        self.check_col2im_nd(ksize, stride, pad, gpu=True)
+
+
+class TestCol2ImNDParameterRanks(unittest.TestCase):
+
+    def setUp(self):
+        self.dims = (4, 3)
+        self.ksize = (2, 2)
+        self.stride = (1, 1)
+        self.pad = (0, 0)
+        self.outs = tuple(conv_nd.get_conv_outsize(d, k, s, p)
+                          for (d, k, s, p) in zip(
+                              self.dims, self.ksize, self.stride, self.pad))
+        col_shape = (2, 3) + self.ksize + self.outs
+        self.col = numpy.random.uniform(-1, 1, col_shape).astype(numpy.float32)
+
+    def test_col2im_nd_cpu_parameter_ranks(self):
+        # Invalid ksize length.
+        col_shape = (2, 3) + (2,) + self.outs
+        col = numpy.random.uniform(-1, 1, col_shape).astype(numpy.float32)
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_cpu(col, self.stride, self.pad, self.dims)
+
+        # Invalid stride length.
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_cpu(self.col, (1,), self.pad, self.dims)
+
+        # Invalid pad length.
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_cpu(self.col, self.stride, (0,), self.dims)
+
+        # Invalid dims length.
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_cpu(self.col, self.stride, self.pad, (4,))
+
+    @attr.gpu
+    def test_col2im_nd_gpu_parameter_ranks(self):
+        # Invalid ksize length.
+        col_shape = (2, 3) + (2,) + self.outs
+        col = numpy.random.uniform(-1, 1, col_shape).astype(numpy.float32)
+        col_gpu = cuda.to_gpu(col)
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_gpu(col_gpu, self.stride, self.pad, self.dims)
+
+        col_gpu = cuda.to_gpu(self.col)
+
+        # Invalid stride length.
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_gpu(col_gpu, (1,), self.pad, self.dims)
+
+        # Invalid pad length.
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_gpu(col_gpu, self.stride, (0,), self.dims)
+
+        # Invalid dims length.
+        with self.assertRaises(AssertionError):
+            conv_nd.col2im_nd_gpu(col_gpu, self.stride, self.pad, (4,))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_conv_nd_kernel.py
+++ b/tests/chainer_tests/utils_tests/test_conv_nd_kernel.py
@@ -1,0 +1,49 @@
+import unittest
+
+import mock
+
+import chainer
+from chainer import testing
+from chainer.testing import attr
+from chainer.utils import conv_nd_kernel
+
+
+@testing.parameterize(*testing.product({
+    'ndim': [2, 3, 4],
+}))
+@attr.gpu
+class TestIm2colNDKernelMemo(unittest.TestCase):
+
+    def setUp(self):
+        chainer.cuda.clear_memo()
+
+    def test_im2col_nd_kernel_memo(self):
+        ndim = self.ndim
+        with mock.patch(
+                'chainer.utils.conv_nd_kernel.Im2colNDKernel._generate') as m:
+            conv_nd_kernel.Im2colNDKernel.generate(ndim)
+            m.assert_called_once_with(ndim)
+            conv_nd_kernel.Im2colNDKernel.generate(ndim)
+            m.assert_called_once_with(ndim)
+
+
+@testing.parameterize(*testing.product({
+    'ndim': [2, 3, 4],
+}))
+@attr.gpu
+class TestCol2imNDKernelMemo(unittest.TestCase):
+
+    def setUp(self):
+        chainer.cuda.clear_memo()
+
+    def test_col2im_nd_kernel_memo(self):
+        ndim = self.ndim
+        with mock.patch(
+                'chainer.utils.conv_nd_kernel.Col2imNDKernel._generate') as m:
+            conv_nd_kernel.Col2imNDKernel.generate(ndim)
+            m.assert_called_once_with(ndim)
+            conv_nd_kernel.Col2imNDKernel.generate(ndim)
+            m.assert_called_once_with(ndim)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR implements N-dimensional convolution function and link, following #1279 which is reverted by #1542, and now support cuDNN 5.x.

In this PR, it is to support FP16, FP32 and FP64 of storing precision, and FP32 and FP64 of computing precision. FP16 computing precision will be supported through another issue, since we would require policy making on how to treat FP16 computing precision on GPUs with compute capability that does not support it.