### PR TITLE
Experimental feature

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -130,3 +130,5 @@ basic_math.install_variable_arithmetics()
 array.get_item.install_variable_get_item()
 
 init_weight = initializers.init_weight
+
+disable_experimental_feature_warning = False

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -4,8 +4,8 @@ from chainer.utils import walker_alias  # NOQA
 
 
 # import class and function
-from chainer.utils.walker_alias import WalkerAlias  # NOQA
 from chainer.utils.experimental import experimental  # NOQA
+from chainer.utils.walker_alias import WalkerAlias  # NOQA
 
 
 def force_array(x, dtype=None):

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,7 +1,7 @@
 import numpy
 
-from chainer.utils import walker_alias
 from chainer.utils import experimental as experimental_
+from chainer.utils import walker_alias
 
 WalkerAlias = walker_alias.WalkerAlias
 experimental = experimental_.experimental

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,8 +1,10 @@
 import numpy
 
 from chainer.utils import walker_alias
+from chainer.utils import experimental as experimental_
 
 WalkerAlias = walker_alias.WalkerAlias
+experimental = experimental_.experimental
 
 
 def force_array(x, dtype=None):

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -6,7 +6,7 @@ import warnings
 def experimental(api_name=None):
     """A function for marking APIs as experimental
 
-    Developer of the API can mark it as *experimental* by calling
+    The developer of the API can mark it as *experimental* by calling
     this function. When users call experimental APIs, `FutureWarning`
     is raised once for each experimental API.
     The presentation of `FutureWarning` is disabled by setting

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -3,7 +3,7 @@ import warnings
 
 
 def experimental(api_name):
-    """A function for marking APIs as experimental.
+    """Declares that user is using an experimental feature.
 
     The developer of an API can mark it as *experimental* by calling
     this function. When users call experimental APIs, :class:`FutureWarning`
@@ -65,8 +65,8 @@ The interface can change in the future.
         ... FutureWarning: chainer.foo.C is an experimental API. \
 The interface can change in the future
 
-    If we want to mark ``__init__`` method only, rather than class itself.
-    It is recommended that we explicitly feed its API name.
+    If we want to mark ``__init__`` method only, rather than class itself,
+    it is recommended that we explicitly feed its API name.
 
     .. testcode::
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -13,11 +13,64 @@ def experimental(api_name=None):
     `chainer.disable_experimental_warning` to `True`,
     which is `False` by default.
 
+    The basic usage is to call it in the function or method we want to
+    mark as experimental.
+
+    >>> from chainer.utils import experiment
+    ...
+    ... def f(x):
+    ...   experiment()
+    ...   # concrete implementation of f follows
+    ...
+    ... f(1)
+    FutureWarning: f is an experimental API. The interface can change in the future
+
+    By default, if the caller is a function, its name is used as an API name,
+    while if the caller is a method or a class mehtod,
+    `<class name>.<method name>` is used.
+
+    >>> class C(object):
+    ...   def f(self):
+    ...     experiment()
+    ...
+    ... c = C()
+    ... c.f()
+    FutureWarning: C.f is an experimental API. The interface can change in the future
+
+    We can also define the name of experimental API name as an argument.
+    It will use in the warning that will be issued.
+
+    >>> def g(x):
+    ...   experiment('My function')
+    ...
+    ... g(1)
+    FutureWarning: g is an experimental API. The interface can change in the future
+
+    If we want mark whole class, you should call this function
+    in its `__init__` method.
+
+    >>> class C():
+    ...   def __init__(self):
+    ...     experiment()
+
+    >>> C()
+    FutureWarning: C is an experimental API. The interface can change in the future
+    
+    If we want to mark `__init__` method only, rather than class itself.
+    It is recommended that we explicitly feed its API name.
+
+    >>> class D():
+    ...   def __init__(self):
+    ...     experiment('D.__init__')
+    FutureWarning: D.__init__ is an experimental API. The interface can change in the future
+
     Args:
         api_name(str): The name of an API marked as experimental.
-            If it is `None`, it is inferred from the caller.
-            If the caller is a function, its name is used.
-            If the caller is a method or a class mehtod,
+            If it is `None`, it is inferred from the caller by the following rule.
+            * If the caller is a function, its name is used.
+            * If the caller is `__init__` method of a class,
+            The class name of the method is used.
+            * If the caller is a method (other than `__init__`) of a class or a class mehtod,
             `<class name>.<method name>` is used.
     """
 
@@ -26,10 +79,13 @@ def experimental(api_name=None):
 
         frame = inspect.stack()[1][0]
         f_locals = frame.f_locals
-        if 'self' in f_locals:
+        if 'self' in f_locals:  # The caller is a method.
             class_name = f_locals['self'].__class__.__name__
-            api_name = class_name + '.' + api_name
-        elif 'cls' in f_locals:
+            if api_name == '__init__':
+                api_name = class_name
+            else:
+                api_name = class_name + '.' + api_name
+        elif 'cls' in f_locals:  # The caller is class method.
             class_name = f_locals['cls'].__name__
             api_name = class_name + '.' + api_name
 

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -4,6 +4,22 @@ import warnings
 
 
 def experimental(api_name=None):
