### PR TITLE
Support FP16 and FP64 in N-dimensional convolution link

### DIFF
--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -25,7 +25,8 @@ class ConvolutionND(link.Link):
             :func:`~chainer.init_weight` helper function can take.
         initial_bias: Value used to initialize the bias vector. May be an
             initializer instance or another value except ``None`` that
-            :func:`~chainer.init_weight` helper function can take.
+            :func:`~chainer.init_weight` helper function can take. If ``None``
+            is given, this link does not use the bias vector.
         use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
             See :func:`~chainer.functions.convolution_nd` for exact conditions
             of cuDNN availability.

--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -1,5 +1,3 @@
-import numpy
-
 from chainer.functions.connection import convolution_nd
 from chainer import initializers
 from chainer import link

--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -21,12 +21,11 @@ class ConvolutionND(link.Link):
         pad (int or tuple of ints): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p, ..., p)`` are equivalent.
         initialW: Value used to initialize the filter weight. May be an
-            initializer instance or another value the same with that
-            :func:`~chainer.init_weight` function can take.
+            initializer instance or another value that
+            :func:`~chainer.init_weight` helper function can take.
         initial_bias: Value used to initialize the bias vector. May be an
-            initializer instance or another value except ``None`` the same
-            with that :func:`~chainer.init_weight` function can take. If
-            ``None`` is supplied, the link does not have the bias vector.
+            initializer instance or another value except ``None`` that
+            :func:`~chainer.init_weight` helper function can take.
         use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
             See :func:`~chainer.functions.convolution_nd` for exact conditions
             of cuDNN availability.

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -29,7 +29,7 @@ class TestConvolutionND(unittest.TestCase):
 
         self.link = convolution_nd.ConvolutionND(
             ndim, 3, 2, self.ksize, stride=self.stride, pad=self.pad,
-            initial_bias=initializers.Uniform(1), bias_dtype=self.dtype)
+            initial_bias=initializers.Uniform(scale=1., dtype=self.dtype))
         self.link.cleargrads()
 
         x_shape = (2, 3) + self.dims

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -66,7 +66,7 @@ class TestConvolutionND(unittest.TestCase):
         self.assertEqual(y_cpu.data.dtype, self.x.dtype)
 
         self.link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x.dtype))
+        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
         y_gpu = self.link(x_gpu)
         self.assertEqual(y_gpu.data.dtype, self.x.dtype)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -17,6 +17,7 @@ from chainer.utils import conv_nd
 
 @testing.parameterize(*testing.product({
     'dims': [(10,), (10, 8), (10, 8, 6)],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64]
 }))
 class TestConvolutionND(unittest.TestCase):
 
@@ -28,15 +29,20 @@ class TestConvolutionND(unittest.TestCase):
 
         self.link = convolution_nd.ConvolutionND(
             ndim, 3, 2, self.ksize, stride=self.stride, pad=self.pad,
-            initial_bias=initializers.Uniform(1))
+            initial_bias=initializers.Uniform(1), bias_dtype=self.dtype)
         self.link.zerograds()
 
         x_shape = (2, 3) + self.dims
-        self.x = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
         gy_shape = (2, 2) + tuple(
             conv.get_conv_outsize(d, k, s, p) for (d, k, s, p) in zip(
                 self.dims, self.ksize, self.stride, self.pad))
-        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
+
+        self.check_backward_options = {'eps': 1e-2, 'atol': 1e-3, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {
+                'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4}
 
     @attr.gpu
     def test_im2col_consistency(self):
@@ -57,12 +63,12 @@ class TestConvolutionND(unittest.TestCase):
     def check_forward_consistency(self):
         x_cpu = chainer.Variable(self.x)
         y_cpu = self.link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, numpy.float32)
+        self.assertEqual(y_cpu.data.dtype, self.x.dtype)
 
         self.link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
+        x_gpu = chainer.Variable(cuda.to_gpu(self.x.dtype))
         y_gpu = self.link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, numpy.float32)
+        self.assertEqual(y_gpu.data.dtype, self.x.dtype)
 
         testing.assert_allclose(y_cpu.data, y_gpu.data.get())
 
@@ -80,7 +86,7 @@ class TestConvolutionND(unittest.TestCase):
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             self.link, x_data, y_grad, (self.link.W, self.link.b),
-            eps=1e-2, atol=1e-3, rtol=1e-3)
+            **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -63,12 +63,12 @@ class TestConvolutionND(unittest.TestCase):
     def check_forward_consistency(self):
         x_cpu = chainer.Variable(self.x)
         y_cpu = self.link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, self.x.dtype)
+        self.assertEqual(y_cpu.data.dtype, self.dtype)
 
         self.link.to_gpu()
         x_gpu = chainer.Variable(cuda.to_gpu(self.x))
         y_gpu = self.link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, self.x.dtype)
+        self.assertEqual(y_gpu.data.dtype, self.dtype)
 
         testing.assert_allclose(y_cpu.data, y_gpu.data.get())
 


### PR DESCRIPTION
This PR make `ConvolutionND` link support `dtype` of FP16 and FP64, which are currently supported only in `convolution_nd` function. Fix #1625.

There are the following possible approaches how to supply its parameter `dtype` to the link:
- Make `ConvolutionND` link to accept parameter `dtype` so that it can `add_param` parameters with the supplied `dtype`.
- Make initializers to be responsible of converting parameters `dtype`

This PR implements in the former approach and, as a future issue, it would be expected that shape placeholder facility also supports `dtype` of uninitialized parameters as well as their `shape`.
