### PR TITLE
Fix test for rollaxis.

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
@@ -68,7 +68,7 @@ class TestRollaxisInvalidType(unittest.TestCase):
 
     def check_type_error(self, x):
         with self.assertRaises(type_check.InvalidType):
-            functions.rollaxis(self.x, self.axis, self.start)
+            functions.rollaxis(x, self.axis, self.start)
 
     def test_type_error_cpu(self):
         self.check_type_error(self.x)


### PR DESCRIPTION
This PR fixes a test for rollaxis function, where `test_type_error_gpu` should be tested with cupy.ndarray but is tested with numpy.ndarray.
