### PR TITLE
Fix AlexNet in examples to use the correct order of layers

### DIFF
--- a/examples/imagenet/alex.py
+++ b/examples/imagenet/alex.py
@@ -23,10 +23,10 @@ class Alex(chainer.Chain):
         self.train = True
 
     def __call__(self, x, t):
-        h = F.max_pooling_2d(F.relu(
-            F.local_response_normalization(self.conv1(x))), 3, stride=2)
-        h = F.max_pooling_2d(F.relu(
-            F.local_response_normalization(self.conv2(h))), 3, stride=2)
+        h = F.max_pooling_2d(F.local_response_normalization(
+            F.relu(self.conv1(x))), 3, stride=2)
+        h = F.max_pooling_2d(F.local_response_normalization(
+            F.relu(self.conv2(h))), 3, stride=2)
         h = F.relu(self.conv3(h))
         h = F.relu(self.conv4(h))
         h = F.max_pooling_2d(F.relu(self.conv5(h)), 3, stride=2)


### PR DESCRIPTION
Despite the original AlexNet applies the local response normalization layer after the relu, the current example applies the relu after the local response normalization layer.
(This bug was originally reported by another guy in the nvidia event)