### PR TITLE
Fix norm test to avoid numpy v1.10 bug

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -30,7 +30,7 @@ class TestTrace(unittest.TestCase):
     'keepdims': [True, False],
 }) + testing.product({
     'shape': [(1, 2), (2, 2)],
-    'ord': [-numpy.Inf, -1, 1, numpy.Inf, 'fro'],
+    'ord': [-numpy.Inf, -1, 1, numpy.Inf],
     'axis': [(0, 1), None],
     'keepdims': [True, False],
 }) + testing.product({
@@ -46,6 +46,26 @@ class TestTrace(unittest.TestCase):
 })
 )
 @testing.gpu
+class TestNorm(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, type_check=False)
+    def test_trace(self, xp, dtype):
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        with testing.NumpyError(divide='ignore'):
+            return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(1, 2), (2, 2)],
+    'ord': ['fro'],
+    'axis': [(0, 1), None],
+    'keepdims': [True, False],
+}))
+@testing.gpu
+@testing.with_requires('numpy>=1.11')
 class TestNorm(unittest.TestCase):
 
     _multiprocess_can_split_ = True


### PR DESCRIPTION
This is test result with numpy 1.10.4.
```
nosetests tests/cupy_tests/linalg_tests/test_norms.py
......F........................................................................................................................................................................F........
======================================================================
FAIL: test_trace (test_norms.TestNorm_param_103)  parameter: {'ord': 'fro', 'shape': (2, 2), 'keepdims': False, 'axis': None}
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/okuta/env/chainer/chainer/cupy/testing/helper.py", line 403, in test_func
    impl(self, *args, **kw)
  File "/home/okuta/env/chainer/chainer/cupy/testing/helper.py", line 114, in test_func
    check_func(cupy_result, numpy_result)
  File "/home/okuta/env/chainer/chainer/cupy/testing/helper.py", line 164, in check_func
    rtol, atol, err_msg, verbose)
  File "/home/okuta/env/chainer/chainer/cupy/testing/array.py", line 26, in assert_allclose
    rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)
  File "/home/okuta/env/chainer/.direnv/python-2.7.12/lib/python2.7/site-packages/numpy/testing/utils.py", line 1359, in assert_allclose
    verbose=verbose, header=header)
  File "/home/okuta/env/chainer/.direnv/python-2.7.12/lib/python2.7/site-packages/numpy/testing/utils.py", line 713, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Not equal to tolerance rtol=0.001, atol=0.0001

(mismatch 100.0%)
 x: array(1.4142135623730951)
 y: array(1.0, dtype=float32)
-------------------- >> begin captured stdout << ---------------------
dtype is <type 'numpy.bool_'>

--------------------- >> end captured stdout << ----------------------

======================================================================
FAIL: test_trace (test_norms.TestNorm_param_93)  parameter: {'ord': 'fro', 'shape': (2, 2), 'keepdims': True, 'axis': None}
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/okuta/env/chainer/chainer/cupy/testing/helper.py", line 403, in test_func
    impl(self, *args, **kw)
▽File "/home/okuta/env/chainer/chainer/cupy/testing/helper.py", line 114, in test_func
    check_func(cupy_result, numpy_result)
  File "/home/okuta/env/chainer/chainer/cupy/testing/helper.py", line 164, in check_func
    rtol, atol, err_msg, verbose)
  File "/home/okuta/env/chainer/chainer/cupy/testing/array.py", line 26, in assert_allclose
    rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)
  File "/home/okuta/env/chainer/.direnv/python-2.7.12/lib/python2.7/site-packages/numpy/testing/utils.py", line 1359, in assert_allclose
    verbose=verbose, header=header)
  File "/home/okuta/env/chainer/.direnv/python-2.7.12/lib/python2.7/site-packages/numpy/testing/utils.py", line 713, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Not equal to tolerance rtol=0.001, atol=0.0001

(mismatch 100.0%)
 x: array([[ 1.414214]])
 y: array([[ 1.]], dtype=float32)
-------------------- >> begin captured stdout << ---------------------
dtype is <type 'numpy.bool_'>

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 184 tests in 7.609s

FAILED (failures=2)
```