### PR TITLE
Fix dropout state bug on rnn API

### DIFF
--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -67,7 +67,8 @@ class DropoutStates(object):
         cudnn.set_dropout_descriptor(self.desc, handle, dropout)
 
     @staticmethod
-    def create(handle, states, dropout, seed):
+    def create(handle, dropout, seed):
+        states = cudnn.create_dropout_states(handle)
         desc = cudnn.create_dropout_descriptor(
             handle, dropout, states.data.ptr, states.size, seed)
         return DropoutStates(states, desc)
@@ -92,9 +93,7 @@ class DropoutRandomStates(object):
     def create_dropout_states(self, dropout):
         handle = cudnn.get_handle()
         if self._states is None:
-            states = cudnn.create_dropout_states(handle)
-            self._states = DropoutStates.create(
-                handle, states, dropout, self._seed)
+            self._states = DropoutStates.create(handle, dropout, self._seed)
         else:
             self._states.set_dropout_ratio(handle, dropout)
 

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -235,6 +235,11 @@ def create_dropout_descriptor(
     return desc
 
 
+def set_dropout_descriptor(desc, handle, dropout):
+    # When the fourth argument is NULL, random state is not updated.
+    cudnn.setDropoutDescriptor(desc.value, handle, dropout, 0, 0, 0)
+
+
 def create_rnn_descriptor(hidden_size, num_layers, dropout_desc,
                           input_mode, direction, mode, data_type):
     desc = Descriptor(cudnn.createRNNDescriptor(),


### PR DESCRIPTION
I fixed NStepLSTM. This fix reuses dropout descriptor instead of reproducing it.
fix #1803 