### PR TITLE
Fix norm result dtype and test it

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -22,20 +22,17 @@ def norm(x, ord=None, axis=None, keepdims=False):
         cupy.ndarray
 
     """
-    if not issubclass(x.dtype.type, (numpy.inexact, numpy.object_)):
+    if not issubclass(x.dtype.type, numpy.inexact):
         x = x.astype(float)
 
     # Immediately handle some default, simple, fast, and common cases.
     if axis is None:
         ndim = x.ndim
-        if ((ord is None) or (ord in ('f', 'fro') and ndim == 2) or
-                (ord == 2 and ndim == 1)):
-
-            x = x.ravel()
-            sqnorm = cupy.sum(x ** 2)
-            ret = cupy.sqrt(sqnorm)
+        if (ord is None or (ndim == 1 and ord == 2) or
+                (ndim == 2 and ord in ('f', 'fro'))):
+            ret = cupy.sqrt(cupy.sum(x.ravel() ** 2))
             if keepdims:
-                ret = ret.reshape(ndim * [1])
+                ret = ret.reshape((1,) * ndim)
             return ret
 
     # Normalize the `axis` argument to a tuple.
@@ -57,7 +54,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             return abs(x).min(axis=axis, keepdims=keepdims)
         elif ord == 0:
             # Zero norm
-            return (x != 0).sum(axis=axis, keepdims=keepdims, dtype=x.dtype)
+            return (x != 0).sum(axis=axis, keepdims=keepdims, dtype='d')
         elif ord == 1:
             # special case for speedup
             return abs(x).sum(axis=axis, keepdims=keepdims)
@@ -70,9 +67,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 float(ord)
             except TypeError:
                 raise ValueError("Invalid norm order for vectors.")
-            absx = abs(x)
+            absx = abs(x).astype('d')
             absx **= ord
-            return absx.sum(axis=axis, keepdims=keepdims) ** (1.0 / ord)
+            ret = absx.sum(axis=axis, keepdims=keepdims)
+            ret **= (1.0 / ord)
+            return ret
     elif len(axis) == 2:
         row_axis, col_axis = axis
         if row_axis < 0:

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -54,6 +54,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             return abs(x).min(axis=axis, keepdims=keepdims)
         elif ord == 0:
             # Zero norm
+            # Convert to Python float in accordance with NumPy
             return (x != 0).sum(axis=axis, keepdims=keepdims, dtype='d')
         elif ord == 1:
             # special case for speedup

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -46,7 +46,7 @@ class TestTrace(unittest.TestCase):
 })
 )
 @testing.gpu
-@testing.with_requires('numpy>=1.11.2')
+@testing.with_requires('numpy>=1.11.2')  # The old version dtype is strange
 class TestNorm(unittest.TestCase):
 
     _multiprocess_can_split_ = True

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -46,12 +46,14 @@ class TestTrace(unittest.TestCase):
 })
 )
 @testing.gpu
+@testing.with_requires('numpy>=1.11.2')
 class TestNorm(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, type_check=False)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_trace(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
+        with testing.NumpyError(divide='ignore'):
+            return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)


### PR DESCRIPTION
Old version `norm` is not tested about result dtype.
Old version `numpy.norm` is broken, because `numpy.sqrt` is broken (it is fixed at v1.11.2).