### PR TITLE
LSTM supports parameter shape place holder

### DIFF
--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -22,19 +22,27 @@ class LSTMBase(link.Chain):
                                   initialW=0, nobias=True),
         )
         self.state_size = out_size
+        self.lateral_init = lateral_init
+        self.upward_init = upward_init
+        self.bias_init = bias_init
+        self.forget_bias_init = forget_bias_init
 
-        for i in six.moves.range(0, 4 * out_size, out_size):
+        if in_size is not None:
+            self._initialize_params(in_size)
+
+    def _initialize_params(self, in_size):
+        for i in six.moves.range(0, 4 * self.state_size, self.state_size):
             initializers.init_weight(
-                self.lateral.W.data[i:i + out_size, :], lateral_init)
+                self.lateral.W.data[i:i + self.state_size, :], self.lateral_init)
             initializers.init_weight(
-                self.upward.W.data[i:i + out_size, :], upward_init)
+                self.upward.W.data[i:i + self.state_size, :], self.upward_init)
 
         a, i, f, o = lstm._extract_gates(
-            self.upward.b.data.reshape(1, 4 * out_size, 1))
-        initializers.init_weight(a, bias_init)
-        initializers.init_weight(i, bias_init)
-        initializers.init_weight(f, forget_bias_init)
-        initializers.init_weight(o, bias_init)
+            self.upward.b.data.reshape(1, 4 * self.state_size, 1))
+        initializers.init_weight(a, self.bias_init)
+        initializers.init_weight(i, self.bias_init)
+        initializers.init_weight(f, self.forget_bias_init)
+        initializers.init_weight(o, self.bias_init)
 
 
 class StatelessLSTM(LSTMBase):
@@ -70,6 +78,11 @@ class StatelessLSTM(LSTMBase):
                 output of LSTM units.
 
         """
+        if self.upward.has_uninitialized_params:
+            in_size = x.size // len(x.data)
+            self.upward._initialize_params(in_size)
+            self._initialize_params(in_size)
+
         lstm_in = self.upward(x)
         if h is not None:
             lstm_in += self.lateral(h)
@@ -197,6 +210,11 @@ class LSTM(LSTMBase):
             ~chainer.Variable: Outputs of updated LSTM units.
 
         """
+        if self.upward.has_uninitialized_params:
+            in_size = x.size // len(x.data)
+            self.upward._initialize_params(in_size)
+            self._initialize_params(in_size)
+
         batch = x.shape[0]
         lstm_in = self.upward(x)
         h_rest = None

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -28,9 +28,9 @@ class LSTMBase(link.Chain):
         self.forget_bias_init = forget_bias_init
 
         if in_size is not None:
-            self._initialize_params(in_size)
+            self._initialize_params()
 
-    def _initialize_params(self, in_size):
+    def _initialize_params(self):
         for i in six.moves.range(0, 4 * self.state_size, self.state_size):
             initializers.init_weight(
                 self.lateral.W.data[i:i + self.state_size, :],
@@ -82,7 +82,7 @@ class StatelessLSTM(LSTMBase):
         if self.upward.has_uninitialized_params:
             in_size = x.size // len(x.data)
             self.upward._initialize_params(in_size)
-            self._initialize_params(in_size)
+            self._initialize_params()
 
         lstm_in = self.upward(x)
         if h is not None:
@@ -214,7 +214,7 @@ class LSTM(LSTMBase):
         if self.upward.has_uninitialized_params:
             in_size = x.size // len(x.data)
             self.upward._initialize_params(in_size)
-            self._initialize_params(in_size)
+            self._initialize_params()
 
         batch = x.shape[0]
         lstm_in = self.upward(x)

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -56,7 +56,9 @@ class StatelessLSTM(LSTMBase):
     hidden states.
 
     Args:
-        in_size (int): Dimensionality of input vectors.
+        in_size (int): Dimension of input vectors. If None, parameter
+            initialization will be deferred until the first forward data pass
+            at which time the size will be determined.
         out_size (int): Dimensionality of output vectors.
 
     Attributes:
@@ -118,7 +120,9 @@ class LSTM(LSTMBase):
     applying the function.
 
     Args:
-        in_size (int): Dimensionality of input vectors.
+        in_size (int): Dimension of input vectors. If None, parameter
+            initialization will be deferred until the first forward data pass
+            at which time the size will be determined.
         out_size (int): Dimensionality of output vectors.
         lateral_init: A callable that takes ``numpy.ndarray`` or
             ``cupy.ndarray`` and edits its value.

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -33,7 +33,8 @@ class LSTMBase(link.Chain):
     def _initialize_params(self, in_size):
         for i in six.moves.range(0, 4 * self.state_size, self.state_size):
             initializers.init_weight(
-                self.lateral.W.data[i:i + self.state_size, :], self.lateral_init)
+                self.lateral.W.data[i:i + self.state_size, :],
+                self.lateral_init)
             initializers.init_weight(
                 self.upward.W.data[i:i + self.state_size, :], self.upward_init)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -10,23 +10,22 @@ from chainer import testing
 from chainer.testing import attr
 
 