+    """A function for marking APIs as experimental
+
+    Developer of the API can mark it as *experimental* by calling
+    this function. When users call experimental APIs, `FutureWarning`
+    is raised once for each experimental API.
+    The presentation of `FutureWarning` is disabled by setting
+    `chainer.disable_experimental_warning` to `True`,
+    which is `False` by default.
+
+    Args:
+        api_name(str): The name of an API marked as experimental.
+            If it is `None`, it is inferred from the caller.
+            If the caller is a function, its name is used.
+            If the caller is a method or a class mehtod,
+            `<class name>.<method name>` is used.
+    """
 
     if api_name is None:
         api_name = inspect.stack()[1][3]

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -23,7 +23,8 @@ def experimental(api_name):
         warnings.simplefilter('always')
 
         def wrapper(message, category, filename, lineno, file=None, line=None):
-            sys.stdout.write(warnings.formatwarning(message, category, filename, lineno))
+            sys.stdout.write(warnings.formatwarning(
+                message, category, filename, lineno))
 
         showwarning_orig = warnings.showwarning
         warnings.showwarning = wrapper

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -17,7 +17,9 @@ def experimental(api_name):
 
     .. testsetup::
 
+        import sys
         import warnings
+
         warnings.simplefilter('always')
 
         def wrapper(message, category, filename, lineno, file=None, line=None):

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -18,10 +18,10 @@ def experimental(api_name=None):
 
     By default, if the caller is a function, its name is used as an API name.
 
-    >>> from chainer.utils import experiment
+    >>> from chainer.utils import experimental
     ...
     ... def f(x):
-    ...   experiment()
+    ...   experimental()
     ...   # concrete implementation of f follows
     ...
     ... f(1)
@@ -33,7 +33,7 @@ The interface can change in the future.
 
     >>> class C(object):
     ...   def f(self):
-    ...     experiment()
+    ...     experimental()
     ...
     ... c = C()
     ... c.f()
@@ -45,7 +45,7 @@ The interface can change in the future
     This function will use it in the warning issued.
 
     >>> def g(x):
-    ...   experiment('My function')
+    ...   experimental('My function')
     ...
     ... g(1)
     FutureWarning: My function is an experimental API. \
@@ -56,7 +56,7 @@ The interface can change in the future
 
     >>> class C():
     ...   def __init__(self):
-    ...     experiment()
+    ...     experimental()
     ...
     ... C()
     FutureWarning: C is an experimental API. \
@@ -67,7 +67,7 @@ The interface can change in the future
 
     >>> class D():
     ...   def __init__(self):
-    ...     experiment('D.__init__')
+    ...     experimental('D.__init__')
     ...
     ... D()
     FutureWarning: D.__init__ is an experimental API. \

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -15,14 +15,25 @@ def experimental(api_name):
     The basic usage is to call it in the function or method we want to
     mark as experimental along with the API name.
 
-    >>> from chainer.utils import experimental
-    ...
-    ... def f(x):
-    ...   experimental('chainer.foo.bar.f')
-    ...   # concrete implementation of f follows
-    ...
-    ... f(1)
-    FutureWarning: chainer.experimental.f is an experimental API. \
+    .. testcode::
+        :hide:
+
+        import warnings
+        warnings.simplefilter('always')
+
+
+    .. testcode::
+        from chainer.utils import experimental
+
+        def f(x):
+          experimental('chainer.foo.bar.f')
+          # concrete implementation of f follows
+
+        f(1)
+
+    .. testoutput::
+
+         FutureWarning: chainer.experimental.f is an experimental API. \
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -1,0 +1,20 @@
+import chainer
+import warnings
+import inspect
+
+
+def experimental(api_name=None):
+
+    if api_name is None:
+        api_name = inspect.stack()[1][3]
+
+        frame = inspect.stack()[1][0]
+        f_locals = frame.f_locals
+        if 'self' in f_locals:
+            class_name = f_locals['self'].__class__.__name__
+            api_name = class_name + '.' + api_name
+
+    if not chainer.disable_experimental_feature_warning:
+        warnings.warn('{} is an experimental API. '
+                      'The interface can change in the future'.format(api_name),
+                      FutureWarning)

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -2,7 +2,7 @@ import chainer
 import warnings
 
 
