### PR TITLE
Add seed option to split functions

### DIFF
--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -116,7 +116,8 @@ def split_dataset_random(dataset, first_size, seed=None):
         dataset: Dataset to split.
         first_size (int): Size of the first subset.
         seed (int): Seed the generator used for the permutation of indexes.
-            If an integer is specified, it is guaranteed that each sample
+            If an integer beging convertible to 32 bit unsigned integers is
+            specified, it is guaranteed that each sample
             in the given dataset always belongs to a specific subset.
             If ``None``, the permutation is changed randomly.
 
@@ -181,7 +182,8 @@ def get_cross_validation_datasets_random(dataset, n_fold, seed=None):
         dataset: Dataset to split.
         n_fold (int): Number of splits for cross validation.
         seed (int): Seed the generator used for the permutation of indexes.
-            If an integer is specified, it is guaranteed that each sample
+            If an integer beging convertible to 32 bit unsigned integers is
+            specified, it is guaranteed that each sample
             in the given dataset always belongs to a specific subset.
             If ``None``, the permutation is changed randomly.
 

--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -105,7 +105,7 @@ def split_dataset(dataset, split_at, order=None):
     return subset1, subset2
 
 
-def split_dataset_random(dataset, first_size):
+def split_dataset_random(dataset, first_size, seed=None):
     """Splits a dataset into two subsets randomly.
 
     This function creates two instances of :class:`SubDataset`. These instances
@@ -115,6 +115,10 @@ def split_dataset_random(dataset, first_size):
     Args:
         dataset: Dataset to split.
         first_size (int): Size of the first subset.
+        seed (int): Seed the generator used for the permutation of indexes.
+            If an integer is specified, it is guaranteed that each sample
+            in the given dataset always belongs to a specific subset.
+            If ``None``, the permutation is changed randomly.
 
     Returns:
         tuple: Two :class:`SubDataset` objects. The first subset contains
@@ -123,7 +127,9 @@ def split_dataset_random(dataset, first_size):
             dataset.
 
     """
+    numpy.random.seed(seed)
     order = numpy.random.permutation(len(dataset))
+    numpy.random.seed(None)
     return split_dataset(dataset, first_size, order)
 
 
@@ -167,7 +173,7 @@ def get_cross_validation_datasets(dataset, n_fold, order=None):
     return splits
 
 
-def get_cross_validation_datasets_random(dataset, n_fold):
+def get_cross_validation_datasets_random(dataset, n_fold, seed=None):
     """Creates a set of training/test splits for cross validation randomly.
 
     This function acts almost same as :func:`get_cross_validation_dataset`,
@@ -176,10 +182,16 @@ def get_cross_validation_datasets_random(dataset, n_fold):
     Args:
         dataset: Dataset to split.
         n_fold (int): Number of splits for cross validation.
+        seed (int): Seed the generator used for the permutation of indexes.
+            If an integer is specified, it is guaranteed that each sample
+            in the given dataset always belongs to a specific subset.
+            If ``None``, the permutation is changed randomly.
 
     Returns:
         list of tuples: List of dataset splits.
 
     """
+    numpy.random.seed(seed)
     order = numpy.random.permutation(len(dataset))
+    numpy.random.seed(None)
     return get_cross_validation_datasets(dataset, n_fold, order)

--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -127,9 +127,7 @@ def split_dataset_random(dataset, first_size, seed=None):
             dataset.
 
     """
-    numpy.random.seed(seed)
-    order = numpy.random.permutation(len(dataset))
-    numpy.random.seed(None)
+    order = numpy.random.RandomState(seed).permutation(len(dataset))
     return split_dataset(dataset, first_size, order)
 
 
@@ -191,7 +189,5 @@ def get_cross_validation_datasets_random(dataset, n_fold, seed=None):
         list of tuples: List of dataset splits.
 
     """
-    numpy.random.seed(seed)
-    order = numpy.random.permutation(len(dataset))
-    numpy.random.seed(None)
+    order = numpy.random.RandomState(seed).permutation(len(dataset))
     return get_cross_validation_datasets(dataset, n_fold, order)

--- a/tests/chainer_tests/datasets_tests/test_sub_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_sub_dataset.py
@@ -78,6 +78,15 @@ class TestSplitDataset(unittest.TestCase):
         reconst = sorted(set(subset1).union(subset2))
         self.assertEqual(reconst, original)
 
+        subset1a, subset2a = datasets.split_dataset_random(original, 2, seed=3)
+        reconst = sorted(set(subset1a).union(subset2a))
+        self.assertEqual(reconst, original)
+        subset1b, subset2b = datasets.split_dataset_random(original, 2, seed=3)
+        self.assertEqual(set(subset1a), set(subset1b))
+        self.assertEqual(set(subset2a), set(subset2b))
+        reconst = sorted(set(subset1a).union(subset2a))
+        self.assertEqual(reconst, original)
+
 
 class TestGetCrossValidationDatasets(unittest.TestCase):
 
@@ -164,6 +173,14 @@ class TestGetCrossValidationDatasets(unittest.TestCase):
         validation_union = sorted(
             list(cvs[0][1]) + list(cvs[1][1]) + list(cvs[2][1]))
         self.assertEqual(validation_union, original)
+
+        cvs_a = datasets.get_cross_validation_datasets_random(
+            original, 3, seed=5)
+        cvs_b = datasets.get_cross_validation_datasets_random(
+            original, 3, seed=5)
+        for (tr_a, te_a), (tr_b, te_b) in zip(cvs_a, cvs_b):
+            self.assertEqual(set(tr_a), set(tr_b))
+            self.assertEqual(set(te_a), set(te_b))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR aims to add ``seed`` option to ``split_dataset_random()`` and ``get_cross_validation_datasets_random()`` functions.
It would be useful when you split a dataset to train and test datasets, train a NN with the train dataset, and test the trained NN with the test dataset by another script.