-@testing.parameterize(
-    {'in_size': 10, 'out_size': 10},
-    {'in_size': 10, 'out_size': 40},
-)
+@testing.parameterize(*testing.product_dict(
+        [
+            {'in_size': 10, 'out_size': 10},
+            {'in_size': 10, 'out_size': 40},
+        ],
+        [
+            {'input_none': False},
+            {'input_none': True},
+        ]
+))
 class TestLSTM(unittest.TestCase):
 
     def setUp(self):
-        self.link = links.LSTM(self.in_size, self.out_size)
-        upward = self.link.upward.W.data
-        upward[...] = numpy.random.uniform(-1, 1, upward.shape)
-        lateral = self.link.lateral.W.data
-        lateral[...] = numpy.random.uniform(-1, 1, lateral.shape)
+        in_size = None if self.input_none else self.in_size
+        self.link = links.LSTM(in_size, self.out_size)
         self.link.cleargrads()
-
-        self.upward = upward.copy()  # fixed on CPU
-        self.lateral = lateral.copy()  # fixed on CPU
-
         x1_shape = (4, self.in_size)
         self.x1 = numpy.random.uniform(-1, 1, x1_shape).astype(numpy.float32)
         x2_shape = (3, self.in_size)
@@ -218,22 +217,22 @@ class TestLSTMInvalidSize(unittest.TestCase):
                                         cuda.to_gpu(self.x2))
 
 
-@testing.parameterize(
-    {'in_size': 10, 'out_size': 10},
-    {'in_size': 10, 'out_size': 40},
-)
+@testing.parameterize(*testing.product_dict(
+        [
+            {'in_size': 10, 'out_size': 10},
+            {'in_size': 10, 'out_size': 40},
+        ],
+        [
+            {'input_none': False},
+            {'input_none': True},
+        ]
+))
 class TestStatelessLSTM(unittest.TestCase):
 
     def setUp(self):
-        self.link = links.StatelessLSTM(self.in_size, self.out_size)
-        upward = self.link.upward.W.data
-        upward[...] = numpy.random.uniform(-1, 1, upward.shape)
-        lateral = self.link.lateral.W.data
-        lateral[...] = numpy.random.uniform(-1, 1, lateral.shape)
+        in_size = None if self.input_none else self.in_size
+        self.link = links.StatelessLSTM(in_size, self.out_size)
         self.link.cleargrads()
-
-        self.upward = upward.copy()  # fixed on CPU
-        self.lateral = lateral.copy()  # fixed on CPU
 
         x_shape = (4, self.in_size)
         self.x = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)


### PR DESCRIPTION
This PR enables us to put `None` as the input size of `LSTM` and `StatelessLSTM` links.

```
a = chainer.Variable(numpy.random.uniform(0, 1, (5, 10)).astype(numpy.float32))
l = L.LSTM(None, 5)
l(a)
```
