### PR TITLE
Add integer array indexing on one axis for __getitem__

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1017,22 +1017,6 @@ cdef class ndarray:
         else:
             slices = list(slices)
 
-        # Check if advanced is true and if there are multiple integer indexing
-        advanced = False
-        axis = None
-        for i, s in enumerate(slices):
-            if isinstance(s, (numpy.ndarray, ndarray)):
-                if issubclass(s.dtype.type, numpy.integer):
-                    if advanced:
-                        advanced = True
-                        axis = None
-                    else:
-                        advanced = True
-                        axis = i
-                else:
-                    raise ValueError('Advanced indexing with ' +
-                                     'non-integer array is not supported')
-
         # Expand ellipsis into empty slices
         ellipsis = -1
         n_newaxes = n_ellipses = 0
@@ -1051,6 +1035,22 @@ cdef class ndarray:
             slices[ellipsis:ellipsis + 1] = noneslices * ellipsis_size
 
         slices += noneslices * (ndim - <Py_ssize_t>len(slices) + n_newaxes)
+
+        # Check if advanced is true and if there are multiple integer indexing
+        advanced = False
+        axis = None
+        for i, s in enumerate(slices):
+            if isinstance(s, (numpy.ndarray, ndarray)):
+                if issubclass(s.dtype.type, numpy.integer):
+                    if advanced:
+                        advanced = True
+                        axis = None
+                    else:
+                        advanced = True
+                        axis = i
+                else:
+                    raise ValueError('Advanced indexing with ' +
+                                     'non-integer array is not supported')
 
         if advanced:
             if axis is not None:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1006,6 +1006,20 @@ cdef class ndarray:
         return self._shape[0]
 
     def __getitem__(self, slices):
+        """x.__getitem__(y) <==> x[y]
+
+        .. note::
+
+           CuPy handles out-of-bounds indices differently from NumPy.
+           NumPy handles them by raising an error, but CuPy wraps around them.
+
+           Examples
+           --------
+           >>> a = cupy.arange(3)
+           >>> a[[1, 3]]
+           array([1, 0])
+
+        """
         # supports basic indexing (by slices, ints or Ellipsis).
         # also supports indexing by an array on one axis
         # TODO(beam2d): Support the advanced indexing of NumPy.

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1026,7 +1026,7 @@ cdef class ndarray:
         for i, s in enumerate(slices):
             if s is None:
                 n_newaxes += 1
-            elif s == Ellipsis:
+            elif s is Ellipsis:
                 n_ellipses += 1
                 ellipsis = i
         ndim = self._shape.size()

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1040,6 +1040,9 @@ cdef class ndarray:
         advanced = False
         axis = None
         for i, s in enumerate(slices):
+            if isinstance(s, list):
+                s = numpy.array(s)
+                slices[i] = s
             if isinstance(s, (numpy.ndarray, ndarray)):
                 if issubclass(s.dtype.type, numpy.integer):
                     if advanced:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1107,7 +1107,7 @@ cdef class ndarray:
                     ind += self._shape[j]
                 if not (0 <= ind < self._shape[j]):
                     msg = ('Index %s is out of bounds for axis %s with '
-                            'size %s' % (s, j, self._shape[j]))
+                           'size %s' % (s, j, self._shape[j]))
                     raise IndexError(msg)
                 offset += ind * self._strides[j]
                 j += 1

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1036,6 +1036,9 @@ cdef class ndarray:
 
         slices += noneslices * (ndim - <Py_ssize_t>len(slices) + n_newaxes)
 
+        if len(slices) > self.ndim + n_newaxes:
+            raise IndexError('too many indices for array')
+
         # Check if advanced is true and if there are multiple integer indexing
         advanced = False
         axis = None

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1006,7 +1006,8 @@ cdef class ndarray:
         return self._shape[0]
 
     def __getitem__(self, slices):
-        # It supports the basic indexing (by slices, ints or Ellipsis) only.
+        # supports basic indexing (by slices, ints or Ellipsis).
+        # also supports indexing by an array on one axis
         # TODO(beam2d): Support the advanced indexing of NumPy.
         cdef Py_ssize_t i, j, offset, ndim, n_newaxes, n_ellipses, ellipsis
         cdef Py_ssize_t ellipsis_sizem, s_start, s_stop, s_step, dim, ind
