### PR TITLE
Move broadcast_to to cupy.core.core

### DIFF
--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -37,6 +37,7 @@ ascontiguousarray = core.ascontiguousarray
 
 rollaxis = core.rollaxis
 broadcast = core.broadcast
+broadcast_to = core.broadcast_to
 
 
 # -----------------------------------------------------------------------------

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1661,6 +1661,13 @@ cdef class broadcast:
 
 
 cpdef ndarray broadcast_to(ndarray array, shape):
+    """Broadcast an array to a given shape.
+
+    .. seealso::
+        :func:`cupy.broadcast_to` for full documentation,
+        :meth:`numpy.broadcast_to`
+
+    """
     if array.ndim > len(shape):
         raise ValueError(
             'input operand has more dimensions than allowed by the axis '

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1659,6 +1659,28 @@ cdef class broadcast:
 
         self.values = tuple(broadcasted)
 
+
+cpdef ndarray broadcast_to(ndarray array, shape):
+    if array.ndim > len(shape):
+        raise ValueError(
+            'input operand has more dimensions than allowed by the axis '
+            'remapping')
+
+    strides = [0] * len(shape)
+    for i in range(array.ndim):
+        j = -i - 1
+        sh = shape[j]
+        a_sh = array.shape[j]
+        if sh == a_sh:
+            strides[j] = array._strides[j % array.ndim]
+        elif a_sh != 1:
+            raise ValueError('Broadcasting failed')
+
+    view = array.view()
+    view._set_shape_and_strides(shape, strides)
+    return view
+
+
 cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     """Repeat arrays along an axis.
 

--- a/cupy/manipulation/dims.py
+++ b/cupy/manipulation/dims.py
@@ -136,7 +136,7 @@ def broadcast_to(array, shape):
     .. seealso:: :func:`numpy.broadcast_to`
 
     """
-    return core.core.broadcast_to(array, shape)
+    return core.broadcast_to(array, shape)
 
 
 def expand_dims(a, axis):

--- a/cupy/manipulation/dims.py
+++ b/cupy/manipulation/dims.py
@@ -136,24 +136,7 @@ def broadcast_to(array, shape):
     .. seealso:: :func:`numpy.broadcast_to`
 
     """
-    if array.ndim > len(shape):
-        raise ValueError(
-            'input operand has more dimensions than allowed by the axis '
-            'remapping')
-
-    strides = [0] * len(shape)
-    for i in range(array.ndim):
-        j = -i - 1
-        sh = shape[j]
-        a_sh = array.shape[j]
-        if sh == a_sh:
-            strides[j] = array._strides[j]
-        elif a_sh != 1:
-            raise ValueError('Broadcasting failed')
-
-    view = array.view()
-    view._set_shape_and_strides(shape, strides)
-    return view
+    return core.core.broadcast_to(array, shape)
 
 
 def expand_dims(a, axis):


### PR DESCRIPTION
This PR moves `broadcast_to` from `cupy/manipulation/dims.py` to `cupy/core/core.pyx`. This is necessary for methods inside of `core` to call `broadcast_to`.

Some changes being made include ...
+ the method is now defined by `cpdef`.
+ on line 1682 of `core.pyx`, `j` is changed to `j % array.ndim`. This is necessary because `_strides` does not accept negative values as index