### PR TITLE
Use close method directly instead of using with statement

### DIFF
--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -12,6 +12,17 @@ import six
 from chainer.dataset import dataset_mixin
 
 
+def _read_image_as_array(path, dtype):
+    f = Image.open(path)
+    try:
+        image = numpy.asarray(f, dtype=dtype)
+    finally:
+        # Only pillow >= 3.0 has 'close' method
+        if hasattr(f, 'close'):
+            f.close()
+    return image
+
+
 class ImageDataset(dataset_mixin.DatasetMixin):
 
     """Dataset of images built from a list of paths to image files.
@@ -58,8 +69,8 @@ class ImageDataset(dataset_mixin.DatasetMixin):
 
     def get_example(self, i):
         path = os.path.join(self._root, self._paths[i])
-        with Image.open(path) as f:
-            image = numpy.asarray(f, dtype=self._dtype)
+        image = _read_image_as_array(path, self._dtype)
+
         if image.ndim == 2:
             # image is greyscale
             image = image[:, :, numpy.newaxis]
@@ -122,8 +133,8 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
     def get_example(self, i):
         path, int_label = self._pairs[i]
         full_path = os.path.join(self._root, path)
-        with Image.open(full_path) as f:
-            image = numpy.asarray(f, dtype=self._dtype)
+        image = _read_image_as_array(full_path, self._dtype)
+
         if image.ndim == 2:
             # image is greyscale
             image = image[:, :, numpy.newaxis]


### PR DESCRIPTION
In pillow>=3.0, Image object supports with statement and has close method. However, in pillow 2, Image object has none of them. To support both versions, I used close method directly only when an Image object has the method.

related to #1583 