### PR TITLE
Fix BN problem, it works with copy().

### DIFF
--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -126,8 +126,8 @@ class BatchNormalization(link.Link):
                 self.use_cudnn)
             ret = func(x, gamma, beta)
 
-            self.avg_mean = func.running_mean
-            self.avg_var = func.running_var
+            self.avg_mean[:] = func.running_mean
+            self.avg_var[:] = func.running_var
         else:
             # Use running average statistics or fine-tuned statistics.
             mean = variable.Variable(self.avg_mean, volatile='auto')


### PR DESCRIPTION
In current BN implementation, it assign new values to avg_mean and avg_var.
It causes a problem when you use copy() to make a new model for validation (as ImageNet example does).