### PR TITLE
Fix cupy.clip

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2319,7 +2319,7 @@ cdef _clip = create_ufunc(
     'cupy_clip',
     ('???->?', 'bbb->b', 'BBB->B', 'hhh->h', 'HHH->H', 'iii->i', 'III->I',
      'lll->l', 'LLL->L', 'qqq->q', 'QQQ->Q', 'eee->e', 'fff->f', 'ddd->d'),
-    'out0 = (in0 < in1 ? in1 : (in0 > in2 ? in2 : in0))')
+    'out0 = in0 < in1 ? in1 : (in0 > in2 ? in2 : in0)')
 
 
 # -----------------------------------------------------------------------------

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2319,7 +2319,7 @@ cdef _clip = create_ufunc(
     'cupy_clip',
     ('???->?', 'bbb->b', 'BBB->B', 'hhh->h', 'HHH->H', 'iii->i', 'III->I',
      'lll->l', 'LLL->L', 'qqq->q', 'QQQ->Q', 'eee->e', 'fff->f', 'ddd->d'),
-    'out0 = min(in2, max(in1, in0))')
+    'out0 = (in0 < in1 ? in1 : (in0 > in2 ? in2 : in0))')
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
cupy.clip returns different values (compared to numpy.clip) when a_min is greater than a_max.
`cupy.clip(cupy.arange(10), 7, 3)` must be evaluated to [7, 7, 7, 7, 7, 7, 7, 3, 3, 3].
