### PR TITLE
Fixed bug in link when passing numpy int types in shape.

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -15,11 +15,11 @@ def _is_shape(value):
         return True
     elif isinstance(value, collections.Sequence):
         try:
-            return all(isinstance(int(x), six.integer_types) for x in value)
+            return all(int(x) for x in value)
         except TypeError:
             return False
     try:
-        return isinstance(int(value), six.integer_types)
+        return int(value)
     except TypeError:
         return False
 

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -16,11 +16,11 @@ def _is_shape(value):
     elif isinstance(value, collections.Sequence):
         try:
             return all(isinstance(int(x), six.integer_types) for x in value)
-        except:
+        except TypeError:
             return False
     try:
         return isinstance(int(value), six.integer_types)
-    except:
+    except TypeError:
         return False
 
     return False

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -13,12 +13,17 @@ from chainer import variable
 def _is_shape(value):
     if value is None:
         return True
-    elif isinstance(value, six.integer_types):
-        return True
     elif isinstance(value, collections.Sequence):
-        return all(isinstance(x, six.integer_types) for x in value)
-    else:
+        try:
+            return all(isinstance(int(x), six.integer_types) for x in value)
+        except:
+            return False
+    try:
+        return isinstance(int(value), six.integer_types)
+    except:
         return False
+
+    return False
 
 
 def _ensure_shape_dtype(value):

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -12,7 +12,9 @@ from chainer.testing import attr
 class TestLink(unittest.TestCase):
 
     def setUp(self):
-        self.link = chainer.Link(x=((2, 3), 'd'), y=2)
+        x_shape_0 = 2
+        x_shape_1 = numpy.int64(3)
+        self.link = chainer.Link(x=((x_shape_0, x_shape_1), 'd'), y=2)
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'


### PR DESCRIPTION
This fixes a bug when supplying a shape to the `__init__()` of link that contains numpy integer types. For example a shape of the form `(numpy.int64, int)` should be considered a valid shape.