### PR TITLE
Use dot instead of matmul for numpy 1.9

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1021,7 +1021,7 @@ class TestMatMulVarVar(unittest.TestCase):
         else:
             options = {'atol': 1e-7, 'rtol': 1e-7}
         testing.assert_allclose(
-            operator.matmul(self.x, self.y), z.data, **options)
+            self.x.dot(self.y), z.data, **options)
 
     @unittest.skipUnless(sys.version_info >= (3, 5),
                          'Only for Python3.5 or higher')


### PR DESCRIPTION
ndarray of numpy 1.9 doesn't support matmul operator (@). I fixed a test to use dot method instead.