@@ -1016,9 +1017,22 @@ cdef class ndarray:
         else:
             slices = list(slices)
 
-        for s in slices:
-            if isinstance(s, ndarray):
-                raise ValueError('Advanced indexing is not supported')
+        # Check if advanced is true and if there are multiple integer indexing
+        advanced = False
+        axis = None
+        for i, s in enumerate(slices):
+            if isinstance(s, (numpy.ndarray, ndarray)):
+                if s.dtype in [numpy.int64, numpy.int32,
+                               numpy.int16, numpy.int8]:
+                    if advanced:
+                        advanced = True
+                        axis = None
+                    else:
+                        advanced = True
+                        axis = i
+                else:
+                    raise ValueError('Advanced indexing with ' +
+                                     'non-integer array is not supported')
 
         # Expand ellipsis into empty slices
         ellipsis = -1
@@ -1039,52 +1053,64 @@ cdef class ndarray:
 
         slices += noneslices * (ndim - <Py_ssize_t>len(slices) + n_newaxes)
 
-        # Create new shape and stride
-        j = 0
-        offset = 0
-        for i, s in enumerate(slices):
-            if s is None:
-                shape.push_back(1)
-                if j < ndim:
-                    strides.push_back(self._strides[j])
-                elif ndim > 0:
-                    strides.push_back(self._strides[ndim - 1])
-                else:
-                    strides.push_back(self.itemsize)
-            elif ndim <= j:
-                raise IndexError("too many indices for array")
-            elif isinstance(s, slice):
-                s = internal.complete_slice(s, self._shape[j])
-                s_start = s.start
-                s_stop = s.stop
-                s_step = s.step
-                if s_step > 0:
-                    dim = (s_stop - s_start - 1) // s_step + 1
-                else:
-                    dim = (s_stop - s_start + 1) // s_step + 1
-
-                shape.push_back(dim)
-                strides.push_back(self._strides[j] * s_step)
-
-                offset += s_start * self._strides[j]
-                j += 1
-            elif numpy.isscalar(s):
-                ind = int(s)
-                if ind < 0:
-                    ind += self._shape[j]
-                if not (0 <= ind < self._shape[j]):
-                    msg = ('Index %s is out of bounds for axis %s with size %s'
-                           % (s, j, self._shape[j]))
-                    raise IndexError(msg)
-                offset += ind * self._strides[j]
-                j += 1
+        if advanced:
+            if (axis is not None and
+                all(isinstance(a, slice) and
+                    equal_slices(a, slice(None)) for a in slices[:axis]) and
+                all(isinstance(a, slice) and
+                    equal_slices(a, slice(None)) for a in slices[axis + 1:])):
+                return self.take(slices[axis], axis)
             else:
-                raise TypeError('Invalid index type: %s' % type(slices[i]))
+                raise NotImplementedError('Adv indexing with 2 or ' +
+                                          'more arrays is not supported')
 
-        v = self.view()
-        v.data = self.data + offset
-        v._set_shape_and_strides(shape, strides)
-        return v
+        else:
+            # Create new shape and stride
+            j = 0
+            offset = 0
+            for i, s in enumerate(slices):
+                if s is None:
+                    shape.push_back(1)
+                    if j < ndim:
+                        strides.push_back(self._strides[j])
+                    elif ndim > 0:
+                        strides.push_back(self._strides[ndim - 1])
+                    else:
+                        strides.push_back(self.itemsize)
+                elif ndim <= j:
+                    raise IndexError("too many indices for array")
+                elif isinstance(s, slice):
+                    s = internal.complete_slice(s, self._shape[j])
+                    s_start = s.start
+                    s_stop = s.stop
+                    s_step = s.step
+                    if s_step > 0:
+                        dim = (s_stop - s_start - 1) // s_step + 1
+                    else:
+                        dim = (s_stop - s_start + 1) // s_step + 1
+
+                    shape.push_back(dim)
+                    strides.push_back(self._strides[j] * s_step)
+
+                    offset += s_start * self._strides[j]
+                    j += 1
+                elif numpy.isscalar(s):
+                    ind = int(s)
+                    if ind < 0:
+                        ind += self._shape[j]
+                    if not (0 <= ind < self._shape[j]):
+                        msg = ('Index %s is out of bounds for axis %s with '
+                               'size %s' % (s, j, self._shape[j]))
+                        raise IndexError(msg)
+                    offset += ind * self._strides[j]
+                    j += 1
+                else:
+                    raise TypeError('Invalid index type: %s' % type(slices[i]))
+
+            v = self.view()
+            v.data = self.data + offset
+            v._set_shape_and_strides(shape, strides)
+            return v
 
     def __setitem__(self, slices, value):
         cdef ndarray v, x, y
