### PR TITLE
Make convolution_nd function work with ndarray.

### DIFF
--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -343,7 +343,7 @@ def convolution_nd(x, W, b=None, stride=1, pad=0, use_cudnn=True,
 
     .. seealso:: :class:`ConvolutionND`, :func:`convolution_2d`
     """
-    ndim = len(x.data.shape[2:])
+    ndim = len(x.shape[2:])
     func = ConvolutionND(ndim, stride, pad, use_cudnn, cover_all)
     if b is None:
         return func(x, W)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -257,13 +257,13 @@ class TestConvolutionNDarraySupplied(unittest.TestCase):
         testing.assert_allclose(y_ary.data, y_var.data)
 
     def test_array_supplied_cpu(self):
-        self.check_ndarray_supplied(self.x_data, self.W_data, self.b_data)
+        self.check_array_supplied(self.x_data, self.W_data, self.b_data)
 
     @attr.gpu
     def test_array_supplied_gpu(self):
-        self.check_ndarray_supplied(cuda.to_gpu(self.x_data),
-                                    cuda.to_gpu(self.W_data),
-                                    cuda.to_gpu(self.b_data))
+        self.check_array_supplied(cuda.to_gpu(self.x_data),
+                                  cuda.to_gpu(self.W_data),
+                                  cuda.to_gpu(self.b_data))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -231,4 +231,39 @@ class TestConvolutionNDCudnnCall(unittest.TestCase):
             y.backward()
             self.assertEqual(func.called, self.expect)
 
+
+class TestConvolutionNDNdarraySupplied(unittest.TestCase):
+
+    def setUp(self):
+        N = 2
+        in_channels = 3
+        out_channels = 2
+        dtype = numpy.float32
+
+        x_shape = (N, in_channels, 3, 3, 3)
+        self.x_data = numpy.random.uniform(-1, 1, x_shape).astype(dtype)
+        W_shape = (out_channels, in_channels, 1, 1, 1)
+        self.W_data = numpy.random.uniform(-1, 1, W_shape).astype(dtype)
+        self.b_data = numpy.random.uniform(-1, 1, out_channels).astype(dtype)
+
+    def check_ndarray_supplied(self, x_ary, W_ary, b_ary):
+        y_ary = functions.convolution_nd(x_ary, W_ary, b_ary)
+
+        x_var = chainer.Variable(x_ary)
+        W_var = chainer.Variable(W_ary)
+        b_var = chainer.Variable(b_ary)
+        y_var = functions.convolution_nd(x_var, W_var, b_var)
+
+        testing.assert_allclose(y_ary.data, y_var.data)
+
+    def test_ndarray_supplied_cpu(self):
+        self.check_ndarray_supplied(self.x_data, self.W_data, self.b_data)
+
+    @attr.gpu
+    def test_ndarray_supplied_gpu(self):
+        self.check_ndarray_supplied(cuda.to_gpu(self.x_data),
+                                    cuda.to_gpu(self.W_data),
+                                    cuda.to_gpu(self.b_data))
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -232,7 +232,7 @@ class TestConvolutionNDCudnnCall(unittest.TestCase):
             self.assertEqual(func.called, self.expect)
 
 
-class TestConvolutionNDNdarraySupplied(unittest.TestCase):
+class TestConvolutionNDarraySupplied(unittest.TestCase):
 
     def setUp(self):
         N = 2
@@ -246,7 +246,7 @@ class TestConvolutionNDNdarraySupplied(unittest.TestCase):
         self.W_data = numpy.random.uniform(-1, 1, W_shape).astype(dtype)
         self.b_data = numpy.random.uniform(-1, 1, out_channels).astype(dtype)
 
-    def check_ndarray_supplied(self, x_ary, W_ary, b_ary):
+    def check_array_supplied(self, x_ary, W_ary, b_ary):
         y_ary = functions.convolution_nd(x_ary, W_ary, b_ary)
 
         x_var = chainer.Variable(x_ary)
@@ -256,11 +256,11 @@ class TestConvolutionNDNdarraySupplied(unittest.TestCase):
 
         testing.assert_allclose(y_ary.data, y_var.data)
 
-    def test_ndarray_supplied_cpu(self):
+    def test_array_supplied_cpu(self):
         self.check_ndarray_supplied(self.x_data, self.W_data, self.b_data)
 
     @attr.gpu
-    def test_ndarray_supplied_gpu(self):
+    def test_array_supplied_gpu(self):
         self.check_ndarray_supplied(cuda.to_gpu(self.x_data),
                                     cuda.to_gpu(self.W_data),
                                     cuda.to_gpu(self.b_data))


### PR DESCRIPTION
Related to #1687 .

This PR makes `convolution_nd` function accept `ndarray` as its `x` argument. Its docstring is modified in #1687 .

