### PR TITLE
Remove nvtx on Windows for a while

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -68,6 +68,12 @@ MODULES = [
     }
 ]
 
+if sys.platform == 'win32':
+    mod_cuda = MODULES[0]
+    mod_cuda['file'].remove('cupy.cuda.nvtx')
+    mod_cuda['include'].remove('nvToolsExt.h')
+    mod_cuda['libraries'].remove('nvToolsExt')
+
 
 def localpath(*args):
     return path.abspath(path.join(path.dirname(__file__), *args))

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -9,7 +9,9 @@
 #include <cuda_profiler_api.h>
 #include <cuda_runtime.h>
 #include <curand.h>
+#ifndef _WIN32
 #include <nvToolsExt.h>
+#endif
 
 #if CUDA_VERSION < 8000
 #if CUDA_VERSION >= 7050


### PR DESCRIPTION
Exclude `cupy.cuda.nvtx` on Windows for a while to solve a build issue. This should be fixed in near future.

Ref: https://github.com/pfnet/chainer/issues/1660
