### PR TITLE
Accept dtype to add parameters via Link's __init__ method.

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -1,3 +1,4 @@
+import collections
 import copy
 import warnings
 
@@ -8,14 +9,24 @@ from chainer import cuda
 from chainer import variable
 
 
-def _ensure_shape_dtype(value):
-    if isinstance(value, tuple) and \
-       len(value) == 2 and \
-       not isinstance(value[1], six.integer_types):
-        # Approximately identify a shape-dtype pair.
-        return value
+def _is_shape(value):
+    if value is None:
+        return True
+    elif isinstance(value, six.integer_types):
+        return True
+    elif isinstance(value, collections.Sequence):
+        return all(isinstance(x, six.integer_types) for x in value)
     else:
-        return (value, numpy.float32)
+        return False
+
+
+def _ensure_shape_dtype(value):
+    # Return value paired with dtype FP32 if it is a shape.
+    if _is_shape(value):
+        return (value, 'f')
+    # Otherwise, returns it with assuming a shape-dtype pair.
+    else:
+        return value
 
 
 class Link(object):

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -8,6 +8,16 @@ from chainer import cuda
 from chainer import variable
 
 
+def _ensure_shape_dtype(value):
+    if isinstance(value, tuple) and \
+       len(value) == 2 and \
+       not isinstance(value[1], six.integer_types):
+        # Approximately identify a shape-dtype pair.
+        return value
+    else:
+        return (value, numpy.float32)
+
+
 class Link(object):
 
     """Building block of model definitions.
@@ -83,7 +93,9 @@ class Link(object):
 
     Args:
         params: Shapes of initial parameters. The keywords are used as their
-            names. The names are also set to the parameter variables.
+            names. The names are also set to the parameter variables. You may
+            pass tuples of a shape and a dtype ``(shape, dtype)`` to add
+            parameters with specifying their dtypes.
 
     Attributes:
         name (str): Name of this link, given by the parent chain (if exists).
@@ -97,8 +109,9 @@ class Link(object):
         self._cpu = True
         self.name = None
 
-        for name, shape in six.iteritems(params):
-            self.add_param(name, shape)
+        for name, value in six.iteritems(params):
+            shape, dtype = _ensure_shape_dtype(value)
+            self.add_param(name, shape, dtype=dtype)
 
     @property
     def xp(self):

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -103,10 +103,11 @@ class Link(object):
        operator.
 
     Args:
-        params: Shapes of initial parameters. The keywords are used as their
-            names. The names are also set to the parameter variables. You may
-            pass tuples of a shape and a dtype ``(shape, dtype)`` to add
-            parameters with specifying their dtypes.
+        params: Names, shapes, and optional dtypes of initial parameters. The
+            keywords are used as the parameter names and the corresponding
+            values consist either of the shape or a tuple of shape and a dtype
+            `(shape, dtype)`. If only the shape is supplied, the default dtype
+            will be used.
 
     Attributes:
         name (str): Name of this link, given by the parent chain (if exists).

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -12,7 +12,7 @@ from chainer.testing import attr
 class TestLink(unittest.TestCase):
 
     def setUp(self):
-        self.link = chainer.Link(x=(2, 3), y=2)
+        self.link = chainer.Link(x=((2, 3), 'd'), y=2)
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'
@@ -30,7 +30,7 @@ class TestLink(unittest.TestCase):
         self.assertTrue(numpy.all(numpy.isnan(var.grad)))
 
     def test_init(self):
-        self.check_param_init('x', (2, 3), 'f')
+        self.check_param_init('x', (2, 3), 'd')
         self.check_param_init('y', (2,), 'f')
 
     def test_add_param(self):


### PR DESCRIPTION
Fix #1631.

This PR makes Link's `__init__` method to accept dtypes as well as shapes to register parameters as the following:

    l = link.Link(W=((2, 3), 'd'))

where link `l` has parameter `W` with its shape of `(2, 3)` and dtype of `'d'`.
