### PR TITLE
Try to build shared library to check dependent libraries

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -82,9 +82,14 @@ def check_library(compiler, includes=(), libraries=(),
     source = ''.join(['#include <%s>\n' % header for header in includes])
     source += 'int main(int argc, char* argv[]) {return 0;}'
     try:
-        build.build_and_run(compiler, source, libraries,
-                            include_dirs, library_dirs)
-    except Exception:
+        # We need to try to build a shared library because distutils
+        # uses different option to build an executable and a shared library.
+        # Especially when a user build an executable, distutils does not use
+        # LDFLAGS environment variable.
+        build.build_shlib(compiler, source, libraries,
+                          include_dirs, library_dirs)
+    except Exception as e:
+        print(e)
         return False
     return True
 

--- a/install/build.py
+++ b/install/build.py
@@ -109,6 +109,34 @@ def check_cudnn_version(compiler, settings):
     return True
 
 
+def build_shlib(compiler, source, libraries=(),
+                include_dirs=(), library_dirs=()):
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        fname = os.path.join(temp_dir, 'a.cpp')
+        with open(fname, 'w') as f:
+            f.write(source)
+
+        objects = compiler.compile([fname], output_dir=temp_dir,
+                                   include_dirs=include_dirs)
+        
+        try:
+            postargs = ['/MANIFEST'] if sys.platform == 'win32' else []
+            compiler.link_shared_lib(objects,
+                                     os.path.join(temp_dir, 'a'),
+                                     libraries=libraries,
+                                     library_dirs=library_dirs,
+                                     extra_postargs=postargs,
+                                     target_lang='c++')
+        except Exception as e:
+            msg = 'Cannot build a stub file.\nOriginal error: {0}'.format(e)
+            raise Exception(msg)
+
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
 def build_and_run(compiler, source, libraries=(),
                   include_dirs=(), library_dirs=()):
     temp_dir = tempfile.mkdtemp()

--- a/install/build.py
+++ b/install/build.py
@@ -120,7 +120,7 @@ def build_shlib(compiler, source, libraries=(),
 
         objects = compiler.compile([fname], output_dir=temp_dir,
                                    include_dirs=include_dirs)
-        
+
         try:
             postargs = ['/MANIFEST'] if sys.platform == 'win32' else []
             compiler.link_shared_lib(objects,


### PR DESCRIPTION
I fixed setup script to build a shared library when it checks libraries, because distutils doesn't check LDFLAGS when it build an executable.