@@ -1949,6 +1975,12 @@ cpdef ndarray _diagonal(ndarray a, Py_ssize_t offset=0, Py_ssize_t axis1=0,
         a.shape[:-2] + (diag_size,),
         a.strides[:-2] + (a.strides[-1] + a.strides[-2],))
     return ret
+
+
+def equal_slices(s1, s2):
+    return (s1.start == s2.start and
+            s1.stop == s2.stop and
+            s1.step == s2.step)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -1,55 +1,82 @@
 import unittest
 
-import numpy as np
+import numpy
 
 import cupy
 from cupy import testing
 
 
+@testing.parameterize(
+    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (slice(None), [1, 0])},
+    {'shape': (2, 3, 4), 'transpose': (1, 2, 0), 'indexes': (slice(None), [1, 0])},
+    {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, -1], slice(None))},
+    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (Ellipsis, [1, 0])},
+    {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, -1], Ellipsis)},
+    {'shape': (2, 3, 4), 'transpose': None,
+     'indexes': (slice(None), slice(None), [[1, -1], [0, 3]])},
+)
 @testing.gpu
-class TestArrayAdvancedIndexing(unittest.TestCase):
+class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_1d_adv_indexing(self, xp, dtype):
-        shp = (2, 3, 4)
-        a = xp.arange(np.product(shp)).reshape(shp).astype(dtype)
-        idx = (slice(None), np.array([1, 0]), slice(None))
-        return a[idx]
+    def test_adv_getitem(self, xp, dtype):
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        if self.transpose:
+            a = a.transpose(self.transpose)
+        return a[self.indexes]
+
+
+@testing.parameterize(
+    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (slice(None), cupy.array([1, 0]))},
+    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (numpy.array([1, 0],))},
+)
+@testing.gpu
+class TestArrayAdvancedIndexingArrayClass(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_1d_adv_indexing_gpu_idx(self, xp, dtype):
-        shp = (2, 3, 4)
-        a = xp.arange(np.product(shp)).reshape(shp).astype(dtype)
-        idx = (slice(None), xp.array([1, 0]), slice(None))
-        return a[idx]
+    def test_adv_getitem(self, xp, dtype):
+        indexes = list(self.indexes)
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        if self.transpose:
+            a = a.transpose(self.transpose)
+
+        if xp is numpy:
+            for i, s in enumerate(indexes):
+                if isinstance(s, cupy.ndarray):
+                    indexes[i] = s.get()
+
+        return a[tuple(indexes)]
+
+
+@testing.parameterize(
+    {'shape': (), 'transpose': None, 'indexes': ([1],)},
+    {'shape': (2, 3), 'transpose': None,
+     'indexes': (slice(None), [1, 2], slice(None))},
+)
+@testing.gpu
+class TestArrayInvalidIndexAdv(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_2d_adv_indexing_gpu_idx(self, xp, dtype):
-        shp = (2, 3, 4)
-        a = xp.arange(np.product(shp)).reshape(shp).astype(dtype)
-        idx = (slice(None), xp.array([[0, 1], [1, 0]]), slice(None))
-        return a[idx]
+    @testing.numpy_cupy_raises()
+    def test_invalid_adv_getitem(self, xp, dtype):
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        if self.transpose:
+            a = a.transpose(self.transpose)
+        a[self.indexes]
 
-    def test_not_supported_arr_and_int(self):
-        shp = (2, 3, 4)
-        a = cupy.arange(np.product(shp)).reshape(shp)
-        idx = (slice(None), np.array([1, 0]), 1)
-        with self.assertRaises(NotImplementedError):
-            a[idx]
 
-    def test_not_supported_two_arr(self):
-        shp = (2, 3, 4)
-        a = cupy.arange(np.product(shp)).reshape(shp)
-        idx = (slice(None), np.array([1, 0]), np.array([1, 0]))
-        with self.assertRaises(NotImplementedError):
-            a[idx]
+@testing.parameterize(
+    {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, 0], [2, 1])},
+)
+@testing.gpu
+class TestArrayAdvancedIndexingNotSupported(unittest.TestCase):
 
