### PR TITLE
Fix GIL bug when call cuLaunchKernel

### DIFF
--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -33,7 +33,7 @@ cdef extern from "cupy_cuda.h":
         unsigned int gridDimZ, unsigned int blockDimX,
         unsigned int blockDimY, unsigned int blockDimZ,
         unsigned int sharedMemBytes, Stream hStream,
-        void** kernelParams, void** extra)
+        void** kernelParams, void** extra) nogil
 
 
 ###############################################################################
@@ -106,9 +106,10 @@ cpdef launchKernel(
         unsigned int block_dim_y, unsigned int block_dim_z,
         unsigned int shared_mem_bytes, size_t stream, size_t kernel_params,
         size_t extra):
-    status = cuLaunchKernel(
-        <Function>f, grid_dim_x, grid_dim_y, grid_dim_z,
-        block_dim_x, block_dim_y, block_dim_z,
-        shared_mem_bytes, <Stream>stream,
-        <void**>kernel_params, <void**>extra)
+    with nogil:
+        status = cuLaunchKernel(
+            <Function>f, grid_dim_x, grid_dim_y, grid_dim_z,
+            block_dim_x, block_dim_y, block_dim_z,
+            shared_mem_bytes, <Stream>stream,
+            <void**>kernel_params, <void**>extra)
     check_status(status)


### PR DESCRIPTION
`./train_imagenet.py` had stopped in my environment.
