### PR TITLE
Add support of flipud() and fliplr()

### DIFF
--- a/chainer/functions/array/fliplr.py
+++ b/chainer/functions/array/fliplr.py
@@ -1,0 +1,27 @@
+import numpy
+
+from chainer import cuda
+from chainer import function
+from chainer.utils import type_check
+
+class FlipLR(function.Function):
+    """Flip array in the left/right direction."""
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
+        return xp.fliplr(inputs[0]),
+
+    def backward(self, inputs, grads):
+        xp = cuda.get_array_module(*inputs)
+        return xp.fliplr(grads[0]),
+
+def fliplr(a):
+    """Flip array in the left/right direction.
+
+    Args:
+        xs (~chainer.Variable): Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+
+    """
+    return FlipLR()(*xs)

--- a/chainer/functions/array/flipud.py
+++ b/chainer/functions/array/flipud.py
@@ -1,0 +1,27 @@
+import numpy
+
+from chainer import cuda
+from chainer import function
+from chainer.utils import type_check
+
+class FlipUD(function.Function):
+    """Flip array in the up/down direction."""
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
+        return xp.flipud(inputs[0]),
+
+    def backward(self, inputs, grads):
+        xp = cuda.get_array_module(*inputs)
+        return xp.flipud(grads[0]),
+
+def flipud(a):
+    """Flip array in the up/down direction.
+
+    Args:
+        xs (~chainer.Variable): Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+
+    """
+    return FlipUD()(*xs)

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -1,9 +1,39 @@
 import cupy
 
-# TODO(okuta): Implement fliplr
+def fliplr(a):
+    """Flip array in the left/right direction.
+
+    Flip the entries in each row in the left/right direction. Columns
+    are preserved, but appear in a different order than before.
+
+    Args:
+        a (~cupy.ndarray): Input array.
+
+    Returns:
+        ~cupy.ndarray: Output array.
+
+    .. seealso:: :func:`numpy.fliplr`
+
+    """
+    return cupy.take(a, cupy.arange(a.shape[1] - 1, -1, -1), axis=1)
 
 
-# TODO(okuta): Implement flipud
+def flipud(a):
+    """Flip array in the up/down direction.
+
+    Flip the entries in each column in the up/down direction. Rows are
+    preserved, but appear in a different order than before.
+
+    Args:
+        a (~cupy.ndarray): Input array.
+
+    Returns:
+        ~cupy.ndarray: Output array.
+
+    .. seealso:: :func:`numpy.flipud`
+
+    """
+    return cupy.take(a, cupy.arange(a.shape[0] - 1, -1, -1), axis=0)
 
 
 def roll(a, shift, axis=None):


### PR DESCRIPTION
This pull request contains 4 features.

1. Implementation of cupy.flipud() which works same as numpy.flipud()
2. Implementation of cupy.fliplr()  which works same as numpy.fliplr()
3. Implementation of Functions.FlipUD which is a wrapper of cupy.flipud()
4. Implementation of Functions.FlipLR which is a wrapper of cupy.fliplr()

Because I am a novice programmer of matrix manipulation, my implementation may be quite slow, but I required it for my model.  I hope someone will improve them.
