### PR TITLE
Move part of concatenate to cupy.core.core

### DIFF
--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -38,6 +38,7 @@ ascontiguousarray = core.ascontiguousarray
 rollaxis = core.rollaxis
 broadcast = core.broadcast
 broadcast_to = core.broadcast_to
+concatenate = core.concatenate
 
 
 # -----------------------------------------------------------------------------

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1769,6 +1769,20 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
         offset += repeats[i]
     return ret
 
+
+cpdef ndarray concatenate(tup, axis, shape, dtype):
+    cdef ndarray ret
+    ret = ndarray(shape, dtype=dtype)
+
+    skip = (slice(None),) * axis
+    i = 0
+    for a in tup:
+        aw = a.shape[axis]
+        ret[skip + (slice(i, i + aw),)] = a
+        i += aw
+ 
+    return ret
+
 # -----------------------------------------------------------------------------
 # Binary operations
 # -----------------------------------------------------------------------------

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1780,7 +1780,7 @@ cpdef ndarray concatenate(tup, axis, shape, dtype):
         aw = a.shape[axis]
         ret[skip + (slice(i, i + aw),)] = a
         i += aw
- 
+
     return ret
 
 # -----------------------------------------------------------------------------

--- a/cupy/manipulation/join.py
+++ b/cupy/manipulation/join.py
@@ -2,6 +2,7 @@ import numpy
 import six
 
 import cupy
+from cupy import core
 
 
 def column_stack(tup):
@@ -75,16 +76,7 @@ def concatenate(tup, axis=0):
         raise ValueError('Cannot concatenate from empty tuple')
 
     dtype = numpy.find_common_type([a.dtype for a in tup], [])
-    ret = cupy.empty(shape, dtype=dtype)
-
-    skip = (slice(None),) * axis
-    i = 0
-    for a in tup:
-        aw = a.shape[axis]
-        ret[skip + (slice(i, i + aw),)] = a
-        i += aw
-
-    return ret
+    return core.concatenate(tup, axis, shape, dtype)
 
 
 def dstack(tup):


### PR DESCRIPTION
This PR moves `concatenate` from `cupy/manipulation/join.py` to `cupy/core/core.pyx`.
I needed `concatenate` in `cupy.core.core` in #1863.

I had choice of either...
+ copy the entire function in `cupy/manipulation/join.py`.
+ exclude part that handles irregular cases.

I decided the latter in my implementation.