### PR TITLE
Add use_cudnn flag to BatchNormalization link

### DIFF
--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -39,6 +39,7 @@ class BatchNormalization(link.Link):
             unit(1) which makes no effect.
         use_beta (bool): If `True`, use shifting parameter. Otherwise, use
             unit(0) which makes no effect.
+        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
 
     See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
           Internal Covariate Shift <http://arxiv.org/abs/1502.03167>`_
@@ -56,12 +57,13 @@ class BatchNormalization(link.Link):
         decay (float): Decay rate of moving average. It is used on training.
         eps (float): Epsilon value for numerical stability. This value is added
             to the batch variances.
+        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
 
     """
 
     def __init__(self, size, decay=0.9, eps=2e-5, dtype=numpy.float32,
                  use_gamma=True, use_beta=True,
-                 initial_gamma=None, initial_beta=None):
+                 initial_gamma=None, initial_beta=None, use_cudnn=True):
         super(BatchNormalization, self).__init__()
         if use_gamma:
             self.add_param('gamma', size, dtype=dtype)
@@ -78,6 +80,7 @@ class BatchNormalization(link.Link):
         self.add_persistent('N', 0)
         self.decay = decay
         self.eps = eps
+        self.use_cudnn = use_cudnn
 
     def __call__(self, x, test=False, finetune=False):
         """Invokes the forward propagation of BatchNormalization.
@@ -119,7 +122,8 @@ class BatchNormalization(link.Link):
                 decay = self.decay
 
             func = batch_normalization.BatchNormalizationFunction(
-                self.eps, self.avg_mean, self.avg_var, True, decay)
+                self.eps, self.avg_mean, self.avg_var, True, decay,
+                self.use_cudnn)
             ret = func(x, gamma, beta)
 
             self.avg_mean = func.running_mean
@@ -129,7 +133,7 @@ class BatchNormalization(link.Link):
             mean = variable.Variable(self.avg_mean, volatile='auto')
             var = variable.Variable(self.avg_var, volatile='auto')
             ret = batch_normalization.fixed_batch_normalization(
-                x, gamma, beta, mean, var, self.eps)
+                x, gamma, beta, mean, var, self.eps, self.use_cudnn)
         return ret
 
     def start_finetuning(self):

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -85,6 +85,11 @@ class BatchNormalizationTest(unittest.TestCase):
         self.link.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
 
+    @attr.cudnn
+    def test_forward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_forward_gpu()
+
     @attr.multi_gpu(2)
     @condition.retry(3)
     def test_forward_multi_gpu(self):
@@ -108,6 +113,11 @@ class BatchNormalizationTest(unittest.TestCase):
     def test_backward_gpu(self):
         self.link.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    @attr.cudnn
+    def test_backward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_backward_gpu()
 
 
 @testing.parameterize(
@@ -150,6 +160,11 @@ class TestPopulationStatistics(unittest.TestCase):
         self.link.to_gpu()
         self.check_statistics(cuda.to_gpu(self.x), cuda.to_gpu(self.y))
 
+    @attr.cudnn
+    def test_statistics_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_statistics_gpu()
+
     def check_statistics2(self, x, y):
         x = chainer.Variable(x)
         y = chainer.Variable(y)
@@ -180,6 +195,11 @@ class TestPopulationStatistics(unittest.TestCase):
         self.check_statistics2(
             cuda.to_gpu(self.x),
             cuda.to_gpu(self.y))
+
+    @attr.cudnn
+    def test_statistics2_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_statistics2_gpu()
 
 
 @testing.parameterize(*testing.product({
@@ -234,6 +254,11 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
         y_expected = cuda.to_gpu(self.y_expected)
         self.check_forward(x, y_expected)
 
+    @attr.cudnn
+    def test_forward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_forward_gpu()
+
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(self.link, x_data, y_grad,
                                       eps=1e-2, rtol=1e-3, atol=1e-4)
@@ -249,6 +274,11 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
         x = cuda.to_gpu(self.x)
         gy = cuda.to_gpu(self.gy)
         self.check_backward(x, gy)
+
+    @attr.cudnn
+    def test_backward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_backward_gpu()
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
`batch_normalization` and `fixed_batch_normalization` functions support the `use_cudnn` argument, while `BatchNormalization` link does not have a corresponding attribute, which is added by this PR.