### PR TITLE
Configuration file for rtd-build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 .\#*
 .coverage
 .eggs/
+_readthedocs_build
 chainer.egg-info/
 dist/
 htmlcov/

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+name: chainer
+type: sphinx
+base: docs/source
+python:
+  setup_py_install: true

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,6 @@
 name: chainer
 type: sphinx
 base: docs/source
+requirements_file: docs/requirements.txt
 python:
   setup_py_install: true


### PR DESCRIPTION
I made a configuration file for rtd-bulild command. You can build the document with `rtd-build` command under the root. This command creates clean environment using virtual-env.
https://github.com/rtfd/readthedocs-build

related to #1600