-    def test_not_supporeted_arr_and_none(self):
-        shp = (2, 3, 4)
-        a = cupy.arange(np.product(shp)).reshape(shp)
-        idx = (slice(None), np.array([1, 0]), None)
+    @testing.for_all_dtypes()
+    def test_not_supported_adv_indexing(self, dtype):
+        a = testing.shaped_arange(self.shape, cupy, dtype)
+        if self.transpose:
+            a = a.transpose(self.transpose)
         with self.assertRaises(NotImplementedError):
-            a[idx]
+            a[self.indexes]

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -7,17 +7,30 @@ from cupy import testing
 
 
 @testing.parameterize(
-    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (slice(None), [1, 0])},
-    {'shape': (2, 3, 4), 'transpose': (1, 2, 0),
-     'indexes': (slice(None), [1, 0])},
-    {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, -1], slice(None))},
-    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (Ellipsis, [1, 0])},
-    {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, -1], Ellipsis)},
-    {'shape': (2, 3, 4), 'transpose': None,
+    {'shape': (2, 3, 4), 'indexes': (slice(None), [1, 0])},
+    {'shape': (2, 3, 4), 'indexes': (slice(None), [1, 0])},
+    {'shape': (2, 3, 4), 'indexes': ([1, -1], slice(None))},
+    {'shape': (2, 3, 4), 'indexes': (Ellipsis, [1, 0])},
+    {'shape': (2, 3, 4), 'indexes': ([1, -1], Ellipsis)},
+    {'shape': (2, 3, 4),
      'indexes': (slice(None), slice(None), [[1, -1], [0, 3]])},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_adv_getitem(self, xp, dtype):
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        return a[self.indexes]
+
+
+@testing.parameterize(
+    {'shape': (2, 3, 4), 'transpose': (1, 2, 0),
+     'indexes': (slice(None), [1, 0])},
+)
+@testing.gpu
+class TestArrayAdvancedIndexingParametrizedTransp(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -29,9 +42,8 @@ class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'shape': (2, 3, 4), 'transpose': None,
-     'indexes': (slice(None), cupy.array([1, 0]))},
-    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (numpy.array([1, 0],))},
+    {'shape': (2, 3, 4), 'indexes': (slice(None), cupy.array([1, 0]))},
+    {'shape': (2, 3, 4), 'indexes': (numpy.array([1, 0],))},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingArrayClass(unittest.TestCase):
@@ -41,8 +53,6 @@ class TestArrayAdvancedIndexingArrayClass(unittest.TestCase):
     def test_adv_getitem(self, xp, dtype):
         indexes = list(self.indexes)
         a = testing.shaped_arange(self.shape, xp, dtype)
-        if self.transpose:
-            a = a.transpose(self.transpose)
 
         if xp is numpy:
             for i, s in enumerate(indexes):
@@ -53,9 +63,8 @@ class TestArrayAdvancedIndexingArrayClass(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'shape': (), 'transpose': None, 'indexes': ([1],)},
-    {'shape': (2, 3), 'transpose': None,
-     'indexes': (slice(None), [1, 2], slice(None))},
+    {'shape': (), 'indexes': ([1],)},
+    {'shape': (2, 3), 'indexes': (slice(None), [1, 2], slice(None))},
 )
 @testing.gpu
 class TestArrayInvalidIndexAdv(unittest.TestCase):
