### PR TITLE
Fix build

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -17,7 +17,7 @@ from install import utils
 
 
 dummy_extension = setuptools.Extension('chainer', ['chainer.c'])
-cython_version = '0.23.0'
+cython_version = '0.24.0'
 MODULES = [
     {
         'name': 'cuda',

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -136,7 +136,7 @@ The destination directories depend on your environment.
 Install Chainer for developers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Chainer uses Cython (>=0.23).
+Chainer uses Cython (>=0.24).
 Developers need to use Cython to regenerate C++ sources from ``pyx`` files.
 We recommend to use ``pip`` with ``-e`` option for editable mode::
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ on_rtd = chainer_setup_build.check_readthedocs_environment()
 if on_rtd:
     print('Add develop command for Read the Docs')
     sys.argv.insert(1, 'develop')
-    setup_requires = ['Cython>=0.23'] + setup_requires
+    setup_requires = ['Cython>=0.24'] + setup_requires
 
 chainer_setup_build.parse_args()
 


### PR DESCRIPTION
Installation of Chainer 1.15.0 fails when Cython 0.23 is installed. ~~This PR fixes build by using Cython 0.24.1. This PR makes build slower. **Although build of Chainer gets slower, Chainer itself does not.**~~

Do not delete this branch before release of 1.15.1.

Fixes #1609.