### PR TITLE
Fix build of CuPy reference

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -442,7 +442,9 @@ int cublasSgemmEx(
         cublasOperation_t transb, int m, int n, int k,
         const float *alpha, const void *A, cudaDataType Atype,
         int lda, const void *B, cudaDataType Btype, int ldb,
-        const float *beta, void *C, cudaDataType Ctype, int ldc);
+        const float *beta, void *C, cudaDataType Ctype, int ldc) {
+    return 0;
+}
 
 
 // BLAS extension


### PR DESCRIPTION
Fix build of documents by eliminating undefined reference error.