### PR TITLE
Remove variable wrap

### DIFF
--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -5,6 +5,7 @@ import six
 from chainer import configuration
 from chainer.dataset import convert
 from chainer.dataset import iterator as iterator_module
+from chainer import function
 from chainer import link
 from chainer import reporter as reporter_module
 from chainer.training import extension
@@ -166,17 +167,13 @@ class Evaluator(extension.Extension):
             observation = {}
             with reporter_module.report_scope(observation):
                 in_arrays = self.converter(batch, self.device)
-                if isinstance(in_arrays, tuple):
-                    in_vars = tuple(variable.Variable(x, volatile='on')
-                                    for x in in_arrays)
-                    eval_func(*in_vars)
-                elif isinstance(in_arrays, dict):
-                    in_vars = {key: variable.Variable(x, volatile='on')
-                               for key, x in six.iteritems(in_arrays)}
-                    eval_func(**in_vars)
-                else:
-                    in_var = variable.Variable(in_arrays, volatile='on')
-                    eval_func(in_var)
+                with function.no_backprop_mode():
+                    if isinstance(in_arrays, tuple):
+                        eval_func(*in_arrays)
+                    elif isinstance(in_arrays, dict):
+                        eval_func(**in_arrays)
+                    else:
+                        eval_func(in_arrays)
 
             summary.add(observation)
 

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -9,7 +9,6 @@ from chainer import function
 from chainer import link
 from chainer import reporter as reporter_module
 from chainer.training import extension
-from chainer import variable
 
 
 class Evaluator(extension.Extension):

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -5,7 +5,6 @@ from chainer.dataset import convert
 from chainer.dataset import iterator as iterator_module
 from chainer import function
 from chainer import optimizer as optimizer_module
-from chainer import variable
 
 
 class Updater(object):

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -183,15 +183,11 @@ class StandardUpdater(Updater):
         loss_func = self.loss_func or optimizer.target
 
         if isinstance(in_arrays, tuple):
-            in_vars = tuple(variable.Variable(x) for x in in_arrays)
-            optimizer.update(loss_func, *in_vars)
+            optimizer.update(loss_func, *in_arrays)
         elif isinstance(in_arrays, dict):
-            in_vars = {key: variable.Variable(x)
-                       for key, x in six.iteritems(in_arrays)}
-            optimizer.update(loss_func, **in_vars)
+            optimizer.update(loss_func, **in_arrays)
         else:
-            in_var = variable.Variable(in_arrays)
-            optimizer.update(loss_func, in_var)
+            optimizer.update(loss_func, in_arrays)
 
     def serialize(self, serializer):
         for name, iterator in six.iteritems(self._iterators):

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -3,6 +3,7 @@ import six
 
 from chainer.dataset import convert
 from chainer.dataset import iterator as iterator_module
+from chainer import function
 from chainer import optimizer as optimizer_module
 from chainer import variable
 
@@ -302,12 +303,13 @@ class ParallelUpdater(StandardUpdater):
             in_arrays = in_arrays_list[model_key]
             loss_func = self.loss_func or model
 
-            if isinstance(in_arrays, tuple):
-                loss = loss_func(*in_arrays)
-            elif isinstance(in_arrays, dict):
-                loss = loss_func(**in_arrays)
-            else:
-                loss = loss_func(in_arrays)
+            with function.force_backprop_mode():
+                if isinstance(in_arrays, tuple):
+                    loss = loss_func(*in_arrays)
+                elif isinstance(in_arrays, dict):
+                    loss = loss_func(**in_arrays)
+                else:
+                    loss = loss_func(in_arrays)
             losses.append(loss)
 
         # For _uninitialized_params

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -303,15 +303,12 @@ class ParallelUpdater(StandardUpdater):
             loss_func = self.loss_func or model
 
             if isinstance(in_arrays, tuple):
-                in_vars = tuple(variable.Variable(x) for x in in_arrays)
-                losses.append(loss_func(*in_vars))
+                loss = loss_func(*in_arrays)
             elif isinstance(in_arrays, dict):
-                in_vars = {key: variable.Variable(x)
-                           for key, x in six.iteritems(in_arrays)}
-                losses.append(loss_func(**in_vars))
+                loss = loss_func(**in_arrays)
             else:
-                in_vars = variable.Variable(in_arrays)
-                losses.append(loss_func(in_vars))
+                loss = loss_func(in_arrays)
+            losses.append(loss)
 
         # For _uninitialized_params
         for model in six.itervalues(self._models):

