### PR TITLE
Extract evaluation procedure from training extension `Evaluator`

### DIFF
--- a/chainer/training/__init__.py
+++ b/chainer/training/__init__.py
@@ -2,7 +2,7 @@ from chainer.training import extension
 from chainer.training import trainer
 from chainer.training import trigger
 from chainer.training import updater
-
+from chainer.training import evaluator
 
 Extension = extension.Extension
 make_extension = extension.make_extension
@@ -18,3 +18,6 @@ get_trigger = trigger.get_trigger
 Updater = updater.Updater
 StandardUpdater = updater.StandardUpdater
 ParallelUpdater = updater.ParallelUpdater
+
+Evaluator = evaluator.Evaluator
+StandardEvaluator = evaluator.StandardEvaluator

--- a/chainer/training/__init__.py
+++ b/chainer/training/__init__.py
@@ -1,8 +1,8 @@
+from chainer.training import evaluator
 from chainer.training import extension
 from chainer.training import trainer
 from chainer.training import trigger
 from chainer.training import updater
-from chainer.training import evaluator
 
 Extension = extension.Extension
 make_extension = extension.make_extension

--- a/chainer/training/evaluator.py
+++ b/chainer/training/evaluator.py
@@ -1,0 +1,197 @@
+import copy
+import six
+
+from chainer import link
+from chainer import reporter as reporter_module
+from chainer import variable
+from chainer.dataset import convert
+from chainer.dataset import iterator as iterator_module
+
+
+class Evaluator(object):
+    """Base class of all evaluators.
+    """
+
+    def run(self):
+        raise NotImplementedError
+
+    def evaluate(self):
+        raise NotImplementedError
+
+    def get_iterator(self, name):
+        raise NotImplementedError
+
+    def get_all_iterators(self):
+        raise NotImplementedError
+
+    def get_target(self, name):
+        raise NotImplementedError
+
+    def get_all_targets(self):
+        raise NotImplementedError
+
+
+def eval_func_with_volatile(eval_func, in_arrays):
+    if isinstance(in_arrays, tuple):
+        in_vars = tuple(
+                variable.Variable(x, volatile='on') for x in in_arrays
+        )
+        eval_func(*in_vars)
+    elif isinstance(in_arrays, dict):
+        in_vars = {
+            key: variable.Variable(x, volatile='on')
+            for key, x in six.iteritems(in_arrays)
+        }
+        eval_func(**in_vars)
+    else:
+        in_var = variable.Variable(in_arrays, volatile='on')
+        eval_func(in_var)
+
+
+class StandardEvaluator(Evaluator):
+    """Standard implementation of Evaluator.
+
+    This is the standard implementation of :class:`Evaluator`.
+    It evaluate *target link* with given iterator and summarize the reported
+    values in the link by calling :func:`~chainer.reporter.report`.
+    It accepts one or more iterators and one or more links.
+    The default evaluate routine assumes that there is only one training
+    dataset and one model. Users can override this evaluate routine by
+    inheriting this class and overriding the :meth:`evaluate` method. Each
+    batch is converted to input arrays by
+    :func:`~chainer.datasets.concat_examples` by default,
+    which can also manually set by ``converter`` argument.
+
+        >>> from chainer.training.evaluator import StandardEvaluator
+        >>> import chainer
+        >>> import numpy as np
+        >>>
+        >>> model = chainer.links.Classifier(
+        >>>         chainer.links.Linear(
+        >>>                 2, 2,
+        >>>                 nobias=True,
+        >>>                 initialW=np.identity(2, dtype=np.float32),
+        >>>         )
+        >>> )
+        >>>
+        >>> data = [
+        >>>     (np.asarray([1, 0], dtype=np.float32), np.int32(0)),  # true
+        >>>     (np.asarray([1, 0], dtype=np.float32), np.int32(0)),  # true
+        >>>     (np.asarray([0, 1], dtype=np.float32), np.int32(1)),  # true
+        >>>     (np.asarray([0, 1], dtype=np.float32), np.int32(1)),  # true
+        >>>     (np.asarray([0, 1], dtype=np.float32), np.int32(0)),  # false
+        >>> ]
+        >>>
+        >>> iterator = chainer.iterators.SerialIterator(data, 5, repeat=False)
+        >>>
+        >>> evaluator = StandardEvaluator(iterator, model)
+        >>> result = evaluator.run()
+        >>> print(result)
+        {'main/accuracy': 0.8000000119209289, 'main/loss': 0.5132616162300109}
+
+    Args:
+        iterator: Dataset iterator. It can also be a dictionary of iterators.
+            If this is just an iterator, then the iterator is registered by
+            the name ``'main'``.
+        target: Target link object. It can also be a dictionary of links. If
+            this is just a link, then the link is registered by the name
+            ``'main'``.
+        converter: Converter function to build input arrays. Each batch
+            extracted by the main iterator and the ``device`` option are passed
+            to this function. :func:`~chainer.dataset.concat_examples` is used
+            by default.
+        device: Device to which the training data is sent. Negative value
+            indicates the host memory (CPU).
+        loss_func: Loss function. The target link of the main optimizer is used
+            by default.
+        eval_hook_before: Function to prepare for each evaluation process.
+            It is called at the beginning of the evaluation.
+            (ex. clear state of LSTM, set testing flag of batch normalization).
+        eval_hook_after: Function to finish for each evaluation process. It is
+            called at the end of the evaluation.
+        prefix: Prefix observer name for the reporter.
+    """
+
+    def __init__(self, iterator, target,
+                 converter=convert.concat_examples,
+                 device=None, eval_func=None,
+                 eval_hook_before=None, eval_hook_after=None):
+        if isinstance(iterator, iterator_module.Iterator):
+            iterator = {'main': iterator}
+
+        if isinstance(target, link.Link):
+            target = {'main': target}
+
+        self._iterators = iterator
+        self._targets = target
+
+        self.converter = converter
+        self.device = device
+        self.eval_hook_before = eval_hook_before
+        self.eval_hook_after = eval_hook_after
+        self.eval_func = eval_func
+
+    def run(self, prefix=''):
+        reporter = reporter_module.Reporter()
+        for name, target in six.iteritems(self._targets):
+            reporter.add_observer(prefix + name, target)
+            reporter.add_observers(prefix + name,
+                                   target.namedlinks(skipself=True))
+        with reporter:
+            result = self.evaluate()
+
+        return result
+
+    def evaluate(self):
+        """Evaluates the model and returns a result dictionary.
+
+        This method runs the evaluation loop over the given dataset. It
+        accumulates the reported values to :class:`~chainer.DictSummary` and
+        returns a dictionary whose values are means computed by the summary.
+
+        Users can override this method to customize the evaluation routine.
+
+        Returns:
+            dict: Result dictionary. This dictionary is further reported via
+                :func:`~chainer.report` without specifying any observer.
+
+        """
+        iterator = self._iterators['main']
+        target = self._targets['main']
+        eval_func = self.eval_func or target
+
+        if self.eval_hook_before:
+            self.eval_hook_before(self)
+
+        it = copy.copy(iterator)
+        summary = reporter_module.DictSummary()
+
+        for batch in it:
+            observation = {}
+            with reporter_module.report_scope(observation):
+                in_arrays = self.converter(batch, self.device)
+
+                eval_func_with_volatile(eval_func, in_arrays)
+
+            summary.add(observation)
+
+        if self.eval_hook_after:
+            self.eval_hook_after(self)
+
+        return summary.compute_mean()
+
+    def get_iterator(self, name):
+        """Returns the iterator of the given name."""
+        return self._iterators[name]
+
+    def get_all_iterators(self):
+        """Returns a dictionary of all iterators."""
+        return dict(self._iterators)
+
+    def get_target(self, name):
+        """Returns the target link of the given name."""
+        return self._targets[name]
+
+    def get_all_targets(self):
+        """Returns a dictionary of all target links."""
+        return dict(self._targets)

