### PR TITLE
Fix fan_out that is different from other frameworks.

### DIFF
--- a/chainer/initializer.py
+++ b/chainer/initializer.py
@@ -41,6 +41,7 @@ def get_fans(shape):
     if len(shape) < 2:
         raise ValueError('shape must be of length >= 2: shape={}', shape)
 
-    fan_in = numpy.prod(shape[1:])
-    fan_out = shape[0]
+    receptive_field_size = numpy.prod(shape[2:], dtype=numpy.int32)
+    fan_in = shape[1] * receptive_field_size
+    fan_out = shape[0] * receptive_field_size
     return fan_in, fan_out

--- a/tests/chainer_tests/test_initializer.py
+++ b/tests/chainer_tests/test_initializer.py
@@ -6,7 +6,8 @@ from chainer import testing
 
 @testing.parameterize(
     {'shape': (2, 1), 'expect': (1, 2)},
-    {'shape': (2, 3, 4), 'expect': (12, 2)})
+    {'shape': (2, 3, 4), 'expect': (12, 8)},
+    {'shape': (2, 3, 4, 5), 'expect': (60, 40)})
 class TestGetFans(unittest.TestCase):
 
     def test_get_fans(self):


### PR DESCRIPTION
I fixed `fan_out` in initializer.py that is different from other frameworks.

I think `get_fans` is based on keras implementation and keras used `shape[0]` as `fan_out`, but it is fixed in https://github.com/fchollet/keras/pull/2252 
Other implementation of `fan_out`:
- Caffe  
  https://github.com/BVLC/caffe/blob/master/include/caffe/filler.hpp#L193
- Tensorflow  
  https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/layers/python/layers/initializers.py#L126
