### PR TITLE
Progress_bar and print_report support Windows

### DIFF
--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -1,7 +1,9 @@
+import os
 import sys
 
 from chainer.training import extension
 from chainer.training.extensions import log_report as log_report_module
+from chainer.training.extensions import util
 
 
 class PrintReport(extension.Extension):
@@ -43,9 +45,6 @@ class PrintReport(extension.Extension):
     def __call__(self, trainer):
         out = self._out
 
-        # delete the printed contents from the current cursor
-        out.write('\033[J')
-
         if self._header:
             out.write(self._header)
             self._header = None
@@ -62,6 +61,11 @@ class PrintReport(extension.Extension):
         log = log_report.log
         log_len = self._log_len
         while len(log) > log_len:
+            # delete the printed contents from the current cursor
+            if os.name == 'nt':
+                util.erase_console(0, 0)
+            else:
+                out.write('\033[J')
             self._print(log[log_len])
             log_len += 1
         self._log_len = log_len

--- a/chainer/training/extensions/progress_bar.py
+++ b/chainer/training/extensions/progress_bar.py
@@ -1,9 +1,11 @@
 from __future__ import division
 import datetime
+import os
 import sys
 import time
 
 from chainer.training import extension
+from chainer.training.extensions import util
 from chainer.training import trigger
 
 
@@ -66,7 +68,10 @@ class ProgressBar(extension.Extension):
 
             recent_timing.append((iteration, epoch, now))
 
-            out.write('\033[J')
+            if os.name == 'nt':
+                util.erase_console(0, 0)
+            else:
+                out.write('\033[J')
 
             if unit == 'iteration':
                 rate = iteration / length
@@ -104,7 +109,10 @@ class ProgressBar(extension.Extension):
                               datetime.timedelta(seconds=estimated_time)))
 
             # move the cursor to the head of the progress bar
-            out.write('\033[4A')
+            if os.name == 'nt':
+                util.set_console_cursor_position(0, -4)
+            else:
+                out.write('\033[4A')
             out.flush()
 
             if len(recent_timing) > 100:
@@ -113,5 +121,8 @@ class ProgressBar(extension.Extension):
     def finalize(self):
         # delete the progress bar
         out = self._out
-        out.write('\033[J')
+        if os.name == 'nt':
+            util.erase_console(0, 0)
+        else:
+            out.write('\033[J')
         out.flush()

--- a/chainer/training/extensions/util.py
+++ b/chainer/training/extensions/util.py
@@ -1,0 +1,55 @@
+import os
+if os.name == "nt":
+    import ctypes
+
+    _STD_OUTPUT_HANDLE = -11
+
+    class _COORD(ctypes.Structure):
+        _fields_ = [("X", ctypes.c_short), ("Y", ctypes.c_short)]
+
+    class _SMALL_RECT(ctypes.Structure):
+        _fields_ = [("Left", ctypes.c_short), ("Top", ctypes.c_short),
+                    ("Right", ctypes.c_short), ("Bottom", ctypes.c_short)]
+
+    class _CONSOLE_SCREEN_BUFFER_INFO(ctypes.Structure):
+        _fields_ = [("dwSize", _COORD), ("dwCursorPosition", _COORD),
+                    ("wAttributes", ctypes.c_ushort),
+                    ("srWindow", _SMALL_RECT),
+                    ("dwMaximumWindowSize", _COORD)]
+
+    def set_console_cursor_position(x, y):
+        """Set relative cursor position from current position to (x,y)"""
+
+        whnd = ctypes.windll.kernel32.GetStdHandle(_STD_OUTPUT_HANDLE)
+        csbi = _CONSOLE_SCREEN_BUFFER_INFO()
+        ctypes.windll.kernel32.GetConsoleScreenBufferInfo(whnd,
+                                                          ctypes.byref(csbi))
+        cur_pos = csbi.dwCursorPosition
+        pos = _COORD(cur_pos.X + x, cur_pos.Y + y)
+        ctypes.windll.kernel32.SetConsoleCursorPosition(whnd, pos)
+
+    def erase_console(x, y, mode=0):
+        """Erase screen.
+
+        Mode=0: From (x,y) position down to the bottom of the screen.
+        Mode=1: From (x,y) position down to the begining of line.
+        Mode=2: Hole screen
+        """
+
+        whnd = ctypes.windll.kernel32.GetStdHandle(_STD_OUTPUT_HANDLE)
+        csbi = _CONSOLE_SCREEN_BUFFER_INFO()
+        ctypes.windll.kernel32.GetConsoleScreenBufferInfo(whnd,
+                                                          ctypes.byref(csbi))
+        cur_pos = csbi.dwCursorPosition
+        wr = ctypes.c_ulong()
+        if mode == 0:
+            num = csbi.srWindow.Right * (csbi.srWindow.Bottom -
+                                         cur_pos.Y) - cur_pos.X
+            ctypes.windll.kernel32.FillConsoleOutputCharacterA(
+                whnd, ord(' '), num, cur_pos, ctypes.byref(wr))
+        elif mode == 1:
+            num = cur_pos.X
+            ctypes.windll.kernel32.FillConsoleOutputCharacterA(
+                whnd, ord(' '), num, _COORD(0, cur_pos.Y), ctypes.byref(wr))
+        elif mode == 2:
+            os.system('cls')


### PR DESCRIPTION
“progress_bar” and “print_report” does not work well on windows, because
Windows command console does not support ANSI escape sequence. Adding
some functions for this. And these extensions can work well on Windows.
