### PR TITLE
Count words before trimming data

### DIFF
--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -174,16 +174,16 @@ if args.gpu >= 0:
     cuda.get_device(args.gpu).use()
 
 train, val, _ = chainer.datasets.get_ptb_words()
+counts = collections.Counter(train)
+counts.update(collections.Counter(val))
 n_vocab = max(train) + 1
+
 if args.test:
     train = train[:100]
     val = val[:100]
 
 vocab = chainer.datasets.get_ptb_words_vocabulary()
 index2word = {wid: word for word, wid in six.iteritems(vocab)}
-
-counts = collections.Counter(train)
-counts.update(collections.Counter(val))
 
 print('n_vocab: %d' % n_vocab)
 print('data length: %d' % len(train))


### PR DESCRIPTION
word2vec example contains a bug when a user run it with `--test` option. I fixed it to count words before trimming data for test mode.
Please execute this command:
```
$ examples/word2vec/train_word2vec.py -e 1 -b 10 -m cbow --out-type ns --test
```

related #1500 
