### PR TITLE
Append except clause to functions that returns int

### DIFF
--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -308,4 +308,4 @@ cpdef activationBackward_v3(
 
 cpdef size_t createDropoutDescriptor() except *
 cpdef destroyDropoutDescriptor(size_t dropoutDesc)
-cpdef size_t dropoutGetStatesSize(size_t handle)
+cpdef size_t dropoutGetStatesSize(size_t handle) except *

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -325,7 +325,7 @@ cpdef inline check_status(int status):
 # Version
 ###############################################################################
 
-cpdef size_t getVersion():
+cpdef size_t getVersion() except *:
     return cudnnGetVersion()
 
 
@@ -867,7 +867,7 @@ cpdef destroyDropoutDescriptor(size_t dropoutDesc):
     check_status(status)
 
 
-cpdef size_t dropoutGetStatesSize(size_t handle):
+cpdef size_t dropoutGetStatesSize(size_t handle) except *:
     cdef size_t sizeInBytes
     status = cudnnDropoutGetStatesSize(
         <Handle>handle, &sizeInBytes)

--- a/cupy/cuda/curand.pyx
+++ b/cupy/cuda/curand.pyx
@@ -87,7 +87,7 @@ cpdef inline check_status(int status):
 # Generator
 ###############################################################################
 
-cpdef size_t createGenerator(int rng_type):
+cpdef size_t createGenerator(int rng_type) except *:
     cdef Generator generator
     with nogil:
         status = curandCreateGenerator(&generator, <RngType>rng_type)
@@ -100,7 +100,7 @@ cpdef destroyGenerator(size_t generator):
     check_status(status)
 
 
-cpdef int getVersion():
+cpdef int getVersion() except *:
     cdef int version
     status = curandGetVersion(&version)
     check_status(status)

--- a/cupy/cuda/device.pxd
+++ b/cupy/cuda/device.pxd
@@ -1,4 +1,4 @@
-cpdef int get_device_id()
+cpdef int get_device_id() except *
 cpdef get_cublas_handle()
 
 cdef class Device:

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -6,7 +6,7 @@ from cupy.cuda cimport cublas
 from cupy.cuda cimport runtime
 
 
-cpdef int get_device_id():
+cpdef int get_device_id() except *:
     return runtime.getDevice()
 
 


### PR DESCRIPTION
We need to append "except *" to functions returning integers. If not, these functions ignore raised Exceptions.