### PR TITLE
Fix cleargrads and zerograds for uninitialized parameters

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -217,6 +217,7 @@ class Link(object):
 
         """
         class uninitialized_param(object):
+
             def __init__(self):
                 self._cleared = False
                 self._zeroed = False

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -6,6 +6,7 @@ import six
 import chainer
 from chainer import cuda
 import chainer.functions as F
+from chainer import initializers
 import chainer.links as L
 from chainer import optimizers
 from chainer import testing
@@ -19,13 +20,12 @@ class LinearModel(object):
     BATCH_SIZE = 32
     EPOCH = 100
 
-    def __init__(self, optimizer, dtype):
+    def __init__(self, optimizer, dtype, use_placeholder):
         self.dtype = dtype
-        self.model = L.Linear(self.UNIT_NUM, 2)
-        self.model.W.data = self.model.W.data.astype(dtype)
-        self.model.b.data = self.model.b.data.astype(dtype)
-        self.model.W.grad = self.model.W.grad.astype(dtype)
-        self.model.b.grad = self.model.b.grad.astype(dtype)
+        weight = initializers.HeNormal(1 / numpy.sqrt(2), dtype)
+        bias = initializers.Constant(0, dtype)
+        in_size = None if use_placeholder else self.UNIT_NUM
+        self.model = L.Linear(in_size, 2, initialW=weight, initial_bias=bias)
 
         self.optimizer = optimizer
         # true parameters
@@ -85,7 +85,8 @@ class OptimizerTestBase(object):
         raise NotImplementedError()
 
     def setUp(self):
-        self.model = LinearModel(self.create(), self.dtype)
+        self.model = LinearModel(self.create(), self.dtype,
+                                 self.use_placeholder)
 
     @condition.retry(10)
     def test_linear_model_cpu(self):
@@ -126,7 +127,8 @@ class OptimizerTestBase(object):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestAdaDelta(OptimizerTestBase, unittest.TestCase):
 
@@ -135,7 +137,8 @@ class TestAdaDelta(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestAdaGrad(OptimizerTestBase, unittest.TestCase):
 
@@ -144,7 +147,8 @@ class TestAdaGrad(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestAdam(OptimizerTestBase, unittest.TestCase):
 
@@ -153,7 +157,8 @@ class TestAdam(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestMomentumSGD(OptimizerTestBase, unittest.TestCase):
 
@@ -162,7 +167,8 @@ class TestMomentumSGD(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class NesterovAG(OptimizerTestBase, unittest.TestCase):
 
@@ -171,7 +177,8 @@ class NesterovAG(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestRMSprop(OptimizerTestBase, unittest.TestCase):
 
@@ -180,7 +187,8 @@ class TestRMSprop(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestRMSpropGraves(OptimizerTestBase, unittest.TestCase):
 
@@ -189,7 +197,8 @@ class TestRMSpropGraves(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestSGD(OptimizerTestBase, unittest.TestCase):
 
@@ -198,7 +207,8 @@ class TestSGD(OptimizerTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_placeholder': [False, True],
 }))
 class TestSMORMS3(OptimizerTestBase, unittest.TestCase):
 


### PR DESCRIPTION
Fix `cleargrads` and `zerograds` to work properly with uninitialized parameters.
