### PR TITLE
Fix ndarray's OWNDATA flag

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -109,7 +109,7 @@ cdef class ndarray:
 
         """
         return flags.Flags(self._c_contiguous, self._f_contiguous,
-                           self.base is not None)
+                           self.base is None)
 
     property shape:
         """Lengths of axes.

--- a/tests/cupy_tests/core_tests/test_ndarray_owndata.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_owndata.py
@@ -1,0 +1,24 @@
+import unittest
+
+from cupy import core
+from cupy import testing
+
+
+@testing.gpu
+class TestArrayOwndata(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        self.a = core.ndarray(())
+
+    def test_original_array(self):
+        self.assertTrue(self.a.flags.owndata)
+
+    def test_view_array(self):
+        v = self.a.view()
+        self.assertFalse(v.flags.owndata)
+
+    def test_reshaped_array(self):
+        r = self.a.reshape(())
+        self.assertFalse(r.flags.owndata)


### PR DESCRIPTION
```python
>>> numpy.ndarray(()).flags['OWNDATA']
True
>>> cupy.ndarray(()).flags['OWNDATA']
False
>>> numpy.ndarray(()).view().flags['OWNDATA']
False
>>> cupy.ndarray(()).view().flags['OWNDATA']
True
```
