### PR TITLE
Fix: InceptionBN.__call__

### DIFF
--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -40,10 +40,6 @@ class InceptionBN(link.Chain):
 
     .. seealso:: :class:`Inception`
 
-    Attributes:
-        train (bool): If ``True``, then batch normalization layers are used in
-            training mode. If ``False``, they are used in testing mode.
-
     """
 
     def __init__(self, in_channels, out1, proj3, out3, proj33, out33,
@@ -96,10 +92,7 @@ class InceptionBN(link.Chain):
         if pooltype != 'max' and pooltype != 'avg':
             raise NotImplementedError()
 
-        self.train = True
-
-    def __call__(self, x):
-        test = not self.train
+    def __call__(self, x, test=False):
         outs = []
 
         if self.out1 > 0:

--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -98,8 +98,16 @@ class InceptionBN(link.Chain):
 
         self.train = True
 
-    def __call__(self, x):
-        test = not self.train
+    def __call__(self, x, test=None):
+        """
+        Args:
+            x (Variable): An input variable.
+            test (bool): If ``True``, batch normalization layers run in testing mode;
+                if ``test`` is omitted, ``not self.train`` is used as ``test``.
+
+        """
+        if test is None:
+            test = not self.train
         outs = []
 
         if self.out1 > 0:

--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -40,6 +40,10 @@ class InceptionBN(link.Chain):
 
     .. seealso:: :class:`Inception`
 
+    Attributes:
+        train (bool): If ``True``, then batch normalization layers are used in
+            training mode. If ``False``, they are used in testing mode.
+
     """
 
     def __init__(self, in_channels, out1, proj3, out3, proj33, out33,
@@ -92,7 +96,10 @@ class InceptionBN(link.Chain):
         if pooltype != 'max' and pooltype != 'avg':
             raise NotImplementedError()
 
-    def __call__(self, x, test=False):
+        self.train = True
+
+    def __call__(self, x):
+        test = not self.train
         outs = []
 
         if self.out1 > 0:

--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -99,11 +99,13 @@ class InceptionBN(link.Chain):
         self.train = True
 
     def __call__(self, x, test=None):
-        """
+        """Computes the output of the InceptionBN module.
+
         Args:
             x (Variable): An input variable.
-            test (bool): If ``True``, batch normalization layers run in testing mode;
-                if ``test`` is omitted, ``not self.train`` is used as ``test``.
+            test (bool): If ``True``, batch normalization layers run in testing
+                mode; if ``test`` is omitted, ``not self.train`` is used as
+                ``test``.
 
         """
         if test is None:

--- a/examples/imagenet/googlenetbn.py
+++ b/examples/imagenet/googlenetbn.py
@@ -42,38 +42,17 @@ class GoogLeNetBN(chainer.Chain):
             normb2=L.BatchNormalization(1024),
             outb=L.Linear(None, 1000),
         )
-        self._train = True
 
-    @property
-    def train(self):
-        return self._train
-
-    @train.setter
-    def train(self, value):
-        self._train = value
-        self.inc3a.train = value
-        self.inc3b.train = value
-        self.inc3c.train = value
-        self.inc4a.train = value
-        self.inc4b.train = value
-        self.inc4c.train = value
-        self.inc4d.train = value
-        self.inc4e.train = value
-        self.inc5a.train = value
-        self.inc5b.train = value
-
-    def __call__(self, x, t):
-        test = not self.train
-
+    def __call__(self, x, t, test=False):
         h = F.max_pooling_2d(
             F.relu(self.norm1(self.conv1(x), test=test)),  3, stride=2, pad=1)
         h = F.max_pooling_2d(
             F.relu(self.norm2(self.conv2(h), test=test)), 3, stride=2, pad=1)
 
-        h = self.inc3a(h)
-        h = self.inc3b(h)
-        h = self.inc3c(h)
-        h = self.inc4a(h)
+        h = self.inc3a(h, test=test)
+        h = self.inc3b(h, test=test)
+        h = self.inc3c(h, test=test)
+        h = self.inc4a(h, test=test)
 
         a = F.average_pooling_2d(h, 5, stride=3)
         a = F.relu(self.norma(self.conva(a), test=test))
@@ -81,9 +60,9 @@ class GoogLeNetBN(chainer.Chain):
         a = self.outa(a)
         loss1 = F.softmax_cross_entropy(a, t)
 
-        h = self.inc4b(h)
-        h = self.inc4c(h)
-        h = self.inc4d(h)
+        h = self.inc4b(h, test=test)
+        h = self.inc4c(h, test=test)
+        h = self.inc4d(h, test=test)
 
         b = F.average_pooling_2d(h, 5, stride=3)
         b = F.relu(self.normb(self.convb(b), test=test))
@@ -91,9 +70,9 @@ class GoogLeNetBN(chainer.Chain):
         b = self.outb(b)
         loss2 = F.softmax_cross_entropy(b, t)
 
-        h = self.inc4e(h)
-        h = self.inc5a(h)
-        h = F.average_pooling_2d(self.inc5b(h), 7)
+        h = self.inc4e(h, test=test)
+        h = self.inc5a(h, test=test)
+        h = F.average_pooling_2d(self.inc5b(h, test=test), 7)
         h = self.out(h)
         loss3 = F.softmax_cross_entropy(h, t)
 
@@ -162,7 +141,6 @@ class GoogLeNetBNFp16(GoogLeNetBN):
             normb2=L.BatchNormalization(1024, dtype=dtype),
             outb=L.Linear(1024, 1000, initialW=W, bias=bias),
         )
-        self._train = True
 
-    def __call__(self, x, t):
-        return GoogLeNetBN.__call__(self, F.cast(x, self.dtype), t)
+    def __call__(self, x, t, test=False):
+        return GoogLeNetBN.__call__(self, F.cast(x, self.dtype), t, test=test)


### PR DESCRIPTION
BatchNormalization (http://docs.chainer.org/en/stable/_modules/chainer/links/normalization/batch_normalization.html#BatchNormalization) can set test-mode on `__call__(self, x, test=False)`,
but InceptionBN (http://docs.chainer.org/en/stable/_modules/chainer/links/connection/inceptionbn.html#InceptionBN) has a difference interface `__call__(self, x)` and stores test-mode as a property.
The difference confuses us.