-def experimental(api_name=None):
+def experimental(api_name):
     """A function for marking APIs as experimental.
 
     The developer of an API can mark it as *experimental* by calling

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -1,5 +1,4 @@
 import chainer
-import inspect
 import warnings
 
 
@@ -14,52 +13,27 @@ def experimental(api_name=None):
     which is ``False`` by default.
 
     The basic usage is to call it in the function or method we want to
-    mark as experimental.
-
-    By default, if the caller is a function, its name is used as an API name.
+    mark as experimental along with the API name.
 
     >>> from chainer.utils import experimental
     ...
     ... def f(x):
-    ...   experimental()
+    ...   experimental('chainer.foo.bar.f')
     ...   # concrete implementation of f follows
     ...
     ... f(1)
-    FutureWarning: f is an experimental API. \
+    FutureWarning: chainer.experimental.f is an experimental API. \
 The interface can change in the future.
 
-    If the caller is a method or a class mehtod,
-    ``<class name>.<method name>`` is used instead.
-
-    >>> class C(object):
-    ...   def f(self):
-    ...     experimental()
-    ...
-    ... c = C()
-    ... c.f()
-    FutureWarning: C.f is an experimental API. \
-The interface can change in the future
-
-    We can also define the name of experimental
-    API name with ``api_name`` argument.
-    This function will use it in the warning issued.
-
-    >>> def g(x):
-    ...   experimental('My function')
-    ...
-    ... g(1)
-    FutureWarning: My function is an experimental API. \
-The interface can change in the future
-
-    If we want to mark a whole class, you should call this function
-    in its `__init__` method.
+    We can also make a whole class experimental. In that case,
+    we should call this function in its `__init__` method.
 
     >>> class C():
     ...   def __init__(self):
-    ...     experimental()
+    ...     experimental('chainer.foo.C')
     ...
     ... C()
-    FutureWarning: C is an experimental API. \
+    FutureWarning: chainer.foo.C is an experimental API. \
 The interface can change in the future
 
     If we want to mark ``__init__`` method only, rather than class itself.
@@ -73,32 +47,17 @@ The interface can change in the future
     FutureWarning: D.__init__ is an experimental API. \
 The interface can change in the future
 
+    Currently, we do not have any sophisticated way to mark some usage of
+    non-experimental function as experimental.
+    But we can support such usage by explicitly branching it.
+
+    >>> def g(x, experimental_arg=None):
+    ...   if experimental_arg is not None:
+    ...     experimental('experimental_arg of chainer.foo.g')
+
     Args:
         api_name(str): The name of an API marked as experimental.
-            If it is ``None``, it is inferred from the
-            caller by the following rule:
-            If the caller is a function, its name is used.
-            If the caller is a ``__init__`` method of a class,
-            the name of the class is used.
-            If the caller is a class method or
-            a method other than ``__init__``,
-            ``<class name>.<method name>`` is used.
     """
