### PR TITLE
Add multiple integer indexing & basic/adv indexing for __getitem__

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1063,10 +1063,10 @@ cdef class ndarray:
         advanced = False
         axis = None
         for i, s in enumerate(slices):
-            if isinstance(s, list):
-                s = numpy.array(s)
+            if isinstance(s, (list, numpy.ndarray)):
+                s = array(s)
                 slices[i] = s
-            if isinstance(s, (numpy.ndarray, ndarray)):
+            if isinstance(s, ndarray):
                 if issubclass(s.dtype.type, numpy.integer):
                     if advanced:
                         advanced = True

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -15,7 +15,7 @@ def perm(iterable):
     *testing.product({
         'shape': [(4, 4, 4)],
         'indexes': (
-            perm(([1, 0], slice(None))) + 
+            perm(([1, 0], slice(None))) +
             perm(([1, 0], Ellipsis)) +
             perm(([1, 2], None, slice(None))) +
             perm(([1, 0], 1, slice(None))) +
@@ -53,6 +53,7 @@ class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
     def test_adv_getitem(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
         return a[self.indexes]
+
 
 @testing.parameterize(
     {'shape': (2, 3, 4), 'transpose': (1, 2, 0),

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -1,35 +1,38 @@
 import unittest
 
+import itertools
 import numpy
 
 import cupy
 from cupy import testing
 
 
+def perm(iterable):
+    return list(itertools.permutations(iterable))
+
+
 @testing.parameterize(
-    {'shape': (2, 3, 4), 'indexes': (slice(None), [1, 0])},
-    {'shape': (2, 3, 4), 'indexes': (slice(None), [1, 0])},
-    {'shape': (2, 3, 4), 'indexes': ([1, -1], slice(None))},
-    {'shape': (2, 3, 4), 'indexes': (Ellipsis, [1, 0])},
-    {'shape': (2, 3, 4), 'indexes': ([1, -1], Ellipsis)},
-    {'shape': (2, 3, 4),
-     'indexes': (slice(None), slice(None), [[1, -1], [0, 3]])},
-    {'shape': (2, 3, 4), 'indexes': ([1, 0], [2, 1])},
-    {'shape': (2, 3, 4), 'indexes': (slice(None), [1, 0], [2, 1])},
-    {'shape': (2, 3), 'indexes': ([[0, 1], [1, 0]], [[1, 1], [2, 1]])},
-    # array appears with split
-    {'shape': (2, 3, 4), 'indexes': ([0, 1], slice(None), [1, 0])},
-    {'shape': (2, 3, 4), 'indexes': ([0, 1], slice(None), 1)},
-    {'shape': (2, 3, 4), 'indexes': ([1, 0], slice(0, 3, 2), [1, 0])},
-    # three arrays
-    {'shape': (2, 3, 4), 'indexes': ([1, 0], [2, 1], [3, 1])},
-    {'shape': (2, 3, 4), 'indexes': ([1, 0], 1, [3, 1])},
-    {'shape': (2, 3, 4), 'indexes': ([1, 0], 1, None, [3, 1])},
-    # index broadcasting
-    {'shape': (2, 3, 4), 'indexes': (slice(None), [1, 2], [[1, 0], [0, 1], [-1, 1]])},
+    *testing.product({
+        'shape': [(4, 4, 4)],
+        'indexes': (
+            perm(([1, 0], slice(None))) + 
+            perm(([1, 0], Ellipsis)) +
+            perm(([1, 2], None, slice(None))) +
+            perm(([1, 0], 1, slice(None))) +
+            perm(([1, 2], slice(0, 2), slice(None))) +
+            perm((1, [1, 2], 1)) +
+            perm(([[1, -1], [0, 3]], slice(None), slice(None))) +
+            perm(([1, 0], [3, 2], slice(None))) +
+            perm((slice(0, 3, 2), [1, 2], [1, 0])) +
+            perm(([1, 0], [2, 1], [3, 1])) +
+            perm(([1, 0], 1, [3, 1])) +
+            perm(([1, 2], [[1, 0], [0, 1], [-1, 1]], slice(None))) +
+            perm((None, [1, 2], [1, 0]))
+        )
+    })
 )
 @testing.gpu
-class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
+class TestArrayAdvancedIndexingPerm(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
merge after #1832  

This PR makes CuPy's `__getitem__` handle any combination of `:`, `None`, `Ellipsis`, `integer array` that NumPy can handle. This PR does not support `boolean array`.
This extends #1832 by adding supports for ...

+ multiple integer array (e.g. `a[[1, 0], [0, 1]]`)
+ combination of basic indexing and integer array (e.g. `a[1:3, [1, 0, 2]]`)

NumPy advanced array indexing specification is sometimes complicating.
A notable example is a case when array indices are not located next to each other.
Here is an example with indices located next to each other.
```python
>>> shp = (3, 4, 5, 6)
>>> a = np.arange(np.prod(shp)).reshape(shp)
>>> b = [1, 0]; c = [2, 1]
>>> idx = (slice(None), b, c, slice(None))
>>> a[idx].shape
(3, 2, 6)
```

and one where indices are not located next to each other.
```python
>>> shp = (3, 4, 5, 6)
>>> a = np.arange(np.prod(shp)).reshape(shp)
>>> b = [1, 0]; c = [2, 1]
>>> idx = (slice(None), b, slice(None), c)
>>> a[idx].shape
(2, 3, 5)
```

When array indices are not located next to each other, the array axis and slices are reordered so that the array indices are in the first `k` elements of slices.
This means that `a.transpose(1, 3, 0, 2)[b, c, slice(None), slice(None)]` and `a[slice(None), b, slice(None), c]` are same.

Not only that, the transpose rule is true even in the case when one of the indices is an integer.
From what I tested, NumPy handles an integer index as (1,) array in the case when advanced indexing is needed.
```python
>>> shp = (3, 4, 5, 6)
>>> a = np.arange(np.prod(shp)).reshape(shp)
>>> b = [1, 0]; c = 1
>>> idx = (slice(None), b, slice(None), c)
>>> a[idx].shape
(2, 3, 5)
```