--- a/chainer/training/evaluator.py
+++ b/chainer/training/evaluator.py
@@ -4,13 +4,13 @@ import six
 from chainer import link
 from chainer import reporter as reporter_module
 from chainer import variable
+
 from chainer.dataset import convert
 from chainer.dataset import iterator as iterator_module
 
 
 class Evaluator(object):
-    """Base class of all evaluators.
-    """
+    """Base class of all evaluators."""
 
     def run(self):
         raise NotImplementedError
@@ -33,9 +33,7 @@ class Evaluator(object):
 
 def eval_func_with_volatile(eval_func, in_arrays):
     if isinstance(in_arrays, tuple):
-        in_vars = tuple(
-                variable.Variable(x, volatile='on') for x in in_arrays
-        )
+        in_vars = tuple(variable.Variable(x, volatile='on') for x in in_arrays)
         eval_func(*in_vars)
     elif isinstance(in_arrays, dict):
         in_vars = {

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -1,7 +1,7 @@
 from chainer.dataset import convert
 from chainer import reporter as reporter_module
+from chainer.training import evaluator as evaluator_module
 from chainer.training import extension
-from chainer.training import StandardEvaluator
 
 
 class Evaluator(extension.Extension):
@@ -67,11 +67,12 @@ class Evaluator(extension.Extension):
     def __init__(self, iterator, target, converter=convert.concat_examples,
                  device=None, eval_hook=None, eval_func=None, evaluator=None):
         if evaluator is None:
-            evaluator = StandardEvaluator(iterator=iterator, target=target,
-                                          converter=converter, device=device,
-                                          eval_hook_before=eval_hook,
-                                          eval_func=eval_func,
-                                          )
+            evaluator = evaluator_module.StandardEvaluator(
+                    iterator=iterator, target=target,
+                    converter=converter, device=device,
+                    eval_hook_before=eval_hook,
+                    eval_func=eval_func,
+            )
         self.evaluator = evaluator
 
     def get_iterator(self, name):

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -68,11 +68,10 @@ class Evaluator(extension.Extension):
                  device=None, eval_hook=None, eval_func=None, evaluator=None):
         if evaluator is None:
             evaluator = evaluator_module.StandardEvaluator(
-                    iterator=iterator, target=target,
-                    converter=converter, device=device,
-                    eval_hook_before=eval_hook,
-                    eval_func=eval_func,
-            )
+                iterator=iterator, target=target,
+                converter=converter, device=device,
+                eval_hook_before=eval_hook,
+                eval_func=eval_func)
         self.evaluator = evaluator
 
     def get_iterator(self, name):

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -1,6 +1,7 @@
 from chainer.dataset import convert
 from chainer import reporter as reporter_module