@@ -64,13 +73,11 @@ class TestArrayInvalidIndexAdv(unittest.TestCase):
     @testing.numpy_cupy_raises()
     def test_invalid_adv_getitem(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        if self.transpose:
-            a = a.transpose(self.transpose)
         a[self.indexes]
 
 
 @testing.parameterize(
-    {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, 0], [2, 1])},
+    {'shape': (2, 3, 4), 'indexes': ([1, 0], [2, 1])},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingNotSupported(unittest.TestCase):
@@ -78,7 +85,5 @@ class TestArrayAdvancedIndexingNotSupported(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_not_supported_adv_indexing(self, dtype):
         a = testing.shaped_arange(self.shape, cupy, dtype)
-        if self.transpose:
-            a = a.transpose(self.transpose)
         with self.assertRaises(NotImplementedError):
             a[self.indexes]

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -1,0 +1,55 @@
+import unittest
+
+import numpy as np
+
+import cupy
+from cupy import testing
+
+
+@testing.gpu
+class TestArrayAdvancedIndexing(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_1d_adv_indexing(self, xp, dtype):
+        shp = (2, 3, 4)
+        a = xp.arange(np.product(shp)).reshape(shp).astype(dtype)
+        idx = (slice(None), np.array([1, 0]), slice(None))
+        return a[idx]
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_1d_adv_indexing_gpu_idx(self, xp, dtype):
+        shp = (2, 3, 4)
+        a = xp.arange(np.product(shp)).reshape(shp).astype(dtype)
+        idx = (slice(None), xp.array([1, 0]), slice(None))
+        return a[idx]
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_2d_adv_indexing_gpu_idx(self, xp, dtype):
+        shp = (2, 3, 4)
+        a = xp.arange(np.product(shp)).reshape(shp).astype(dtype)
+        idx = (slice(None), xp.array([[0, 1], [1, 0]]), slice(None))
+        return a[idx]
+
+    def test_not_supported_arr_and_int(self):
+        shp = (2, 3, 4)
+        a = cupy.arange(np.product(shp)).reshape(shp)
+        idx = (slice(None), np.array([1, 0]), 1)
+        with self.assertRaises(NotImplementedError):
+            a[idx]
+
+    def test_not_supported_two_arr(self):
+        shp = (2, 3, 4)
+        a = cupy.arange(np.product(shp)).reshape(shp)
+        idx = (slice(None), np.array([1, 0]), np.array([1, 0]))
+        with self.assertRaises(NotImplementedError):
+            a[idx]
+
+    def test_not_supporeted_arr_and_none(self):
+        shp = (2, 3, 4)
+        a = cupy.arange(np.product(shp)).reshape(shp)
+        idx = (slice(None), np.array([1, 0]), None)
+        with self.assertRaises(NotImplementedError):
+            a[idx]

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -8,7 +8,8 @@ from cupy import testing
 
 @testing.parameterize(
     {'shape': (2, 3, 4), 'transpose': None, 'indexes': (slice(None), [1, 0])},
-    {'shape': (2, 3, 4), 'transpose': (1, 2, 0), 'indexes': (slice(None), [1, 0])},
+    {'shape': (2, 3, 4), 'transpose': (1, 2, 0),
+     'indexes': (slice(None), [1, 0])},
     {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, -1], slice(None))},
     {'shape': (2, 3, 4), 'transpose': None, 'indexes': (Ellipsis, [1, 0])},
     {'shape': (2, 3, 4), 'transpose': None, 'indexes': ([1, -1], Ellipsis)},
@@ -28,7 +29,8 @@ class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'shape': (2, 3, 4), 'transpose': None, 'indexes': (slice(None), cupy.array([1, 0]))},
+    {'shape': (2, 3, 4), 'transpose': None,
+     'indexes': (slice(None), cupy.array([1, 0]))},
     {'shape': (2, 3, 4), 'transpose': None, 'indexes': (numpy.array([1, 0],))},
 )
 @testing.gpu


### PR DESCRIPTION
The PR change `ndarray.__getitem__` to accept `ndarray` or `numpy.ndarray` in the argument. It checks for the `dtype` of arrays in the argument, and raise Error when necessary. Currently, only integer arrays are supported. 

The modification simply integrates `take` and `__getitem__`. With this PR, `a[:, idx]` returns same value as `a.take(idx, axis=1)`. 