### PR TITLE
Fix link placeholder problem caused by ndarray input.

### DIFF
--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -88,5 +88,5 @@ class Linear(link.Link):
         """
         if self.has_uninitialized_params:
             with cuda.get_device(self._device_id):
-                self._initialize_params(x.size // len(x.data))
+                self._initialize_params(x.size // x.shape[0])
         return linear.linear(x, self.W, self.b)

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -82,7 +82,7 @@ class StatelessLSTM(LSTMBase):
 
         """
         if self.upward.has_uninitialized_params:
-            in_size = x.size // len(x.data)
+            in_size = x.size // x.shape[0]
             self.upward._initialize_params(in_size)
             self._initialize_params()
 
@@ -216,7 +216,7 @@ class LSTM(LSTMBase):
 
         """
         if self.upward.has_uninitialized_params:
-            in_size = x.size // len(x.data)
+            in_size = x.size // x.shape[0]
             self.upward._initialize_params(in_size)
             self._initialize_params()
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_linear.py
@@ -79,6 +79,9 @@ class TestLinear(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
+@testing.parameterize(
+    {'input_variable': True},
+    {'input_variable': False})
 class TestLinearParameterShapePlaceholder(unittest.TestCase):
 
     in_size = 3
@@ -91,7 +94,10 @@ class TestLinearParameterShapePlaceholder(unittest.TestCase):
         temp_x = numpy.random.uniform(-1, 1,
                                       (self.out_size,
                                        self.in_size)).astype(numpy.float32)
-        self.link(chainer.Variable(temp_x))
+        if self.input_variable:
+            self.link(chainer.Variable(temp_x))
+        else:
+            self.link(temp_x)
         W = self.link.W.data
         W[...] = numpy.random.uniform(-1, 1, W.shape)
         b = self.link.b.data

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -18,6 +18,10 @@ from chainer.testing import attr
     [
         {'input_none': False},
         {'input_none': True},
+    ],
+    [
+        {'input_variable': False},
+        {'input_variable': True},
     ]
 ))
 class TestLSTM(unittest.TestCase):
@@ -35,7 +39,7 @@ class TestLSTM(unittest.TestCase):
 
     def check_forward(self, x1_data, x2_data, x3_data):
         xp = self.link.xp
-        x1 = chainer.Variable(x1_data)
+        x1 = chainer.Variable(x1_data) if self.input_variable else x1_data
         h1 = self.link(x1)
         c0 = chainer.Variable(xp.zeros((len(self.x1), self.out_size),
                                        dtype=self.x1.dtype))
@@ -45,7 +49,7 @@ class TestLSTM(unittest.TestCase):
         testing.assert_allclose(self.link.c.data, c1_expect.data)
 
         batch = len(x2_data)
-        x2 = chainer.Variable(x2_data)
+        x2 = chainer.Variable(x2_data) if self.input_variable else x2_data
         h1_in, h1_rest = functions.split_axis(
             self.link.h.data, [batch], axis=0)
         y2 = self.link(x2)
@@ -56,7 +60,7 @@ class TestLSTM(unittest.TestCase):
         testing.assert_allclose(self.link.h.data[:batch], y2_expect.data)
         testing.assert_allclose(self.link.h.data[batch:], h1_rest.data)
 
-        x3 = chainer.Variable(x3_data)
+        x3 = chainer.Variable(x3_data) if self.input_variable else x3_data
         h2_rest = self.link.h
         y3 = self.link(x3)
         c3_expect, y3_expect = \
@@ -225,6 +229,10 @@ class TestLSTMInvalidSize(unittest.TestCase):
     [
         {'input_none': False},
         {'input_none': True},
+    ],
+    [
+        {'input_variable': False},
+        {'input_variable': True},
     ]
 ))
 class TestStatelessLSTM(unittest.TestCase):
@@ -239,7 +247,7 @@ class TestStatelessLSTM(unittest.TestCase):
 
     def check_forward(self, x_data):
         xp = self.link.xp
-        x = chainer.Variable(x_data)
+        x = chainer.Variable(x_data) if self.input_variable else x_data
         c1, h1 = self.link(None, None, x)
         c0 = chainer.Variable(xp.zeros((len(self.x), self.out_size),
                                        dtype=self.x.dtype))


### PR DESCRIPTION
I fixed the shape placeholder problem caused when ndarray is input.
It occurs in `Linear`, `StatelessLSTM` and `LSTM` links.
This problem caused by `len(x.data)` used for input size calculation.
When `x` is ndarray `len(x.data)` is buffer size of `x`.

Here is an example to cause the problem: (on Chainer v1.17.0)
```
>>> from chainer import links as L
>>> import numpy as np
>>> fc = L.Linear(None, 10)
>>> x = np.zeros((10, 10), dtype=np.float32)
>>> y = fc(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "chainer/links/connection/linear.py", line 91, in __call__
    self._initialize_params(x.size // len(x.data))
  File "chainer/links/connection/linear.py", line 77, in _initialize_params
    initializer=self._W_initializer)
  File "chainer/link.py", line 180, in add_param
    data = initializers.generate_array(initializer, shape, self.xp)
  File "chainer/initializers/__init__.py", line 45, in generate_array
    initializer(array)
  File "chainer/initializers/normal.py", line 93, in __call__
    s = self.scale * numpy.sqrt(2. / fan_in)
ZeroDivisionError: float division by zero
```