--- a/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
@@ -1,0 +1,185 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import dataset
+from chainer.training import extensions
+
+
+class DummyModel(chainer.Chain):
+
+    def __init__(self, test):
+        super(DummyModel, self).__init__()
+        self.args = []
+        self.test = test
+
+    def __call__(self, x):
+        self.args.append(x)
+        chainer.report({'loss': x.sum()}, self)
+
+
+class DummyModelTwoArgs(chainer.Chain):
+
+    def __init__(self, test):
+        super(DummyModelTwoArgs, self).__init__()
+        self.args = []
+        self.test = test
+
+    def __call__(self, x, y):
+        self.args.append((x, y))
+        chainer.report({'loss': x.sum() + y.sum()}, self)
+
+
+class DummyIterator(dataset.Iterator):
+
+    def __init__(self, return_values):
+        self.iterator = iter(return_values)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+class DummyConverter(object):
+
+    def __init__(self, return_values):
+        self.args = []
+        self.iterator = iter(return_values)
+
+    def __call__(self, batch, device):
+        self.args.append({'batch': batch, 'device': device})
+        return next(self.iterator)
+
+
+class TestEvaluator(unittest.TestCase):
+
+    def setUp(self):
+        self.data = [
+            numpy.random.uniform(-1, 1, (3, 4)).astype('f') for _ in range(2)]
+        self.batches = [
+            numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f')
+            for _ in range(2)]
+
+        self.iterator = DummyIterator(self.data)
+        self.converter = DummyConverter(self.batches)
+        self.target = DummyModel(self)
+        self.evaluator = extensions.Evaluator(
+            self.iterator, self.target, converter=self.converter)
+        self.expect_mean = numpy.mean([numpy.sum(x) for x in self.batches])
+
+    def test_evaluate(self):
+        reporter = chainer.Reporter()
+        reporter.add_observer('target', self.target)
+        with reporter:
+            mean = self.evaluator.evaluate()
+
+        # No observation is reported to the current reporter. Instead the
+        # evaluator collect results in order to calculate their mean.
+        self.assertEqual(len(reporter.observation), 0)
+
+        # The converter gets results of the iterator.
+        self.assertEqual(len(self.converter.args), len(self.data))
+        for i in range(len(self.data)):
+            numpy.testing.assert_array_equal(
+                self.converter.args[i]['batch'], self.data[i])
+            self.assertIsNone(self.converter.args[i]['device'])
+
+        # The model gets results of converter.
+        self.assertEqual(len(self.target.args), len(self.batches))
+        for i in range(len(self.batches)):
+            numpy.testing.assert_array_equal(
+                self.target.args[i], self.batches[i])
+
+        self.assertAlmostEqual(mean['target/loss'], self.expect_mean, places=4)
+
+    def test_call(self):
+        mean = self.evaluator()
+        # 'main' is used by default
+        self.assertAlmostEqual(mean['main/loss'], self.expect_mean, places=4)
+
+    def test_evaluator_name(self):
+        self.evaluator.name = 'eval'
+        mean = self.evaluator()
+        # name is used as a prefix
+        self.assertAlmostEqual(
+            mean['eval/main/loss'], self.expect_mean, places=4)
+
+    def test_current_report(self):
+        reporter = chainer.Reporter()
+        with reporter:
+            mean = self.evaluator()
+        # The result is reported to the current reporter.
+        self.assertEqual(reporter.observation, mean)
+
+
+class TestEvaluatorTupleData(unittest.TestCase):
+
+    def setUp(self):
+        self.data = [
+            numpy.random.uniform(-1, 1, (3, 4)).astype('f') for _ in range(2)]
+        self.batches = [
+            (numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f'),
+             numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f'))
+            for _ in range(2)]
+
+        self.iterator = DummyIterator(self.data)
+        self.converter = DummyConverter(self.batches)
+        self.target = DummyModelTwoArgs(self)
+        self.evaluator = extensions.Evaluator(
+            self.iterator, self.target, converter=self.converter, device=1)
+
+    def test_evaluate(self):
+        reporter = chainer.Reporter()
+        reporter.add_observer('target', self.target)
+        with reporter:
+            mean = self.evaluator.evaluate()
+
+        # The converter gets results of the iterator and the device number.
+        self.assertEqual(len(self.converter.args), len(self.data))
+        for i in range(len(self.data)):
+            numpy.testing.assert_array_equal(
+                self.converter.args[i]['batch'], self.data[i])
+            self.assertEqual(self.converter.args[i]['device'], 1)
+
+        # The model gets results of converter.
+        self.assertEqual(len(self.target.args), len(self.batches))
+        for i in range(len(self.batches)):
+            numpy.testing.assert_array_equal(
+                self.target.args[i], self.batches[i])
+
+        expect_mean = numpy.mean([numpy.sum(x) for x in self.batches])
+        self.assertAlmostEqual(mean['target/loss'], expect_mean, places=4)
+
+
+class TestEvaluatorDictData(unittest.TestCase):
+
+    def setUp(self):
+        self.data = range(2)
+        self.batches = [
+            {'x': numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f'),
+             'y': numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f')}
+            for _ in range(2)]
+
+        self.iterator = DummyIterator(self.data)
+        self.converter = DummyConverter(self.batches)
+        self.target = DummyModelTwoArgs(self)
+        self.evaluator = extensions.Evaluator(
+            self.iterator, self.target, converter=self.converter)
+
+    def test_evaluate(self):
+        reporter = chainer.Reporter()
+        reporter.add_observer('target', self.target)
+        with reporter:
+            mean = self.evaluator.evaluate()
+
+        # The model gets results of converter.
+        self.assertEqual(len(self.target.args), len(self.batches))
+        for i in range(len(self.batches)):
+            numpy.testing.assert_array_equal(
+                self.target.args[i][0], self.batches[i]['x'])
+            numpy.testing.assert_array_equal(
+                self.target.args[i][1], self.batches[i]['y'])
+
+        expect_mean = numpy.mean(
+            [numpy.sum(x['x']) + numpy.sum(x['y']) for x in self.batches])
+        self.assertAlmostEqual(mean['target/loss'], expect_mean, places=4)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
@@ -4,6 +4,7 @@ import numpy
 
 import chainer
 from chainer import dataset
+from chainer import testing
 from chainer.training import extensions
 
 
@@ -183,3 +184,6 @@ class TestEvaluatorDictData(unittest.TestCase):
         expect_mean = numpy.mean(
             [numpy.sum(x['x']) + numpy.sum(x['y']) for x in self.batches])
         self.assertAlmostEqual(mean['target/loss'], expect_mean, places=4)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/test_updater.py
+++ b/tests/chainer_tests/training_tests/test_updater.py
@@ -128,10 +128,10 @@ class TestUpdaterUpdateArguments(unittest.TestCase):
         self.assertEqual(len(kwargs), 0)
 
         self.assertIs(loss, self.optimizer.target)
-        self.assertIsInstance(v1, chainer.Variable)
-        self.assertEqual(v1.data, 1)
-        self.assertIsInstance(v2, chainer.Variable)
-        self.assertEqual(v2 .data, 2)
+        self.assertIsInstance(v1, numpy.ndarray)
+        self.assertEqual(v1, 1)
+        self.assertIsInstance(v2, numpy.ndarray)
+        self.assertEqual(v2, 2)
 
         self.assertEqual(iterator.next_called, 1)
 
@@ -150,10 +150,10 @@ class TestUpdaterUpdateArguments(unittest.TestCase):
         v1 = kwargs['x']
         v2 = kwargs['y']
         self.assertIs(loss, self.optimizer.target)
-        self.assertIsInstance(v1, chainer.Variable)
-        self.assertEqual(v1.data, 1)
-        self.assertIsInstance(v2, chainer.Variable)
-        self.assertEqual(v2 .data, 2)
+        self.assertIsInstance(v1, numpy.ndarray)
+        self.assertEqual(v1, 1)
+        self.assertIsInstance(v2, numpy.ndarray)
+        self.assertEqual(v2, 2)
 
         self.assertEqual(iterator.next_called, 1)
 
@@ -170,8 +170,8 @@ class TestUpdaterUpdateArguments(unittest.TestCase):
         self.assertEqual(len(kwargs), 0)
 
         self.assertIs(loss, self.optimizer.target)
-        self.assertIsInstance(v1, chainer.Variable)
-        self.assertEqual(v1.data, 1)
+        self.assertIsInstance(v1, numpy.ndarray)
+        self.assertEqual(v1, 1)
 
         self.assertEqual(iterator.next_called, 1)
 


### PR DESCRIPTION
Now we don't need to wrap `ndarray` with `Variable` because function automatically wrap `ndarray`, and we now have `no_back_prop_mode`. This fix makes dataset more flexible. Without this patch, `dataset` must be a list of tuples of arrays, a list of dicts of arrays or a list of arrays, and it cannot support more structural datasets. With the patch, a user can use any types of datasets. All `ndarray`s are automatically wrapped with `Variable`.
Note that it may breaks compatibility when a user expects that arguments of links are `Variable`. For example, `assert x.data.ndim == (3,)` He need to use `Variable.ndim` in this case.
