### PR TITLE
Add forward and backward test to dropout

### DIFF
--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -49,12 +49,11 @@ class TestDropout(unittest.TestCase):
     def check_backward(self, x_data, y_grad):
         x = chainer.Variable(x_data)
         y = functions.dropout(x, self.ratio)
-        d = {'creator': y.creator}
+        creator = y.creator
         y.grad = y_grad
         y.backward()
 
         def f():
-            creator = d['creator']
             y = _dropout(x_data, creator)
             return y,
         gx, = gradient_check.numerical_grad(f, (x_data, ), (y.grad, ), eps=0.1)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -5,24 +5,60 @@ import numpy
 import chainer
 from chainer import cuda
 from chainer import functions
+from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
+from chainer.testing import condition
 
 
-# TODO(Kenta OONO): This test fixture check types only. Add more detailed test.
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
+def _dropout(x, creator):
+    return x * creator.mask
+
+
+@testing.parameterize(
+    {'dtype': numpy.float16, 'ratio': 0.1},
+    {'dtype': numpy.float32, 'ratio': 0.3},
+    {'dtype': numpy.float64, 'ratio': 0.5},
+    {'dtype': numpy.float64, 'ratio': 0.0},
+)
 class TestDropout(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
 
+        self.check_backward_options = {}
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {
+                'atol': 5e-4, 'rtol': 5e-3}
+
     def check_type_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = functions.dropout(x)
         self.assertEqual(y.data.dtype, self.dtype)
+
+    def check_forward(self, x_data):
+        x = chainer.Variable(x_data)
+        y = functions.dropout(x, self.ratio)
+        if self.ratio == 0.0:
+            y_expect = x_data
+        else:
+            y_expect = _dropout(x_data, y.creator)
+        testing.assert_allclose(y_expect, y.data)
+
+    def check_backward(self, x_data, y_grad):
+        x = chainer.Variable(x_data)
+        y = functions.dropout(x, self.ratio)
+        d = {'creator': y.creator}
+        y.grad = y_grad
+        y.backward()
+
+        def f():
+            creator = d['creator']
+            y = _dropout(x_data, creator)
+            return y,
+        gx, = gradient_check.numerical_grad(f, (x_data, ), (y.grad, ), eps=0.1)
+        testing.assert_allclose(gx, x.grad, **self.check_backward_options)
 
     def test_type_forward_cpu(self):
         self.check_type_forward(self.x)
@@ -30,6 +66,23 @@ class TestDropout(unittest.TestCase):
     @attr.gpu
     def test_type_forward_gpu(self):
         self.check_type_forward(cuda.to_gpu(self.x))
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x),
+                            cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds tests to dropout function.
There is only typecheck test in dropout function.
I add forward and backward tests to dropout test.
I think that these tests may not be enough but are better than nothing.
