### PR TITLE
Implement square function

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -76,6 +76,7 @@ from chainer.functions.math import maximum
 from chainer.functions.math import minimum
 from chainer.functions.math import minmax
 from chainer.functions.math import scale
+from chainer.functions.math import square
 from chainer.functions.math import sqrt
 from chainer.functions.math import sum
 from chainer.functions.math import trigonometric
@@ -271,6 +272,8 @@ Sin = trigonometric.Sin
 sin = trigonometric.sin
 Sinh = hyperbolic.Sinh
 sinh = hyperbolic.sinh
+Square = square.Square
+square = square.square
 Sqrt = sqrt.Sqrt
 sqrt = sqrt.sqrt
 Sum = sum.Sum

--- a/chainer/functions/math/square.py
+++ b/chainer/functions/math/square.py
@@ -1,0 +1,41 @@
+from chainer import cuda
+from chainer import function
+from chainer import utils
+from chainer.utils import type_check
+
+
+class Square(function.Function):
+    @property
+    def label(self):
+        return 'square'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(
+            in_types.size() == 1,
+            in_types[0].dtype.kind == 'f',
+        )
+
+    def forward(self, x):
+        xp = cuda.get_array_module(*x)
+        return utils.force_array(xp.square(x[0], dtype=x[0].dtype)),
+
+    def backward(self, x, gy):
+        xp = cuda.get_array_module(*x)
+        gx = utils.force_array(x[0]*2.0, dtype=x[0].dtype)
+        gx *= gy[0]
+        return gx,
+
+
+def square(x):
+    """Elementwise square function.
+
+    .. math::
+       y_i = x_i*x_i .
+
+    Args:
+        x (~chainer.Variable): Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
+    return Square()(x)

--- a/tests/chainer_tests/functions_tests/math_tests/test_square.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_square.py
@@ -1,0 +1,81 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+import chainer.functions as F
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+
+class UnaryFunctionsTestBase(unittest.TestCase):
+
+    def make_data(self):
+        raise NotImplementedError
+
+    def setUp(self):
+        self.x, self.gy = self.make_data()
+
+    def check_forward(self, op, op_xp, x_data):
+        x = chainer.Variable(x_data)
+        y = op(x)
+        self.assertEqual(x.data.dtype, y.data.dtype)
+        testing.assert_allclose(
+            op_xp(x_data, dtype=x_data.dtype), y.data, atol=1e-7, rtol=1e-7)
+
+    def check_forward_cpu(self, op, op_xp):
+        self.check_forward(op, op_xp, self.x)
+
+    def check_forward_gpu(self, op, op_xp):
+        self.check_forward(op, op_xp, cuda.to_gpu(self.x))
+
+    def check_backward(self, op, x_data, y_grad):
+        gradient_check.check_backward(
+            op, x_data, y_grad, atol=5e-4, rtol=5e-3, dtype=numpy.float64)
+
+    def check_backward_cpu(self, op):
+        self.check_backward(op, self.x, self.gy)
+
+    def check_backward_gpu(self, op):
+        self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    def check_label(self, op, expected):
+        self.assertEqual(op().label, expected)
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), ()],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestSqrt(UnaryFunctionsTestBase):
+
+    def make_data(self):
+        x = numpy.random.uniform(0.1, 1, self.shape).astype(self.dtype)
+        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        return x, gy
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward_cpu(F.square, numpy.square)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.check_forward_gpu(F.square, cuda.cupy.square)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward_cpu(F.square)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward_gpu(F.square)
+
+    def test_label(self):
+        self.check_label(F.Square, 'square')
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_square.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_square.py
@@ -50,7 +50,7 @@ class UnaryFunctionsTestBase(unittest.TestCase):
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestSqrt(UnaryFunctionsTestBase):
+class TestSquare(UnaryFunctionsTestBase):
 
     def make_data(self):
         x = numpy.random.uniform(0.1, 1, self.shape).astype(self.dtype)


### PR DESCRIPTION
This PR implements square function with covering test for input of dtype float16, float32 and float64.
The way to test this function is almost same as sqrt function. (see tests/chainer_tests/functions_tests/math_tests/test_sqrt.py)

