### PR TITLE
Add cupy put

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -207,6 +207,7 @@ diagonal = indexing.indexing.diagonal
 ix_ = indexing.generate.ix_
 
 fill_diagonal = indexing.insert.fill_diagonal
+put = indexing.insert.put
 # -----------------------------------------------------------------------------
 # Input and output
 # -----------------------------------------------------------------------------

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -599,7 +599,7 @@ cdef class ndarray:
 
         .. seealso::
            :func:`cupy.put` for full documentation,
-           :meth: `numpy.ndarray.put`
+           :meth:`numpy.ndarray.put`
 
         """
         _put(self, ind, v, axis=None)
@@ -1987,10 +1987,8 @@ cpdef _put(ndarray a, ind, v, axis=None):
         (1,) * len(lshape) + ind.shape + (1,) * len(rshape))
     if axis == 0 or axis is None:
         _put_kernel_0axis(v, ind, rdim, index_range, a.reduced_view())
-        return
     else:
         _put_kernel(v, ind, cdim, rdim, adim, index_range, a.reduced_view())
-        return
 
 
 cpdef ndarray _diagonal(ndarray a, Py_ssize_t offset=0, Py_ssize_t axis1=0,

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -594,7 +594,7 @@ cdef class ndarray:
         """
         return _take(self, indices, axis, out)
 
-    cpdef put(self, ind, v, axis=None):
+    cpdef put(self, ind, v):
         """Replaces specified elements of an array with given values.
 
         .. seealso::
@@ -602,7 +602,7 @@ cdef class ndarray:
            :meth: `numpy.ndarray.put`
 
         """
-        _put(self, ind, v, axis)
+        _put(self, ind, v, axis=None)
         return
 
     cpdef repeat(self, repeats, axis=None):

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -3,18 +3,18 @@ import numpy
 # TODO(okuta): Implement place
 
 
-def put(a, ind, v, axis=None): 
+def put(a, ind, v, axis=None):
     """Replaces specified elements of an array with given values.
 
     .. note::
-     
+
        Currently CuPy behaves differently from Numpy when elements in ``ind``
        are not unique.
 
     Args:
         a (cupy.ndarray): Target array.
         ind (array_like): Target integer indices
-        v (array_like): Values to place in `a` at target indices. If `v` is 
+        v (array_like): Values to place in `a` at target indices. If `v` is
             shorter than `ind` it will be repeated as necessary.
         axis (int): The axis along which to select indices. The flattened input
             is used by default.

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -6,16 +6,27 @@ import numpy
 def put(a, ind, v):
     """Replaces specified elements of an array with given values.
 
-    .. note::
-
-       Currently CuPy behaves differently from Numpy when elements in ``ind``
-       are not unique.
-
     Args:
         a (cupy.ndarray): Target array.
         ind (array_like): Target integer indices
         v (array_like): Values to place in `a` at target indices. If `v` is
             shorter than `ind` it will be repeated as necessary.
+
+    .. note::
+
+       Currently CuPy behaves differently from Numpy when elements in ``ind``
+       are not unique.
+
+       Examples
+       --------
+       >>> a = cupy.zeros((2,))
+       >>> i = cupy.arange(10001) % 2
+       >>> v = cupy.arange(10000).astype(np.float)
+       >>> cupy.put(a, i, v)
+       >>> a
+       [9982. 9983.]
+
+     .. seealso:: :func:`numpy.put`
 
     """
     a.put(ind, v)

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -3,7 +3,24 @@ import numpy
 # TODO(okuta): Implement place
 
 
-# TODO(okuta): Implement put
+def put(a, ind, v, axis=None): 
+    """Replaces specified elements of an array with given values.
+
+    .. note::
+     
+       Currently CuPy behaves differently from Numpy when elements in ``ind``
+       are not unique.
+
+    Args:
+        a (cupy.ndarray): Target array.
+        ind (array_like): Target integer indices
+        v (array_like): Values to place in `a` at target indices. If `v` is 
+            shorter than `ind` it will be repeated as necessary.
+        axis (int): The axis along which to select indices. The flattened input
+            is used by default.
+
+    """
+    a.put(ind, v, axis)
 
 
 # TODO(okuta): Implement putmask

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -6,6 +6,8 @@ import numpy
 def put(a, ind, v):
     """Replaces specified elements of an array with given values.
 
