### PR TITLE
Treat future.types.newint.newint properly in get_device

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -136,6 +136,16 @@ if available:
     cuda.set_allocator(memory_pool.malloc)
 
 
+if six.PY2:
+    try:
+        from future.types.newint import newint as _newint
+        _integer_types = six.integer_types + (_newint,)
+    except ImportError:
+        _integer_types = six.integer_types
+else:
+    _integer_types = six.integer_types
+
+
 # ------------------------------------------------------------------------------
 # Global states
 # ------------------------------------------------------------------------------
@@ -163,7 +173,7 @@ def get_device(*args):
 
     """
     for arg in args:
-        if type(arg) in six.integer_types:
+        if type(arg) in _integer_types:
             check_cuda_available()
             return Device(arg)
         if isinstance(arg, ndarray):

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -21,6 +21,14 @@ class TestDummyDeviceType(unittest.TestCase):
         self.assertNotEqual(cuda.DummyDeviceType(), 1)
 
 
+_builtins_available = False
+try:
+    import builtins
+    _builtins_available = True
+except ImportError:
+    pass
+
+
 class TestCuda(unittest.TestCase):
 
     def test_get_dummy_device(self):
@@ -37,6 +45,14 @@ class TestCuda(unittest.TestCase):
     @attr.gpu
     def test_get_device_for_int(self):
         self.assertEqual(cuda.get_device(0), cuda.Device(0))
+
+    @attr.gpu
+    @unittest.skipUnless(_builtins_available,
+                         'builtins module is not available')
+    def test_get_device_for_builtin_int(self):
+        # builtins.int is from future package and it is different
+        # from builtin int/long on Python 2.
+        self.assertEqual(cuda.get_device(builtins.int(0)), cuda.Device(0))
 
     def test_to_gpu_unavailable(self):
         x = numpy.array([1])


### PR DESCRIPTION
Note that we do not use `isinstance` in `get_device` for performance.