### PR TITLE
Use shared memory in multiprocess iterator

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -35,9 +35,8 @@ class MultiprocessIterator(iterator.Iterator):
         n_processes (int): Number of worker processes. The number of CPUs is
             used by default.
         n_prefetch (int): Number of prefetch batches.
-        shared_mem (int):
-
-
+        shared_mem (int): The size of using shared memory per data.
+            If ``None``, size is adjusted automatically.
 
     """
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -136,7 +136,7 @@ class MultiprocessIterator(iterator.Iterator):
         assert len(self._workers) == 0
         assert self._shared_mem_size is not None
         mem_size = self._shared_mem_size
-        for i in six.moves.range(self.batch_size * self.n_prefetch):
+        for i in six.moves.range(self.batch_size * (self.n_prefetch + 1)):
             self._mem_list.append(sharedctypes.RawArray('b', mem_size))
             self._unused_mem_queue.put(i)
 

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -1,35 +1,114 @@
 import unittest
 
+import numpy
+import six
+
 from chainer import iterators
 from chainer import testing
 
 
+@testing.parameterize(*testing.product({
+    'n_prefetch': [1, 2],
+    'shared_mem': [None, 1000000],
+}))
 class TestMultiprocessIterator(unittest.TestCase):
 
     def setUp(self):
         self.n_processes = 2
+        self.options = {'n_processes': self.n_processes,
+                        'n_prefetch': self.n_prefetch,
+                        'shared_mem': self.shared_mem}
 
     def test_iterator_repeat(self):
         dataset = [1, 2, 3, 4, 5, 6]
-        it = iterators.MultiprocessIterator(
-            dataset, 2, n_processes=self.n_processes)
+        it = iterators.MultiprocessIterator(dataset, 2, **self.options)
         for i in range(3):
             self.assertEqual(it.epoch, i)
             batch1 = it.next()
             self.assertEqual(len(batch1), 2)
+            self.assertIsInstance(batch1, list)
             self.assertFalse(it.is_new_epoch)
             batch2 = it.next()
             self.assertEqual(len(batch2), 2)
+            self.assertIsInstance(batch2, list)
             self.assertFalse(it.is_new_epoch)
             batch3 = it.next()
             self.assertEqual(len(batch3), 2)
+            self.assertIsInstance(batch3, list)
             self.assertTrue(it.is_new_epoch)
             self.assertEqual(sorted(batch1 + batch2 + batch3), dataset)
 
+    def test_iterator_list_type(self):
+        dataset = [[i, numpy.zeros((10,)) + i] for i in range(6)]
+        it = iterators.MultiprocessIterator(dataset, 2, **self.options)
+        for i in range(3):
+            self.assertEqual(it.epoch, i)
+            batches = {}
+            for j in range(3):
+                batch = it.next()
+                self.assertEqual(len(batch), 2)
+                if j != 2:
+                    self.assertFalse(it.is_new_epoch)
+                else:
+                    self.assertTrue(it.is_new_epoch)
+                for x in batch:
+                    self.assertIsInstance(x, list)
+                    self.assertIsInstance(x[1], numpy.ndarray)
+                    batches[x[0]] = x[1]
+
+            self.assertEqual(len(batches), len(dataset))
+            for k, v in six.iteritems(batches):
+                numpy.testing.assert_allclose(dataset[k][1], v)
+
+    def test_iterator_tuple_type(self):
+        dataset = [(i, numpy.zeros((10,)) + i) for i in range(6)]
+        it = iterators.MultiprocessIterator(dataset, 2, **self.options)
+        for i in range(3):
+            self.assertEqual(it.epoch, i)
+            batches = {}
+            for j in range(3):
+                batch = it.next()
+                self.assertEqual(len(batch), 2)
+                if j != 2:
+                    self.assertFalse(it.is_new_epoch)
+                else:
+                    self.assertTrue(it.is_new_epoch)
+                for x in batch:
+                    self.assertIsInstance(x, tuple)
+                    self.assertIsInstance(x[1], numpy.ndarray)
+                    batches[x[0]] = x[1]
+
+            self.assertEqual(len(batches), len(dataset))
+            for k, v in six.iteritems(batches):
+                numpy.testing.assert_allclose(dataset[k][1], v)
+
+    def test_iterator_dict_type(self):
+        dataset = [{i: numpy.zeros((10,)) + i} for i in range(6)]
+        it = iterators.MultiprocessIterator(dataset, 2, **self.options)
+        for i in range(3):
+            self.assertEqual(it.epoch, i)
+            batches = {}
+            for j in range(3):
+                batch = it.next()
+                self.assertEqual(len(batch), 2)
+                if j != 2:
+                    self.assertFalse(it.is_new_epoch)
+                else:
+                    self.assertTrue(it.is_new_epoch)
+                for x in batch:
+                    self.assertIsInstance(x, dict)
+                    k = x.keys()[0]
+                    v = x.values()[0]
+                    self.assertIsInstance(v, numpy.ndarray)
+                    batches[k] = v
+
+            self.assertEqual(len(batches), len(dataset))
+            for k, v in six.iteritems(batches):
+                numpy.testing.assert_allclose(dataset[k].values()[0], v)
+
     def test_iterator_repeat_not_even(self):
         dataset = [1, 2, 3, 4, 5]
-        it = iterators.MultiprocessIterator(
-            dataset, 2, n_processes=self.n_processes)
+        it = iterators.MultiprocessIterator(dataset, 2, **self.options)
 
         batches = sum([it.next() for _ in range(5)], [])
         self.assertEqual(sorted(batches), sorted(dataset * 2))
@@ -37,7 +116,7 @@ class TestMultiprocessIterator(unittest.TestCase):
     def test_iterator_not_repeat(self):
         dataset = [1, 2, 3, 4, 5]
         it = iterators.MultiprocessIterator(
-            dataset, 2, repeat=False, n_processes=self.n_processes)
+            dataset, 2, repeat=False, **self.options)
 
         batches = sum([it.next() for _ in range(3)], [])
         self.assertEqual(sorted(batches), dataset)
@@ -47,7 +126,7 @@ class TestMultiprocessIterator(unittest.TestCase):
     def test_iterator_not_repeat_not_even(self):
         dataset = [1, 2, 3, 4, 5]
         it = iterators.MultiprocessIterator(
-            dataset, 2, repeat=False, n_processes=self.n_processes)
+            dataset, 2, repeat=False, **self.options)
 
         batch1 = it.next()
         batch2 = it.next()
@@ -60,13 +139,13 @@ class TestMultiprocessIterator(unittest.TestCase):
     def test_iterator_shuffle_divisible(self):
         dataset = list(range(10))
         it = iterators.MultiprocessIterator(
-            dataset, 10, n_processes=self.n_processes)
+            dataset, 10, **self.options)
         self.assertNotEqual(it.next(), it.next())
 
     def test_iterator_shuffle_nondivisible(self):
         dataset = list(range(10))
         it = iterators.MultiprocessIterator(
-            dataset, 3, n_processes=self.n_processes)
+            dataset, 3, **self.options)
         out = sum([it.next() for _ in range(7)], [])
         self.assertNotEqual(out[0:10], out[10:20])
 

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -97,14 +97,13 @@ class TestMultiprocessIterator(unittest.TestCase):
                     self.assertTrue(it.is_new_epoch)
                 for x in batch:
                     self.assertIsInstance(x, dict)
-                    k = x.keys()[0]
-                    v = x.values()[0]
+                    k, v = six.viewitems(x)[0]
                     self.assertIsInstance(v, numpy.ndarray)
                     batches[k] = v
 
             self.assertEqual(len(batches), len(dataset))
             for k, v in six.iteritems(batches):
-                numpy.testing.assert_allclose(dataset[k].values()[0], v)
+                numpy.testing.assert_allclose(six.viewvalues(dataset[k])[0], v)
 
     def test_iterator_repeat_not_even(self):
         dataset = [1, 2, 3, 4, 5]

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -97,13 +97,15 @@ class TestMultiprocessIterator(unittest.TestCase):
                     self.assertTrue(it.is_new_epoch)
                 for x in batch:
                     self.assertIsInstance(x, dict)
-                    k, v = six.viewitems(x)[0]
+                    k = tuple(x)[0]
+                    v = x[k]
                     self.assertIsInstance(v, numpy.ndarray)
                     batches[k] = v
 
             self.assertEqual(len(batches), len(dataset))
             for k, v in six.iteritems(batches):
-                numpy.testing.assert_allclose(six.viewvalues(dataset[k])[0], v)
+                x = dataset[k][tuple(dataset[k])[0]]
+                numpy.testing.assert_allclose(x, v)
 
     def test_iterator_repeat_not_even(self):
         dataset = [1, 2, 3, 4, 5]


### PR DESCRIPTION
This PR reduce training time.

master
```
% ./train_imagenet.py /data/ILSVRC/train10k.txt /data/ILSVRC/val1k.txt --arch alex --gpu 2 --epoch 2 --batchsize 64
228.25s user 55.60s system 296% cpu 1:35.78 total
```

sharedmem
```
% ./train_imagenet.py /data/ILSVRC/train10k.txt /data/ILSVRC/val1k.txt --arch alex --gpu 2 --epoch 2 --batchsize 64
209.88s user 55.53s system 552% cpu 48.033 total
```