### PR TITLE
[WIP] Future warning decorator

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -130,3 +130,5 @@ basic_math.install_variable_arithmetics()
 array.get_item.install_variable_get_item()
 
 init_weight = initializers.init_weight
+
+enable_deprecated = False

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,8 +1,10 @@
 import numpy
 
 from chainer.utils import walker_alias
+from chainer.utils import future_warning as future_warning_
 
 WalkerAlias = walker_alias.WalkerAlias
+future_warning = future_warning_.future_warning
 
 
 def force_array(x, dtype=None):

--- a/chainer/utils/future_warning.py
+++ b/chainer/utils/future_warning.py
@@ -1,0 +1,17 @@
+import functools
+import warnings
+
+import chainer
+
+
+def future_warning(version):
+
+    def _future_warning(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            if not chainer.enable_deprecated:
+                warnings.warn('Deprecated', FutureWarning)
+            return f(*args, **kwargs)
+        return wrapper
+
+    return _future_warning

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -157,6 +157,7 @@ Actual: {0}'''.format(type(data))
     def __pos__(self):
         return self
 
+    @chainer.utils.future_warning('v1.17.0')
     def __len__(self):
         """Returns the number of elements of the data array.
 


### PR DESCRIPTION
This PR add a decorator that indicates the decorated functions will be deprecated in the future. It offers the cheapest way to notify users that they use the deprecated features. We also offers global variable that turn off the warning. Unless users explicitly disable the flag, deprecated functions throws `FutureWarning`. As an example, I annotated `Variable.__len__` with this decorator, as discussed in #1792.

As the initial PR is 10-minute work, we need to consider more function names, warning message, and argument of the decorator.