### PR TITLE
fix scale of elapsed_time for GPU case

### DIFF
--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -45,7 +45,7 @@ class TimerHook(function.FunctionHook):
             self.stop.synchronize()
             # Note that `get_elapsed_time` returns result in milliseconds
             elapsed_time = cuda.cupy.cuda.get_elapsed_time(
-                self.start, self.stop) * 1000
+                self.start, self.stop) / 1000
         self.call_history.append((function, elapsed_time))
 
     def forward_postprocess(self, function, in_data):


### PR DESCRIPTION
This is a bug fix.
Since the returned value is in millisecond scale, it must be divided by 1000 to change second scale.