### PR TITLE
Fix ImageNet example for conflicts of parameter-shape placeholder and model copy

### DIFF
--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -65,6 +65,16 @@ class PreprocessedDataset(chainer.dataset.DatasetMixin):
         return image, label
 
 
+class TestModeEvaluator(extensions.Evaluator):
+
+    def evaluate(self):
+        model = self.get_target('main')
+        model.train = False
+        ret = super(TestModeEvaluator, self).evaluate()
+        model.train = True
+        return ret
+
+
 def main():
     archs = {
         'alex': alex.Alex,
@@ -136,11 +146,7 @@ def main():
     val_interval = (10 if args.test else 100000), 'iteration'
     log_interval = (10 if args.test else 1000), 'iteration'
 
-    # Copy the chain with shared parameters to flip 'train' flag only in test
-    eval_model = model.copy()
-    eval_model.train = False
-
-    trainer.extend(extensions.Evaluator(val_iter, eval_model, device=args.gpu),
+    trainer.extend(TestModeEvaluator(val_iter, model, device=args.gpu),
                    trigger=val_interval)
     trainer.extend(extensions.dump_graph('main/loss'))
     trainer.extend(extensions.snapshot(), trigger=val_interval)


### PR DESCRIPTION
Fix #1691.

The current ImageNet example copies the model for evaluation in order to change the `train` flag. This code relies on an assumption that the model definition is fixed before the training, while it is not fulfilled anymore since the introduction of parameter-shape placeholder #1363. I stopped copying the model for this purpose and wrote a customized evaluator for temporarily changing the `train` flag for evaluation.