### PR TITLE
Fix test for cuDNN v2

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -17,7 +17,7 @@ from chainer.utils import conv
 
 
 @testing.parameterize(*(testing.product({
-    'dims': [(6,), (5, 4), (4, 3, 2)],
+    'dims': [(6,), (5, 4), (4, 3, 3)],
     'cover_all': [True, False],
     'c_contiguous': [True],
     'x_dtype': [numpy.float32],

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -16,7 +16,7 @@ from chainer.utils import conv_nd
 
 
 @testing.parameterize(*testing.product({
-    'dims': [(5,), (5, 4), (4, 3, 2)],
+    'dims': [(5,), (5, 4), (4, 3, 3)],
 }))
 class TestConvolutionND(unittest.TestCase):
 


### PR DESCRIPTION
It seems that cuDNN v2's ndconv does not accept 2 for shape.