-
-    if api_name is None:
-        api_name = inspect.stack()[1][3]
-
-        frame = inspect.stack()[1][0]
-        f_locals = frame.f_locals
-        if 'self' in f_locals:  # The caller is a method.
-            class_name = f_locals['self'].__class__.__name__
-            if api_name == '__init__':
-                api_name = class_name
-            else:
-                api_name = class_name + '.' + api_name
-        elif 'cls' in f_locals:  # The caller is class method.
-            class_name = f_locals['cls'].__name__
-            api_name = class_name + '.' + api_name
 
     if not chainer.disable_experimental_feature_warning:
         warnings.warn('{} is an experimental API. '

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -29,6 +29,9 @@ def experimental(api_name=None):
         if 'self' in f_locals:
             class_name = f_locals['self'].__class__.__name__
             api_name = class_name + '.' + api_name
+        elif 'cls' in f_locals:
+            class_name = f_locals['cls'].__name__
+            api_name = class_name + '.' + api_name
 
     if not chainer.disable_experimental_feature_warning:
         warnings.warn('{} is an experimental API. '

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -4,17 +4,19 @@ import warnings
 
 
 def experimental(api_name=None):
-    """A function for marking APIs as experimental
+    """A function for marking APIs as experimental.
 
-    The developer of the API can mark it as *experimental* by calling
-    this function. When users call experimental APIs, `FutureWarning`
-    is raised once for each experimental API.
-    The presentation of `FutureWarning` is disabled by setting
-    `chainer.disable_experimental_warning` to `True`,
-    which is `False` by default.
+    The developer of an API can mark it as *experimental* by calling
+    this function. When users call experimental APIs, :class:`FutureWarning`
+    is issued.
+    The presentation of :class:`FutureWarning` is disabled by setting
+    ``chainer.disable_experimental_warning`` to ``True``,
+    which is ``False`` by default.
 
     The basic usage is to call it in the function or method we want to
     mark as experimental.
+
+    By default, if the caller is a function, its name is used as an API name.
 
     >>> from chainer.utils import experiment
     ...
@@ -23,11 +25,11 @@ def experimental(api_name=None):
     ...   # concrete implementation of f follows
     ...
     ... f(1)
-    FutureWarning: f is an experimental API. The interface can change in the future
+    FutureWarning: f is an experimental API. \
+The interface can change in the future.
 
-    By default, if the caller is a function, its name is used as an API name,
-    while if the caller is a method or a class mehtod,
-    `<class name>.<method name>` is used.
+    If the caller is a method or a class mehtod,
+    ``<class name>.<method name>`` is used instead.
 
     >>> class C(object):
     ...   def f(self):
@@ -35,43 +37,52 @@ def experimental(api_name=None):
     ...
     ... c = C()
     ... c.f()
-    FutureWarning: C.f is an experimental API. The interface can change in the future
+    FutureWarning: C.f is an experimental API. \
+The interface can change in the future
 
-    We can also define the name of experimental API name as an argument.
-    It will use in the warning that will be issued.
+    We can also define the name of experimental
+    API name with ``api_name`` argument.
+    This function will use it in the warning issued.
 
     >>> def g(x):
     ...   experiment('My function')
     ...
     ... g(1)
-    FutureWarning: g is an experimental API. The interface can change in the future
+    FutureWarning: My function is an experimental API. \
+The interface can change in the future
 
-    If we want mark whole class, you should call this function
+    If we want to mark a whole class, you should call this function
     in its `__init__` method.
 
     >>> class C():
     ...   def __init__(self):
     ...     experiment()
+    ...
+    ... C()
+    FutureWarning: C is an experimental API. \
+The interface can change in the future
 
-    >>> C()
-    FutureWarning: C is an experimental API. The interface can change in the future
-    
-    If we want to mark `__init__` method only, rather than class itself.
+    If we want to mark ``__init__`` method only, rather than class itself.
     It is recommended that we explicitly feed its API name.
 
     >>> class D():
     ...   def __init__(self):
     ...     experiment('D.__init__')
-    FutureWarning: D.__init__ is an experimental API. The interface can change in the future
+    ...
+    ... D()
+    FutureWarning: D.__init__ is an experimental API. \
+The interface can change in the future
 
     Args:
         api_name(str): The name of an API marked as experimental.
-            If it is `None`, it is inferred from the caller by the following rule.
-            * If the caller is a function, its name is used.
-            * If the caller is `__init__` method of a class,
-            The class name of the method is used.
-            * If the caller is a method (other than `__init__`) of a class or a class mehtod,
-            `<class name>.<method name>` is used.
+            If it is ``None``, it is inferred from the
+            caller by the following rule:
+            If the caller is a function, its name is used.
+            If the caller is a ``__init__`` method of a class,
+            the name of the class is used.
+            If the caller is a class method or
+            a method other than ``__init__``,
+            ``<class name>.<method name>`` is used.
     """
 
     if api_name is None:
@@ -91,6 +102,6 @@ def experimental(api_name=None):
 
     if not chainer.disable_experimental_feature_warning:
         warnings.warn('{} is an experimental API. '
-                      'The interface can change in the future'.format(
+                      'The interface can change in the future.'.format(
                           api_name),
                       FutureWarning)

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -15,52 +15,67 @@ def experimental(api_name):
     The basic usage is to call it in the function or method we want to
     mark as experimental along with the API name.
 
-    .. doctest::
-        :hide:
+    .. testsetup::
 
-        >>> import warnings
-        ... warnings.simplefilter('always')
+        import warnings
+        warnings.simplefilter('always')
 
-    .. doctest::
-        >>> from chainer.utils import experimental
-        ...
-        ... def f(x):
-        ...  experimental('chainer.foo.bar.f')
-        ...  # concrete implementation of f follows
-        ...
-        ... f(1)
+    .. testcode::
+
+        from chainer.utils import experimental
+
+        def f(x):
+            experimental('chainer.foo.bar.f')
+            # concrete implementation of f follows
+
+        f(1)
+
+    .. testoutput::
+
         FutureWarning: chainer.experimental.f is an experimental API. \
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,
     we should call this function in its `__init__` method.
 
-    >>> class C():
-    ...   def __init__(self):
-    ...     experimental('chainer.foo.C')
-    ...
-    ... C()
-    FutureWarning: chainer.foo.C is an experimental API. \
+    .. testcode::
+
+        class C():
+            def __init__(self):
+              experimental('chainer.foo.C')
+
+        C()
+
+    .. testoutput::
+
+        FutureWarning: chainer.foo.C is an experimental API. \
 The interface can change in the future
 
     If we want to mark ``__init__`` method only, rather than class itself.
     It is recommended that we explicitly feed its API name.
 
-    >>> class D():
-    ...   def __init__(self):
-    ...     experimental('D.__init__')
-    ...
-    ... D()
-    FutureWarning: D.__init__ is an experimental API. \
+    .. testcode::
+
+        class D():
+            def __init__(self):
+                experimental('D.__init__')
+
+        D()
+
+    .. testoutput::
+
+        FutureWarning: D.__init__ is an experimental API. \
 The interface can change in the future
 
     Currently, we do not have any sophisticated way to mark some usage of
     non-experimental function as experimental.
     But we can support such usage by explicitly branching it.
 
-    >>> def g(x, experimental_arg=None):
-    ...   if experimental_arg is not None:
-    ...     experimental('experimental_arg of chainer.foo.g')
+    .. testcode::
+
+        def g(x, experimental_arg=None):
+            if experimental_arg is not None:
+                experimental('experimental_arg of chainer.foo.g')
 
     Args:
         api_name(str): The name of an API marked as experimental.

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -1,6 +1,6 @@
 import chainer
-import warnings
 import inspect
+import warnings
 
 
 def experimental(api_name=None):
@@ -16,5 +16,6 @@ def experimental(api_name=None):
 
     if not chainer.disable_experimental_feature_warning:
         warnings.warn('{} is an experimental API. '
-                      'The interface can change in the future'.format(api_name),
+                      'The interface can change in the future'.format(
+                          api_name),
                       FutureWarning)

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -33,6 +33,7 @@ def experimental(api_name):
         warnings.showwarning = showwarning_orig
 
     .. testcode::
+        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         from chainer.utils import experimental
 
@@ -44,13 +45,14 @@ def experimental(api_name):
 
     .. testoutput::
 
-        FutureWarning: chainer.experimental.f is an experimental API. \
+        ... FutureWarning: chainer.experimental.f is an experimental API. \
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,
     we should call this function in its ``__init__`` method.
 
     .. testcode::
+        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         class C():
             def __init__(self):
@@ -60,13 +62,14 @@ The interface can change in the future.
 
     .. testoutput::
 
-        FutureWarning: chainer.foo.C is an experimental API. \
+        ... FutureWarning: chainer.foo.C is an experimental API. \
 The interface can change in the future
 
     If we want to mark ``__init__`` method only, rather than class itself.
     It is recommended that we explicitly feed its API name.
 
     .. testcode::
+        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         class D():
             def __init__(self):
@@ -76,7 +79,7 @@ The interface can change in the future
 
     .. testoutput::
 
-        FutureWarning: D.__init__ is an experimental API. \
+       ...  FutureWarning: D.__init__ is an experimental API. \
 The interface can change in the future
 
     Currently, we do not have any sophisticated way to mark some usage of

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -15,25 +15,21 @@ def experimental(api_name):
     The basic usage is to call it in the function or method we want to
     mark as experimental along with the API name.
 
-    .. testcode::
+    .. doctest::
         :hide:
 
-        import warnings
-        warnings.simplefilter('always')
+        >>> import warnings
+        ... warnings.simplefilter('always')
 
-
-    .. testcode::
-        from chainer.utils import experimental
-
-        def f(x):
-          experimental('chainer.foo.bar.f')
-          # concrete implementation of f follows
-
-        f(1)
-
-    .. testoutput::
-
-         FutureWarning: chainer.experimental.f is an experimental API. \
+    .. doctest::
+        >>> from chainer.utils import experimental
+        ...
+        ... def f(x):
+        ...  experimental('chainer.foo.bar.f')
+        ...  # concrete implementation of f follows
+        ...
+        ... f(1)
+        FutureWarning: chainer.experimental.f is an experimental API. \
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -20,6 +20,16 @@ def experimental(api_name):
         import warnings
         warnings.simplefilter('always')
 
+        def wrapper(message, category, filename, lineno, file=None, line=None):
+            sys.stdout.write(warnings.formatwarning(message, category, filename, lineno))
+
+        showwarning_orig = warnings.showwarning
+        warnings.showwarning = wrapper
+
+    .. testcleanup::
+
+        warnings.showwarning = showwarning_orig
+
     .. testcode::
 
         from chainer.utils import experimental

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -60,7 +60,7 @@ The interface can change in the future
     """
 
     if not chainer.disable_experimental_feature_warning:
-        warnings.warn('{} is an experimental API. '
+        warnings.warn('{} is experimental. '
                       'The interface can change in the future.'.format(
                           api_name),
                       FutureWarning)

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -48,7 +48,7 @@ def experimental(api_name):
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,
-    we should call this function in its `__init__` method.
+    we should call this function in its ``__init__`` method.
 
     .. testcode::
 

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -90,8 +90,8 @@ Once experimental APIs get stable, they cannot be experimental again.
 When users use experimental APIs for the first time, warnings are raised once for each experimental API,
 unless users explicitly disable the emission of the warnings in advance.
 
-See the document of `chainer.utils.experimental` how developers mark APIs as experimental practically.
-and how users enable or disable the warnings.
+See the document of `chainer.utils.experimental` how developers mark APIs as experimental
+and how users enable or disable the warnings practically..
 
 .. note::
    It is up to developers if APIs should be annotated as experimental or not.

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -68,6 +68,8 @@ The actual change should be done in the following steps:
 - At the major update announced in the above update, change the API.
 
 
+.. module:: chainer.utils
+
 Experimental APIs
 -----------------
 
@@ -91,7 +93,7 @@ Once experimental APIs become stable, they cannot revert to experimental again.
 When users use experimental APIs for the first time, warnings are raised once for each experimental API,
 unless users explicitly disable the emission of the warnings in advance.
 
-See the document of `chainer.utils.experimental` how developers mark APIs as experimental
+See the document of :meth:`chainer.utils.experimental` how developers mark APIs as experimental
 and how users enable or disable the warnings practically..
 
 .. note::

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -98,7 +98,7 @@ and how users enable or disable the warnings practically..
 
 .. note::
    It is up to developers if APIs should be annotated as experimental or not.
-   We recommend to make the APIs experimental if they implemnt large modules or
+   We recommend to make the APIs experimental if they implement large modules or
    make a decision from several design choices.
 
 

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -94,7 +94,7 @@ When users use experimental APIs for the first time, warnings are raised once fo
 unless users explicitly disable the emission of the warnings in advance.
 
 See the document of :meth:`chainer.utils.experimental` how developers mark APIs as experimental
-and how users enable or disable the warnings practically..
+and how users enable or disable the warnings practically.
 
 .. note::
    It is up to developers if APIs should be annotated as experimental or not.

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -68,6 +68,37 @@ The actual change should be done in the following steps:
 - At the major update announced in the above update, change the API.
 
 
+Experimental APIs
+-----------------
+
+Thanks to many contributors, we have introduced many new features to Chainer.
+But sometimes it was only after we released the new features that we noticed that their APIs are not appropriate.
+The objective of experimental APIs is to alleviate the design failure of them.
+
+Any newly added API can be marked as *experimental*.
+Any API that is not experimental is called *stable* in this document.
+
+.. note::
+    Undocumented behaviors are not considered as APIs. So they are not experimental nor stable.
+    The treatment of undocumented behaviors are descibed in :ref:`undocumented_behavior` section.
+
+Chainer can change the interfaces and documents of experimental APIs at **any** version up.
+This change is not considered as a break of backward compatibility.
+Chainer can remove experimental mark of APIs and make them stable at any **minor** or **major** version up.
+Once experimental APIs get stable, they cannot be experimental again.
+
+When users use experimental APIs for the first time, warnings are raised once for each experimental API,
+unless users explicitly disable the emission of the warnings in advance.
+
+See the document of `chainer.utils.experimental` how developers mark APIs as experimental practically.
+and how users enable or disable the warnings.
+
+.. note::
+   It is up to developers if APIs should be annotated as experimental or not.
+   We recommend to make the APIs experimental if they implemnt large modules or
+   make a decision from several design choices.
+
+
 Supported Backward Compatibility
 --------------------------------
 
@@ -83,6 +114,8 @@ In other words, codes only based on the documented features run correctly with m
 
 Developers are encouraged to use apparent names for objects of implementation details.
 For example, attributes outside of the documented APIs should have one or more underscores at the prefix of their names.
+
+.. _undocumented_behavior:
 
 Undocumented behaviors
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -72,8 +72,9 @@ Experimental APIs
 -----------------
 
 Thanks to many contributors, we have introduced many new features to Chainer.
-But sometimes it was only after we released the new features that we noticed that their APIs are not appropriate.
-The objective of experimental APIs is to alleviate the design failure of them.
+
+However, we have sometimes released new features only to later notice that their APIs are not appropriate.
+The objective of experimental APIs is to avoid such issues by allowing the developer to mark any newly added API as experimental.
 
 Any newly added API can be marked as *experimental*.
 Any API that is not experimental is called *stable* in this document.
@@ -84,8 +85,8 @@ Any API that is not experimental is called *stable* in this document.
 
 Chainer can change the interfaces and documents of experimental APIs at **any** version up.
 This change is not considered as a break of backward compatibility.
-Chainer can remove experimental mark of APIs and make them stable at any **minor** or **major** version up.
-Once experimental APIs get stable, they cannot be experimental again.
+Chainer can promote an experimental API to become stable at any **minor** or **major** version up.
+Once experimental APIs become stable, they cannot revert to experimental again.
 
 When users use experimental APIs for the first time, warnings are raised once for each experimental API,
 unless users explicitly disable the emission of the warnings in advance.

--- a/docs/source/reference/util.rst
+++ b/docs/source/reference/util.rst
@@ -7,3 +7,4 @@ Utilities
    util/cuda
    util/algorithm
    util/reporter
+   util/experimental

--- a/docs/source/reference/util/experimental.rst
+++ b/docs/source/reference/util/experimental.rst
@@ -1,0 +1,5 @@
+Experimental feature annotation
+-------------------------------
+.. automodule:: chainer.utils
+
+.. autofunction:: experimental

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -31,6 +31,9 @@ class C(object):
     def __init__(self):
         utils.experimental()
 
+    def f(self):
+        utils.experimental()
+
 
 class TestExperimental(unittest.TestCase):
 
@@ -63,7 +66,19 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('C.__init__ is an experimental API.', str(w[0].message))
+        self.assertIn('C is an experimental API.', str(w[0].message))
+
+    def test_experimental_with_no_api_name_2(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            c = C()
+
+        with warnings.catch_warnings(record=True) as w:
+            c.f()
+
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, FutureWarning)
+        self.assertIn('C.f is an experimental API.', str(w[0].message))
 
     def test_experimental_static_method(self):
         with warnings.catch_warnings(record=True) as w:

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -124,7 +124,7 @@ class TestExperimentalDuplicate(unittest.TestCase):
 class TestDisableExperimentalWarning(unittest.TestCase):
 
     def setUp(self):
-        self.original = chainer.disablpe_experimental_feature_warning
+        self.original = chainer.disable_experimental_feature_warning
         chainer.disable_experimental_feature_warning = True
 
     def tearDown(self):

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -45,42 +45,41 @@ class TestExperimental(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             f()
 
-        assert len(w) == 1
-        assert issubclass(w[0].category, FutureWarning)
-        assert 'test.f is an experimental API.' in str(w[0].message)
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, FutureWarning)
+        self.assertIn('test.f is an experimental API.', str(w[0].message))
 
     def test_experimental_with_no_api_name(self):
         with warnings.catch_warnings(record=True) as w:
             g()
 
-        assert len(w) == 1
-        assert issubclass(w[0].category, FutureWarning)
-        assert 'g is an experimental API.' in str(w[0].message)
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, FutureWarning)
+        self.assertIn('g is an experimental API.', str(w[0].message))
 
     def test_experimental_with_no_api_name_2(self):
         with warnings.catch_warnings(record=True) as w:
             C()
 
-        assert len(w) == 1
-        assert issubclass(w[0].category, FutureWarning)
-        assert 'C.__init__ is an experimental API.' in str(w[0].message)
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, FutureWarning)
+        self.assertIn('C.__init__ is an experimental API.', str(w[0].message))
 
     def test_experimental_static_method(self):
         with warnings.catch_warnings(record=True) as w:
             C.static_method()
 
-        assert len(w) == 1
-        assert issubclass(w[0].category, FutureWarning)
-        assert 'static_method is an experimental API.' in str(w[0].message)
-
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, FutureWarning)
+        self.assertIn('static_method is an experimental API.', str(w[0].message))
 
     def test_experimental_class_method(self):
         with warnings.catch_warnings(record=True) as w:
             C.class_method()
 