-from chainer.training import extension, StandardEvaluator
+from chainer.training import extension
+from chainer.training import StandardEvaluator
 
 
 class Evaluator(extension.Extension):
@@ -66,11 +67,11 @@ class Evaluator(extension.Extension):
     def __init__(self, iterator, target, converter=convert.concat_examples,
                  device=None, eval_hook=None, eval_func=None, evaluator=None):
         if evaluator is None:
-            evaluator = StandardEvaluator(
-                    iterator=iterator, target=target,
-                    converter=converter, device=device,
-                    eval_hook_before=eval_hook, eval_func=eval_func,
-            )
+            evaluator = StandardEvaluator(iterator=iterator, target=target,
+                                          converter=converter, device=device,
+                                          eval_hook_before=eval_hook,
+                                          eval_func=eval_func,
+                                          )
         self.evaluator = evaluator
 
     def get_iterator(self, name):

--- a/tests/chainer_tests/training_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/test_evaluator.py
@@ -11,8 +11,11 @@ from chainer.training import evaluator as evaluator_module
 
 
 class TestStandardEvaluator(unittest.TestCase):
+
     def test_it(self):
+
         class MyChain(link.Chain):
+
             def __call__(self, x, t):
                 reporter_module.report({
                     'accuracy': accuracy.accuracy(x, t),
@@ -36,3 +39,6 @@ class TestStandardEvaluator(unittest.TestCase):
         result = evaluator.run()
 
         testing.assert_allclose(6. / 8, result['accuracy'])
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/test_evaluator.py
@@ -1,0 +1,39 @@
+import numpy
+import unittest
+
+from chainer import iterators
+from chainer import link
+from chainer import reporter as reporter_module
+from chainer.training import evaluator as evaluator_module
+
+
+class TestStandardEvaluator(unittest.TestCase):
+    def test_it(self):
+        class MyChain(link.Chain):
+            def __call__(self, x, t):
+                reporter_module.report({
+                    'accuracy': (x.data == t.data).mean(),
+                })
+
+        data = [
+            (numpy.int32(0), numpy.int32(0)),  # true
+            (numpy.int32(0), numpy.int32(0)),  # true
+            (numpy.int32(0), numpy.int32(0)),  # true
+            (numpy.int32(1), numpy.int32(1)),  # true
+            (numpy.int32(1), numpy.int32(1)),  # true
+            (numpy.int32(1), numpy.int32(1)),  # true
+            (numpy.int32(0), numpy.int32(1)),  # false
+            (numpy.int32(1), numpy.int32(0)),  # false
+        ]
+        iterator = iterators.SerialIterator(data, 4, repeat=False)
+
+        model = MyChain()
+        evaluator = evaluator_module.StandardEvaluator(iterator, model)
+
+        result = evaluator.run()
+
+        expected_result = {
+            'accuracy': numpy.float32(6 / 8)
+        }
+
+        self.assertDictEqual(expected_result, result)

--- a/tests/chainer_tests/training_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/test_evaluator.py
@@ -1,9 +1,12 @@
-import numpy
+import numpy as np
 import unittest
 
 from chainer import iterators
 from chainer import link
 from chainer import reporter as reporter_module
+from chainer import testing
+
+from chainer.functions.evaluation import accuracy
 from chainer.training import evaluator as evaluator_module
 
 
@@ -12,18 +15,18 @@ class TestStandardEvaluator(unittest.TestCase):
         class MyChain(link.Chain):
             def __call__(self, x, t):
                 reporter_module.report({
-                    'accuracy': (x.data == t.data).mean(),
+                    'accuracy': accuracy.accuracy(x, t),
                 })
 
         data = [
-            (numpy.int32(0), numpy.int32(0)),  # true
-            (numpy.int32(0), numpy.int32(0)),  # true
-            (numpy.int32(0), numpy.int32(0)),  # true
-            (numpy.int32(1), numpy.int32(1)),  # true
-            (numpy.int32(1), numpy.int32(1)),  # true
-            (numpy.int32(1), numpy.int32(1)),  # true
-            (numpy.int32(0), numpy.int32(1)),  # false
-            (numpy.int32(1), numpy.int32(0)),  # false
+            (np.asarray([1, 0], dtype=np.float32), np.int32(0)),  # true
+            (np.asarray([1, 0], dtype=np.float32), np.int32(0)),  # true
+            (np.asarray([1, 0], dtype=np.float32), np.int32(0)),  # true
+            (np.asarray([0, 1], dtype=np.float32), np.int32(1)),  # true
+            (np.asarray([0, 1], dtype=np.float32), np.int32(1)),  # true
+            (np.asarray([0, 1], dtype=np.float32), np.int32(1)),  # true
+            (np.asarray([0, 1], dtype=np.float32), np.int32(0)),  # false
+            (np.asarray([1, 0], dtype=np.float32), np.int32(1)),  # false
         ]
         iterator = iterators.SerialIterator(data, 4, repeat=False)
 
@@ -32,8 +35,4 @@ class TestStandardEvaluator(unittest.TestCase):
 
         result = evaluator.run()
 
-        expected_result = {
-            'accuracy': numpy.float32(6 / 8)
-        }
-
-        self.assertDictEqual(expected_result, result)
+        testing.assert_allclose(6. / 8, result['accuracy'])


### PR DESCRIPTION
Add `chainer.training.evaluator.Evaluator` and `chainer.training.evaluator.StandardEvaluator` to evaluate testing error and accuracy.
Although `chainer.training.extensions.Evaluator` can evaluate them *by itself*, *standalone extension* is strange and it should be pure training extension which call external defined evaluation procedure. Thus, I define evaluator interface(`chainer.training.Evaluator`) and move evaluating codes from `chainer.training.extensions.Evaluator` to `chainer.training.evaluator.StandardEvaluator`.

I tested `examples/mnist/train_mnist.py` and it worked.