+    This function does not support ``mode`` option.
+
     Args:
         a (cupy.ndarray): Target array.
         ind (array_like): Target integer indices

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -3,7 +3,7 @@ import numpy
 # TODO(okuta): Implement place
 
 
-def put(a, ind, v, axis=None):
+def put(a, ind, v):
     """Replaces specified elements of an array with given values.
 
     .. note::
@@ -16,11 +16,9 @@ def put(a, ind, v, axis=None):
         ind (array_like): Target integer indices
         v (array_like): Values to place in `a` at target indices. If `v` is
             shorter than `ind` it will be repeated as necessary.
-        axis (int): The axis along which to select indices. The flattened input
-            is used by default.
 
     """
-    a.put(ind, v, axis)
+    a.put(ind, v)
 
 
 # TODO(okuta): Implement putmask

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -9,8 +9,7 @@ def put(a, ind, v):
     Args:
         a (cupy.ndarray): Target array.
         ind (array_like): Target integer indices
-        v (array_like): Values to place in `a` at target indices. If `v` is
-            shorter than `ind` it will be repeated as necessary.
+        v (array_like): Values to place in ``a`` at target indices.
 
     .. note::
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -37,23 +37,23 @@ def wrap_take(array, *args, **kwargs):
 
 
 def wrap_put(a, ind, v, axis=None):
-    if get_array_module(a) == numpy:
+    if get_array_module(a) is numpy:
         if axis is not None and a.ndim != 0:
-            axis = axis % a.ndim
+            axis %= a.ndim
             slices = ([slice(None)] * axis +
                       [ind] + [slice(None)] * (a.ndim - axis - 1))
             a[slices] = v
         else:
             a.put(ind, v, mode='wrap')
     else:
-        core._put(a, ind, v, axis)
+        core.core._put(a, ind, v, axis)
 
 
 def compute_v_shape(in_shape, indices_shape, axis):
     if axis is None or len(in_shape) == 0:
         return indices_shape
     else:
-        axis = axis % len(in_shape)
+        axis %= len(in_shape)
         lshape = in_shape[:axis]
         rshape = in_shape[axis + 1:]
     return lshape + indices_shape + rshape
@@ -276,18 +276,19 @@ class TestScalaNdarrayPutWithInt(unittest.TestCase):
         return a
 
 
-@testing.parameterize(
-    {'shape': (3, 4, 5), 'indices': (2,), 'axis': 0, 'v_shape': (5,)},
-)
 @testing.gpu
 class TestNdarrayPutBroadcastInput(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_put(self, xp, dtype):
-        a = xp.zeros(self.shape, dtype=dtype)
-        v = testing.shaped_arange(self.v_shape, xp, dtype)
-        wrap_put(a, self.indices, v, self.axis)
+        shape = (3, 4, 5)
+        indices = (2,)
+        axis = 0
+        v_shape = (5,)
+        a = xp.zeros(shape, dtype=dtype)
+        v = testing.shaped_arange(v_shape, xp, dtype)
+        wrap_put(a, indices, v, axis)
         return a
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -46,7 +46,7 @@ def wrap_put(a, ind, v, axis=None):
         else:
             a.put(ind, v, mode='wrap')
     else:
-        a.put(ind, v, axis)
+        core._put(a, ind, v, axis)
 
 
 def compute_v_shape(in_shape, indices_shape, axis):


### PR DESCRIPTION
Merge after #1855 



This PR adds `cupy.put` that functions similarly to `numpy.put`, but different in the following way.
+ `numpy.put` handles values sequentially, whereas `cupy.put` does not. 

Here is an example that illustrates the difference.

```python
>>> a = xp.zeros((2,))

>>> i = xp.arange(10000) % 2
>>> v = xp.arange(10000).astype(np.float)

>>> xp.put(a, i, v)
```

On numpy, whenever there is duplicating indices, the index that appeared last is used to store a value.
```python
>>> print a  # when xp is numpy
[ 9998. 9999.]
```

Whereas, in my implementation of `cupy.put`, the duplicating indices do not get handled as Numpy does. Instead, the index that gets handled by the last called kernel thread that stores values.
```python
>>> print a  # when xp is cupy
[ 9982. 9983.]
```

This can be changed to be compatible to Numpy. However, it requires an extra kernel call to look for duplicates, which I am not sure if worth it.
I would like to hear feedback. Thanks.


##### UPDATE:
I decided to leave CuPy different from NumPy with a index of duplicating values for performance reason.