### PR TITLE
Set zero as grad in initialize of using placeholder parameter

### DIFF
--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -103,6 +103,7 @@ class Convolution2D(link.Link):
         if self.has_uninitialized_params:
             with cuda.get_device(self._device_id):
                 self._initialize_params(x.shape[1])
+                self.W.grad[...] = 0
         return convolution_2d.convolution_2d(
             x, self.W, self.b, self.stride, self.pad, self.use_cudnn,
             deterministic=self.deterministic)

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -97,6 +97,7 @@ class DilatedConvolution2D(link.Link):
         if self.has_uninitialized_params:
             with cuda.get_device(self._device_id):
                 self._initialize_params(x.shape[1])
+                self.W.grad[...] = 0
         return dilated_convolution_2d.dilated_convolution_2d(
             x, self.W, self.b, self.stride,
             self.pad, self.dilate, self.use_cudnn)

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -89,4 +89,5 @@ class Linear(link.Link):
         if self.has_uninitialized_params:
             with cuda.get_device(self._device_id):
                 self._initialize_params(x.size // len(x.data))
+                self.W.grad[...] = 0
         return linear.linear(x, self.W, self.b)


### PR DESCRIPTION
Fix #1799
This bug is critical.
If we use shape placeholder, NN learning will fail. It is difficult for users to notice this bug.

But, this PC is like a work-around. Please tell me about good design.

