### PR TITLE
Update the error message about Cython's failure

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -205,7 +205,8 @@ def check_extensions(extensions):
         for f in x.sources:
             if not path.isfile(f):
                 msg = ('Missing file: %s\n' % f +
-                       'Please install Cython. Please also check the version of Cython.\n' +
+                       'Please install Cython. ' +
+                       'Please also check the version of Cython.\n' +
                        'See http://docs.chainer.org/en/stable/install.html')
                 raise RuntimeError(msg)
 

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -205,7 +205,7 @@ def check_extensions(extensions):
         for f in x.sources:
             if not path.isfile(f):
                 msg = ('Missing file: %s\n' % f +
-                       'Please install Cython.\n' +
+                       'Please install Cython. Please also check the version of Cython.\n' +
                        'See http://docs.chainer.org/en/stable/install.html')
                 raise RuntimeError(msg)
 


### PR DESCRIPTION
Even if old Cython is already installed, `setup.py` just says that `Please install Cython`. Making the message more informative would be beneficial.

![image](https://cloud.githubusercontent.com/assets/469803/20124301/cd1be120-a668-11e6-8516-ec358068c36e.png)
