### PR TITLE
Fixed the link to paper pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Tokui, S., Oono, K., Hido, S. and Clayton, J.,
 Chainer: a Next-Generation Open Source Framework for Deep Learning,
 *Proceedings of Workshop on Machine Learning Systems(LearningSys) in
 The Twenty-ninth Annual Conference on Neural Information Processing Systems (NIPS)*, (2015)
-[URL](http://learningsys.org/papers/LearningSys_2015_paper_33.pdf), [BibTex](chainer_bibtex.txt)
+[URL](http://learningsys.org/2015/papers/LearningSys_2015_paper_33.pdf), [BibTex](chainer_bibtex.txt)
 
 
 ## More information


### PR DESCRIPTION
The NIPS workshop paper has been moved to another URL.