### PR TITLE
Take a snapshot only at the end of the learning in MNIST example

### DIFF
--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -78,7 +78,7 @@ def main():
     trainer.extend(extensions.dump_graph('main/loss'))
 
     # Take a snapshot at each epoch
-    trainer.extend(extensions.snapshot())
+    trainer.extend(extensions.snapshot(), trigger=(args.epoch, 'epoch'))
 
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())

--- a/examples/mnist/train_mnist_data_parallel.py
+++ b/examples/mnist/train_mnist_data_parallel.py
@@ -60,7 +60,7 @@ def main():
 
     trainer.extend(extensions.Evaluator(test_iter, model, device=args.gpu0))
     trainer.extend(extensions.dump_graph('main/loss'))
-    trainer.extend(extensions.snapshot())
+    trainer.extend(extensions.snapshot(), trigger=(args.epoch, 'epoch'))
     trainer.extend(extensions.LogReport())
     trainer.extend(extensions.PrintReport(
         ['epoch', 'main/loss', 'validation/main/loss',

--- a/examples/mnist/train_mnist_model_parallel.py
+++ b/examples/mnist/train_mnist_model_parallel.py
@@ -86,7 +86,7 @@ def main():
 
     trainer.extend(extensions.Evaluator(test_iter, model, device=args.gpu0))
     trainer.extend(extensions.dump_graph('main/loss'))
-    trainer.extend(extensions.snapshot())
+    trainer.extend(extensions.snapshot(), trigger=(args.epoch, 'epoch'))
     trainer.extend(extensions.LogReport())
     trainer.extend(extensions.PrintReport(
         ['epoch', 'main/loss', 'validation/main/loss',


### PR DESCRIPTION
This change decreases the number of snapshots taken in the MNIST example. It makes the example quickly finish.