### PR TITLE
Only test matmul on numpy>=1.10

### DIFF
--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -45,6 +45,7 @@ class TestMatmul(unittest.TestCase):
 
     @unittest.skipUnless(sys.version_info >= (3, 5),
                          'Only for Python3.5 or higher')
+    @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes(name='dtype1')
     @testing.for_all_dtypes(name='dtype2')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-4)  # required for uint8
@@ -55,6 +56,7 @@ class TestMatmul(unittest.TestCase):
         x2 = xp.array(self.x2, dtype=dtype2)
         return operator.matmul(x1, x2)
 
+    @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes(name='dtype1')
     @testing.for_all_dtypes(name='dtype2')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-4)  # required for uint8


### PR DESCRIPTION
Only numpy>=1.10 supports `numpy.matmul`.