-        assert len(w) == 1
-        assert issubclass(w[0].category, FutureWarning)
-        assert 'C.class_method is an experimental API.' in str(w[0].message)
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, FutureWarning)
+        self.assertIn('C.class_method is an experimental API.', str(w[0].message))
 
 
 class TestExperimentalDuplicate(unittest.TestCase):
@@ -97,28 +96,28 @@ class TestExperimentalDuplicate(unittest.TestCase):
             f()
             f()
 
-        assert len(w) == 1
+        self.assertEqual(len(w), 1)
 
     def test_different_functions(self):
         with warnings.catch_warnings(record=True) as w:
             f()
             g()
 
-        assert len(w) == 2
+        self.assertEqual(len(w), 2)
 
     def test_multiple_same_class_instantiation(self):
         with warnings.catch_warnings(record=True) as w:
             C()
             C()
 
-        assert len(w) == 1
+        self.assertEqual(len(w), 1)
 
     def test_multiple_calls_with_different_argument(self):
         with warnings.catch_warnings(record=True) as w:
             h(0)
             h(1)
 
-        assert len(w) == 1
+        self.assertEqual(len(w), 1)
 
 
 class TestDisableExperimentalWarning(unittest.TestCase):
@@ -134,7 +133,7 @@ class TestDisableExperimentalWarning(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             f()
 
-        assert len(w) == 0
+        self.assertEqual(len(w), 0)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -43,7 +43,7 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('f is an experimental API.', str(w[0].message))
+        self.assertIn('f is experimental.', str(w[0].message))
 
     def test_experimental_with_no_api_name_2(self):
         with warnings.catch_warnings(record=True) as w:
@@ -52,7 +52,7 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('C is an experimental API.', str(w[0].message))
+        self.assertIn('C is experimental.', str(w[0].message))
 
     def test_experimental_with_no_api_name_3(self):
         with warnings.catch_warnings():
@@ -65,7 +65,7 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('C.f is an experimental API.', str(w[0].message))
+        self.assertIn('C.f is experimental.', str(w[0].message))
 
     def test_experimental_static_method(self):
         with warnings.catch_warnings(record=True) as w:
@@ -74,7 +74,7 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('static_method is an experimental API.',
+        self.assertIn('static_method is experimental.',
                       str(w[0].message))
 
     def test_experimental_class_method(self):
@@ -84,7 +84,7 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('C.class_method is an experimental API.',
+        self.assertIn('C.class_method is experimental.',
                       str(w[0].message))
 
 

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -71,7 +71,8 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('static_method is an experimental API.', str(w[0].message))
+        self.assertIn('static_method is an experimental API.',
+                      str(w[0].message))
 
     def test_experimental_class_method(self):
         with warnings.catch_warnings(record=True) as w:
@@ -79,7 +80,8 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('C.class_method is an experimental API.', str(w[0].message))
+        self.assertIn('C.class_method is an experimental API.',
+                      str(w[0].message))
 
 
 class TestExperimentalDuplicate(unittest.TestCase):

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -7,32 +7,24 @@ from chainer import utils
 
 
 def f():
-    utils.experimental('test.f')
-
-
-def g():
-    utils.experimental()
-
-
-def h(x):
-    utils.experimental()
+    utils.experimental('f')
 
 
 class C(object):
 
     @staticmethod
     def static_method():
-        utils.experimental()
+        utils.experimental('static_method')
 
     @classmethod
     def class_method(cls):
-        utils.experimental()
+        utils.experimental('C.class_method')
 
     def __init__(self):
-        utils.experimental()
+        utils.experimental('C')
 
     def f(self):
-        utils.experimental()
+        utils.experimental('C.f')
 
 
 class TestExperimental(unittest.TestCase):
@@ -51,16 +43,7 @@ class TestExperimental(unittest.TestCase):
 
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('test.f is an experimental API.', str(w[0].message))
-
-    def test_experimental_with_no_api_name(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            g()
-
-        self.assertEqual(len(w), 1)
-        self.assertIs(w[0].category, FutureWarning)
-        self.assertIn('g is an experimental API.', str(w[0].message))
+        self.assertIn('f is an experimental API.', str(w[0].message))
 
     def test_experimental_with_no_api_name_2(self):
         with warnings.catch_warnings(record=True) as w:

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -1,0 +1,68 @@
+import unittest
+import chainer
+from chainer import utils
+import warnings
+
+
+def f():
+    utils.experimental('test.f')
+
+def g():
+    utils.experimental()
+    
+
+class C(object):
+
+    def __init__(self):
+        utils.experimental()
+
+
+class TestExperimental(unittest.TestCase):
+
+    def setUp(self):
+        self.original = chainer.disable_experimental_feature_warning
+        chainer.disable_experimental_feature_warning = False
+
+    def tearDown(self):
+        chainer.disable_experimental_feature_warning = self.original
+
+    def test_experimental_with_api_name(self):
+        with warnings.catch_warnings(record=True) as w:
+            f()
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert 'test.f is an experimental API.' in str(w[0].message)
+
+    def test_experimental_with_no_api_name(self):
+        with warnings.catch_warnings(record=True) as w:
+            g()
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert 'g is an experimental API.' in str(w[0].message)
+        
+    def test_experimental_with_no_api_name_2(self):
+        with warnings.catch_warnings(record=True) as w:
+            C()
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert 'C.__init__ is an experimental API.' in str(w[0].message)
+
+
+
+class TestDisableExperimentalWarning(unittest.TestCase):
+
+    def setUp(self):
+        self.original = chainer.disable_experimental_feature_warning
+        chainer.disable_experimental_feature_warning = True
+
+    def tearDown(self):
+        chainer.disable_experimental_feature_warning = self.original
+
+    def test_experimental(self):
+        with warnings.catch_warnings(record=True) as w:
+            f()
+
+        assert len(w) == 0

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -20,6 +20,14 @@ def h(x):
 
 class C(object):
 
+    @staticmethod
+    def static_method():
+        utils.experimental()
+
+    @classmethod
+    def class_method(cls):
+        utils.experimental()
+
     def __init__(self):
         utils.experimental()
 
@@ -56,6 +64,33 @@ class TestExperimental(unittest.TestCase):
         assert len(w) == 1
         assert issubclass(w[0].category, FutureWarning)
         assert 'C.__init__ is an experimental API.' in str(w[0].message)
+
+    def test_experimental_static_method(self):
+        with warnings.catch_warnings(record=True) as w:
+            C.static_method()
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert 'static_method is an experimental API.' in str(w[0].message)
+
+
+    def test_experimental_class_method(self):
+        with warnings.catch_warnings(record=True) as w:
+            C.class_method()
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert 'C.class_method is an experimental API.' in str(w[0].message)
+
+
+class TestExperimentalDuplicate(unittest.TestCase):
+
+    def setUp(self):
+        self.original = chainer.disable_experimental_feature_warning
+        chainer.disable_experimental_feature_warning = False
+
+    def tearDown(self):
+        chainer.disable_experimental_feature_warning = self.original
 
     def test_multiple_same_function_calls(self):
         with warnings.catch_warnings(record=True) as w:

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -71,7 +71,7 @@ class TestExperimental(unittest.TestCase):
         self.assertIs(w[0].category, FutureWarning)
         self.assertIn('C is an experimental API.', str(w[0].message))
 
-    def test_experimental_with_no_api_name_2(self):
+    def test_experimental_with_no_api_name_3(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             c = C()

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -77,6 +77,7 @@ class TestExperimental(unittest.TestCase):
             c = C()
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             c.f()
 
         self.assertEqual(len(w), 1)

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -11,6 +11,10 @@ def g():
     utils.experimental()
     
 
+def h(x):
+    utils.experimental()
+
+
 class C(object):
 
     def __init__(self):
@@ -50,6 +54,34 @@ class TestExperimental(unittest.TestCase):
         assert issubclass(w[0].category, FutureWarning)
         assert 'C.__init__ is an experimental API.' in str(w[0].message)
 
+
+    def test_multiple_same_function_calls(self):
+        with warnings.catch_warnings(record=True) as w:
+            f()
+            f()
+
+        assert len(w) == 1
+
+    def test_different_functions(self):
+        with warnings.catch_warnings(record=True) as w:
+            f()
+            g()
+
+        assert len(w) == 2
+
+    def test_multiple_same_class_instantiation(self):
+        with warnings.catch_warnings(record=True) as w:
+            C()
+            C()
+
+        assert len(w) == 1
+
+    def test_multiple_calls_with_different_argument(self):
+        with warnings.catch_warnings(record=True) as w:
+            h(0)
+            h(1)
+
+        assert len(w) == 1
 
 
 class TestDisableExperimentalWarning(unittest.TestCase):

--- a/tests/chainer_tests/utils_tests/test_experimental.py
+++ b/tests/chainer_tests/utils_tests/test_experimental.py
@@ -1,15 +1,18 @@
 import unittest
-import chainer
-from chainer import utils
 import warnings
+
+import chainer
+from chainer import testing
+from chainer import utils
 
 
 def f():
     utils.experimental('test.f')
 
+
 def g():
     utils.experimental()
-    
+
 
 def h(x):
     utils.experimental()
@@ -45,7 +48,7 @@ class TestExperimental(unittest.TestCase):
         assert len(w) == 1
         assert issubclass(w[0].category, FutureWarning)
         assert 'g is an experimental API.' in str(w[0].message)
-        
+
     def test_experimental_with_no_api_name_2(self):
         with warnings.catch_warnings(record=True) as w:
             C()
@@ -53,7 +56,6 @@ class TestExperimental(unittest.TestCase):
         assert len(w) == 1
         assert issubclass(w[0].category, FutureWarning)
         assert 'C.__init__ is an experimental API.' in str(w[0].message)
-
 
     def test_multiple_same_function_calls(self):
         with warnings.catch_warnings(record=True) as w:
@@ -87,7 +89,7 @@ class TestExperimental(unittest.TestCase):
 class TestDisableExperimentalWarning(unittest.TestCase):
 
     def setUp(self):
-        self.original = chainer.disable_experimental_feature_warning
+        self.original = chainer.disablpe_experimental_feature_warning
         chainer.disable_experimental_feature_warning = True
 
     def tearDown(self):
@@ -98,3 +100,6 @@ class TestDisableExperimentalWarning(unittest.TestCase):
             f()
 
         assert len(w) == 0
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds a function that marks an API as *experimental*.

* Developer can mark any newly added API as experimental by calling `chainer.utils.experimental`.
* Chainer can modify the interfaces of experimental APIs at any version up.
* Chainer can remove experimental mark at any minor or major version up and consider the API as *stable*. Once APIs get stable, they cannot be *experimental* again in principle.
* If users use an experimental API for the first time,`FutureWarning` is raised (one warning for each experimental API)
* Users can disable the warning by setting `chainer.disable_experimental_feature_warning`to `False`