### PR TITLE
Extend element size limit for cupy array

### DIFF
--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -39,7 +39,7 @@ class SelectItem(function.Function):
             y = cuda.elementwise(
                 'S t, raw T x',
                 'T y',
-                'ssize_t ind[] = {i, t}; y = x[ind];',
+                'ptrdiff_t ind[] = {i, t}; y = x[ind];',
                 'getitem_fwd'
             )(t, x)
             return y,
@@ -58,7 +58,7 @@ class SelectItem(function.Function):
         gx = cuda.elementwise(
             'S t, T gloss',
             'raw T gx',
-            'ssize_t ind[] = {i, t}; gx[ind] = gloss;',
+            'ptrdiff_t ind[] = {i, t}; gx[ind] = gloss;',
             'getitem_bwd'
         )(t, gloss, gx)
         return gx, None

--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -39,7 +39,7 @@ class SelectItem(function.Function):
             y = cuda.elementwise(
                 'S t, raw T x',
                 'T y',
-                'int ind[] = {i, t}; y = x[ind];',
+                'ssize_t ind[] = {i, t}; y = x[ind];',
                 'getitem_fwd'
             )(t, x)
             return y,
@@ -58,7 +58,7 @@ class SelectItem(function.Function):
         gx = cuda.elementwise(
             'S t, T gloss',
             'raw T gx',
-            'int ind[] = {i, t}; gx[ind] = gloss;',
+            'ssize_t ind[] = {i, t}; gx[ind] = gloss;',
             'getitem_bwd'
         )(t, gloss, gx)
         return gx, None

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -61,7 +61,10 @@ class EmbedIDFunction(function.Function):
             if self.ignore_label is None:
                 cuda.elementwise(
                     'T gy, int32 x, int32 n_out', 'raw T gW',
-                    'int w_ind[] = {x, i % n_out}; atomicAdd(&gW[w_ind], gy)',
+                    '''
+                    ssize_t w_ind[] = {x, i % n_out};
+                    atomicAdd(&gW[w_ind], gy);
+                    ''',
                     'embed_id_bwd')(
                         gy, xp.expand_dims(x, -1), gW.shape[1], gW)
             else:
@@ -69,7 +72,7 @@ class EmbedIDFunction(function.Function):
                     'T gy, int32 x, int32 n_out, int32 ignore', 'raw T gW',
                     '''
                     if (x != ignore) {
-                      int w_ind[] = {x, i % n_out};
+                      ssize_t w_ind[] = {x, i % n_out};
                       atomicAdd(&gW[w_ind], gy);
                     }
                     ''',

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -62,7 +62,7 @@ class EmbedIDFunction(function.Function):
                 cuda.elementwise(
                     'T gy, int32 x, int32 n_out', 'raw T gW',
                     '''
-                    ssize_t w_ind[] = {x, i % n_out};
+                    ptrdiff_t w_ind[] = {x, i % n_out};
                     atomicAdd(&gW[w_ind], gy);
                     ''',
                     'embed_id_bwd')(
@@ -72,7 +72,7 @@ class EmbedIDFunction(function.Function):
                     'T gy, int32 x, int32 n_out, int32 ignore', 'raw T gW',
                     '''
                     if (x != ignore) {
-                      ssize_t w_ind[] = {x, i % n_out};
+                      ptrdiff_t w_ind[] = {x, i % n_out};
                       atomicAdd(&gW[w_ind], gy);
                     }
                     ''',

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -125,8 +125,8 @@ class ConnectionistTemporalClassification(function.Function):
                     '''
                     T value = z;
                     I c = i % b_max, b = i / b_max;
-                    ssize_t ind[2] = {b, -1};
-                    for (ssize_t index = 0; index < c_max; ++index) {
+                    ptrdiff_t ind[2] = {b, -1};
+                    for (ptrdiff_t index = 0; index < c_max; ++index) {
                         ind[1] = index;
                         if (ind[1] < l[ind[0]] && y[ind] == c) {
                             T xvalue = x[ind];

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -125,8 +125,8 @@ class ConnectionistTemporalClassification(function.Function):
                     '''
                     T value = z;
                     I c = i % b_max, b = i / b_max;
-                    int ind[2] = {b, -1};
-                    for (int index = 0; index < c_max; ++index) {
+                    ssize_t ind[2] = {b, -1};
+                    for (ssize_t index = 0; index < c_max; ++index) {
                         ind[1] = index;
                         if (ind[1] < l[ind[0]] && y[ind] == c) {
                             T xvalue = x[ind];

--- a/chainer/functions/loss/hinge.py
+++ b/chainer/functions/loss/hinge.py
@@ -8,7 +8,7 @@ from chainer.utils import type_check
 def _hinge_fwd_kernel():
     return cuda.elementwise(
         'S t', 'raw T bottom_diff',
-        'int ind[] = {i, t}; bottom_diff[ind] *= -1',
+        'ssize_t ind[] = {i, t}; bottom_diff[ind] *= -1',
         'hinge_fwd')
 
 

--- a/chainer/functions/loss/hinge.py
+++ b/chainer/functions/loss/hinge.py
@@ -8,7 +8,7 @@ from chainer.utils import type_check
 def _hinge_fwd_kernel():
     return cuda.elementwise(
         'S t', 'raw T bottom_diff',
-        'ssize_t ind[] = {i, t}; bottom_diff[ind] *= -1',
+        'ptrdiff_t ind[] = {i, t}; bottom_diff[ind] *= -1',
         'hinge_fwd')
 
 

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -64,8 +64,8 @@ class NegativeSamplingFunction(function.Function):
             T f = 0;
             if (mask == 1) {
                 for (int j = 0; j < c; ++j) {
-                  int x_ind[] = {(i / m), j};
-                  int w_ind[] = {k, j};
+                  ssize_t x_ind[] = {(i / m), j};
+                  ssize_t w_ind[] = {k, j};
                   f += x[x_ind] * W[w_ind];
                 }
             }
@@ -133,7 +133,7 @@ class NegativeSamplingFunction(function.Function):
               y = -1;
             }
 
-            g = -y * gloss[0] / (1.0f + __expf(wx * y));
+            g = -y * gloss[0L] / (1.0f + __expf(wx * y));
             ''',
             'negative_sampling_calculate_g'
         )(self.wx, gloss, self.sample_size + 1)
@@ -141,11 +141,11 @@ class NegativeSamplingFunction(function.Function):
         cuda.elementwise(
             'raw T g, raw T W, bool mask, raw S k, int32 c, int32 m', 'T gx',
             '''
-            int d = i / c;
+            ssize_t d = i / c;
             T w = 0;
             if (mask == 1){
                 for (int j = 0; j < m; ++j) {
-                  w += g[d * m + j] * W[k[d * m + j] * c + i % c];
+                  w += g[d * m + j] * W[(ssize_t)k[d * m + j] * c + i % c];
                 }
             }
             gx = w;
@@ -160,7 +160,7 @@ class NegativeSamplingFunction(function.Function):
             '''
             T gi = g;
             if (mask == 1) {
-                for (int j = 0; j < c; ++j) {
+                for (ssize_t j = 0; j < c; ++j) {
                   atomicAdd(&gW[k * c + j], gi * x[(i / m) * c + j]);
                 }
             }

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -64,8 +64,8 @@ class NegativeSamplingFunction(function.Function):
             T f = 0;
             if (mask == 1) {
                 for (int j = 0; j < c; ++j) {
-                  ssize_t x_ind[] = {(i / m), j};
-                  ssize_t w_ind[] = {k, j};
+                  ptrdiff_t x_ind[] = {(i / m), j};
+                  ptrdiff_t w_ind[] = {k, j};
                   f += x[x_ind] * W[w_ind];
                 }
             }
@@ -141,11 +141,11 @@ class NegativeSamplingFunction(function.Function):
         cuda.elementwise(
             'raw T g, raw T W, bool mask, raw S k, int32 c, int32 m', 'T gx',
             '''
-            ssize_t d = i / c;
+            ptrdiff_t d = i / c;
             T w = 0;
             if (mask == 1){
                 for (int j = 0; j < m; ++j) {
-                  w += g[d * m + j] * W[(ssize_t)k[d * m + j] * c + i % c];
+                  w += g[d * m + j] * W[(ptrdiff_t)k[d * m + j] * c + i % c];
                 }
             }
             gx = w;
@@ -160,7 +160,7 @@ class NegativeSamplingFunction(function.Function):
             '''
             T gi = g;
             if (mask == 1) {
-                for (ssize_t j = 0; j < c; ++j) {
+                for (ptrdiff_t j = 0; j < c; ++j) {
                   atomicAdd(&gW[k * c + j], gi * x[(i / m) * c + j]);
                 }
             }

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -82,7 +82,7 @@ class SoftmaxCrossEntropy(function.Function):
         log_y = cupy.rollaxis(log_y, 1, log_y.ndim)
         ret = cuda.reduce(
             'S t, raw T log_y, int32 n_channel, raw T coeff', 'T out',
-            't == -1 ? T(0) : log_y[(ssize_t)_j * n_channel + t]',
+            't == -1 ? T(0) : log_y[(ptrdiff_t)_j * n_channel + t]',
             'a + b', 'out = a * -coeff[0L]', '0', 'crossent_fwd'
         )(t, log_y.reduced_view(), log_y.shape[-1], self._coeff)
         return ret,

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -82,8 +82,8 @@ class SoftmaxCrossEntropy(function.Function):
         log_y = cupy.rollaxis(log_y, 1, log_y.ndim)
         ret = cuda.reduce(
             'S t, raw T log_y, int32 n_channel, raw T coeff', 'T out',
-            't == -1 ? T(0) : log_y[_j * n_channel + t]',
-            'a + b', 'out = a * -coeff[0]', '0', 'crossent_fwd'
+            't == -1 ? T(0) : log_y[(ssize_t)_j * n_channel + t]',
+            'a + b', 'out = a * -coeff[0L]', '0', 'crossent_fwd'
         )(t, log_y.reduced_view(), log_y.shape[-1], self._coeff)
         return ret,
 
@@ -130,7 +130,7 @@ class SoftmaxCrossEntropy(function.Function):
             'T gx',
             '''
                const int c = (i / n_unit % n_channel);
-               gx = (t == -1) ? 0 : (coeff[0] * (y - (c == t)));
+               gx = (t == -1) ? 0 : (coeff[0L] * (y - (c == t)));
             ''',
             'softmax_crossent_bwd')(
                 y, cupy.expand_dims(t, 1), coeff, x.shape[1], n_unit)

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -178,21 +178,21 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
             raw T codes, raw int32 begins, int32 c, int32 max_length''',
             'T ls, T wxy',
             '''
-            ssize_t ind = i / max_length;
-            ssize_t offset = i - ind * max_length;
-            ssize_t t = ts[ind];
+            ptrdiff_t ind = i / max_length;
+            ptrdiff_t offset = i - ind * max_length;
+            ptrdiff_t t = ts[ind];
 
             int begin = begins[t];
-            ssize_t length = begins[t + 1] - begins[t];
+            ptrdiff_t length = begins[t + 1] - begins[t];
 
             if (offset < length) {
-              ssize_t p = begin + offset;
-              ssize_t node = paths[p];
+              ptrdiff_t p = begin + offset;
+              ptrdiff_t node = paths[p];
 
               T wx = 0;
               for (int j = 0; j < c; ++j) {
-                ssize_t w_ind[] = {node, j};
-                ssize_t x_ind[] = {ind, j};
+                ptrdiff_t w_ind[] = {node, j};
+                ptrdiff_t x_ind[] = {ind, j};
                 wx += w[w_ind] * x[x_ind];
               }
               wxy = wx * codes[p];
@@ -221,22 +221,22 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
             int32 c, int32 max_length''',
             'raw T gx, raw T gw',
             '''
-            ssize_t ind = i / max_length;
-            ssize_t offset = i - ind * max_length;
-            ssize_t t = ts[ind];
+            ptrdiff_t ind = i / max_length;
+            ptrdiff_t offset = i - ind * max_length;
+            ptrdiff_t t = ts[ind];
 
-            ssize_t begin = begins[t];
-            ssize_t length = begins[t + 1] - begins[t];
+            ptrdiff_t begin = begins[t];
+            ptrdiff_t length = begins[t + 1] - begins[t];
 
             if (offset < length) {
-              ssize_t p = begin + offset;
-              ssize_t node = paths[p];
+              ptrdiff_t p = begin + offset;
+              ptrdiff_t node = paths[p];
               T code = codes[p];
 
               T g = -gloss[0L] * code / (1.0 + exp(wxy));
               for (int j = 0; j < c; ++j) {
-                ssize_t w_ind[] = {node, j};
-                ssize_t x_ind[] = {ind, j};
+                ptrdiff_t w_ind[] = {node, j};
+                ptrdiff_t x_ind[] = {ind, j};
                 atomicAdd(&gx[x_ind], g * w[w_ind]);
                 atomicAdd(&gw[w_ind], g * x[x_ind]);
               }

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -178,21 +178,21 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
             raw T codes, raw int32 begins, int32 c, int32 max_length''',
             'T ls, T wxy',
             '''
-            int ind = i / max_length;
-            int offset = i - ind * max_length;
-            int t = ts[ind];
+            ssize_t ind = i / max_length;
+            ssize_t offset = i - ind * max_length;
+            ssize_t t = ts[ind];
 
             int begin = begins[t];
-            int length = begins[t + 1] - begins[t];
+            ssize_t length = begins[t + 1] - begins[t];
 
             if (offset < length) {
-              int p = begin + offset;
-              int node = paths[p];
+              ssize_t p = begin + offset;
+              ssize_t node = paths[p];
 
               T wx = 0;
               for (int j = 0; j < c; ++j) {
-                int w_ind[] = {node, j};
-                int x_ind[] = {ind, j};
+                ssize_t w_ind[] = {node, j};
+                ssize_t x_ind[] = {ind, j};
                 wx += w[w_ind] * x[x_ind];
               }
               wxy = wx * codes[p];
@@ -221,22 +221,22 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
             int32 c, int32 max_length''',
             'raw T gx, raw T gw',
             '''
-            int ind = i / max_length;
-            int offset = i - ind * max_length;
-            int t = ts[ind];
+            ssize_t ind = i / max_length;
+            ssize_t offset = i - ind * max_length;
+            ssize_t t = ts[ind];
 
-            int begin = begins[t];
-            int length = begins[t + 1] - begins[t];
+            ssize_t begin = begins[t];
+            ssize_t length = begins[t + 1] - begins[t];
 
             if (offset < length) {
-              int p = begin + offset;
-              int node = paths[p];
+              ssize_t p = begin + offset;
+              ssize_t node = paths[p];
               T code = codes[p];
 
-              T g = -gloss[0] * code / (1.0 + exp(wxy));
+              T g = -gloss[0L] * code / (1.0 + exp(wxy));
               for (int j = 0; j < c; ++j) {
-                int w_ind[] = {node, j};
-                int x_ind[] = {ind, j};
+                ssize_t w_ind[] = {node, j};
+                ssize_t x_ind[] = {ind, j};
                 atomicAdd(&gx[x_ind], g * w[w_ind]);
                 atomicAdd(&gw[w_ind], g * x[x_ind]);
               }

--- a/cupy/core/carray.cuh
+++ b/cupy/core/carray.cuh
@@ -3,10 +3,6 @@
 #define M_PI 3.1415926535897932384626433832795
 #endif
 
-#ifdef _MSC_VER
-typedef ptrdiff_t ssize_t;
-#endif
-
 // float16
 class float16
 {
@@ -139,7 +135,7 @@ __device__ float16 nextafter(float16 x, float16 y) {return float16::nextafter(x,
 
 // CArray
 #define CUPY_FOR(i, n) \
-    for (ssize_t i = blockIdx.x * blockDim.x + threadIdx.x; \
+    for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; \
          i < (n); \
          i += blockDim.x * gridDim.x)
 
@@ -147,24 +143,24 @@ template <typename T, int ndim>
 class CArray {
 private:
   T* data_;
-  ssize_t size_;
-  ssize_t shape_[ndim];
-  ssize_t strides_[ndim];
+  ptrdiff_t size_;
+  ptrdiff_t shape_[ndim];
+  ptrdiff_t strides_[ndim];
 
 public:
-  __device__ ssize_t size() const {
+  __device__ ptrdiff_t size() const {
     return size_;
   }
 
-  __device__ const ssize_t* shape() const {
+  __device__ const ptrdiff_t* shape() const {
     return shape_;
   }
 
-  __device__ const ssize_t* strides() const {
+  __device__ const ptrdiff_t* strides() const {
     return strides_;
   }
 
-  __device__ T& operator[](const ssize_t* idx) {
+  __device__ T& operator[](const ptrdiff_t* idx) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = 0; dim < ndim; ++dim) {
       ptr += strides_[dim] * idx[dim];
@@ -172,11 +168,11 @@ public:
     return *reinterpret_cast<T*>(ptr);
   }
 
-  __device__ T operator[](const ssize_t* idx) const {
+  __device__ T operator[](const ptrdiff_t* idx) const {
     return (*const_cast<CArray<T, ndim>*>(this))[idx];
   }
 
-  __device__ T& operator[](ssize_t i) {
+  __device__ T& operator[](ptrdiff_t i) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = ndim; --dim > 0; ) {
       ptr += strides_[dim] * (i % shape_[dim]);
@@ -189,7 +185,7 @@ public:
     return *reinterpret_cast<T*>(ptr);
   }
 
-  __device__ T operator[](ssize_t i) const {
+  __device__ T operator[](ptrdiff_t i) const {
     return (*const_cast<CArray<T, ndim>*>(this))[i];
   }
 };
@@ -198,26 +194,26 @@ template <typename T>
 class CArray<T, 0> {
 private:
   T* data_;
-  ssize_t size_;
+  ptrdiff_t size_;
 
 public:
-  __device__ ssize_t size() const {
+  __device__ ptrdiff_t size() const {
     return size_;
   }
 
-  __device__ T& operator[](const ssize_t* idx) {
+  __device__ T& operator[](const ptrdiff_t* idx) {
     return *reinterpret_cast<T*>(data_);
   }
 
-  __device__ T operator[](const ssize_t* idx) const {
+  __device__ T operator[](const ptrdiff_t* idx) const {
     return (*const_cast<CArray<T, 0>*>(this))[idx];
   }
 
-  __device__ T& operator[](ssize_t i) {
+  __device__ T& operator[](ptrdiff_t i) {
     return *reinterpret_cast<T*>(data_);
   }
 
-  __device__ T operator[](ssize_t i) const {
+  __device__ T operator[](ptrdiff_t i) const {
     return (*const_cast<CArray<T, 0>*>(this))[i];
   }
 };
@@ -225,19 +221,19 @@ public:
 template <int ndim>
 class CIndexer {
 private:
-  ssize_t size_;
-  ssize_t shape_[ndim];
-  ssize_t index_[ndim];
+  ptrdiff_t size_;
+  ptrdiff_t shape_[ndim];
+  ptrdiff_t index_[ndim];
 
 public:
-  __device__ ssize_t size() const {
+  __device__ ptrdiff_t size() const {
     return size_;
   }
 
-  __device__ void set(ssize_t i) {
-    ssize_t a = i;
-    for (ssize_t dim = ndim; --dim > 0; ) {
-      ssize_t s = shape_[dim];
+  __device__ void set(ptrdiff_t i) {
+    ptrdiff_t a = i;
+    for (ptrdiff_t dim = ndim; --dim > 0; ) {
+      ptrdiff_t s = shape_[dim];
       index_[dim] = (a % s);
       a /= s;
     }
@@ -246,7 +242,7 @@ public:
     }
   }
 
-  __device__ const ssize_t* get() const {
+  __device__ const ptrdiff_t* get() const {
     return index_;
   }
 };
@@ -254,17 +250,17 @@ public:
 template <>
 class CIndexer<0> {
 private:
-  ssize_t size_;
+  ptrdiff_t size_;
 
 public:
-  __device__ ssize_t size() const {
+  __device__ ptrdiff_t size() const {
     return size_;
   }
 
-  __device__ void set(ssize_t i) {
+  __device__ void set(ptrdiff_t i) {
   }
 
-  __device__ const ssize_t* get() const {
+  __device__ const ptrdiff_t* get() const {
     return NULL;
   }
 };

--- a/cupy/core/carray.cuh
+++ b/cupy/core/carray.cuh
@@ -135,7 +135,7 @@ __device__ float16 nextafter(float16 x, float16 y) {return float16::nextafter(x,
 
 // CArray
 #define CUPY_FOR(i, n) \
-    for (int i = blockIdx.x * blockDim.x + threadIdx.x; \
+    for (ssize_t i = blockIdx.x * blockDim.x + threadIdx.x; \
          i < (n); \
          i += blockDim.x * gridDim.x)
 
@@ -143,24 +143,24 @@ template <typename T, int ndim>
 class CArray {
 private:
   T* data_;
-  int size_;
-  int shape_[ndim];
-  int strides_[ndim];
+  ssize_t size_;
+  ssize_t shape_[ndim];
+  ssize_t strides_[ndim];
 
 public:
-  __device__ int size() const {
+  __device__ ssize_t size() const {
     return size_;
   }
 
-  __device__ const int* shape() const {
+  __device__ const ssize_t* shape() const {
     return shape_;
   }
 
-  __device__ const int* strides() const {
+  __device__ const ssize_t* strides() const {
     return strides_;
   }
 
-  __device__ T& operator[](const int* idx) {
+  __device__ T& operator[](const ssize_t* idx) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = 0; dim < ndim; ++dim) {
       ptr += strides_[dim] * idx[dim];
@@ -168,11 +168,11 @@ public:
     return *reinterpret_cast<T*>(ptr);
   }
 
-  __device__ T operator[](const int* idx) const {
+  __device__ T operator[](const ssize_t* idx) const {
     return (*const_cast<CArray<T, ndim>*>(this))[idx];
   }
 
-  __device__ T& operator[](int i) {
+  __device__ T& operator[](ssize_t i) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = ndim; --dim > 0; ) {
       ptr += strides_[dim] * (i % shape_[dim]);
@@ -185,7 +185,7 @@ public:
     return *reinterpret_cast<T*>(ptr);
   }
 
-  __device__ T operator[](int i) const {
+  __device__ T operator[](ssize_t i) const {
     return (*const_cast<CArray<T, ndim>*>(this))[i];
   }
 };
@@ -194,26 +194,26 @@ template <typename T>
 class CArray<T, 0> {
 private:
   T* data_;
-  int size_;
+  ssize_t size_;
 
 public:
-  __device__ int size() const {
+  __device__ ssize_t size() const {
     return size_;
   }
 
-  __device__ T& operator[](const int* idx) {
+  __device__ T& operator[](const ssize_t* idx) {
     return *reinterpret_cast<T*>(data_);
   }
 
-  __device__ T operator[](const int* idx) const {
+  __device__ T operator[](const ssize_t* idx) const {
     return (*const_cast<CArray<T, 0>*>(this))[idx];
   }
 
-  __device__ T& operator[](int i) {
+  __device__ T& operator[](ssize_t i) {
     return *reinterpret_cast<T*>(data_);
   }
 
-  __device__ T operator[](int i) const {
+  __device__ T operator[](ssize_t i) const {
     return (*const_cast<CArray<T, 0>*>(this))[i];
   }
 };
@@ -221,19 +221,19 @@ public:
 template <int ndim>
 class CIndexer {
 private:
-  int size_;
-  int shape_[ndim];
-  int index_[ndim];
+  ssize_t size_;
+  ssize_t shape_[ndim];
+  ssize_t index_[ndim];
 
 public:
-  __device__ int size() const {
+  __device__ ssize_t size() const {
     return size_;
   }
 
-  __device__ void set(int i) {
-    unsigned int a = i;
-    for (int dim = ndim; --dim > 0; ) {
-      unsigned int s = shape_[dim];
+  __device__ void set(ssize_t i) {
+    ssize_t a = i;
+    for (ssize_t dim = ndim; --dim > 0; ) {
+      ssize_t s = shape_[dim];
       index_[dim] = (a % s);
       a /= s;
     }
@@ -242,7 +242,7 @@ public:
     }
   }
 
-  __device__ const int* get() const {
+  __device__ const ssize_t* get() const {
     return index_;
   }
 };
@@ -250,17 +250,17 @@ public:
 template <>
 class CIndexer<0> {
 private:
-  int size_;
+  ssize_t size_;
 
 public:
-  __device__ int size() const {
+  __device__ ssize_t size() const {
     return size_;
   }
 
-  __device__ void set(int i) {
+  __device__ void set(ssize_t i) {
   }
 
-  __device__ const int* get() const {
+  __device__ const ssize_t* get() const {
     return NULL;
   }
 };

--- a/cupy/core/carray.cuh
+++ b/cupy/core/carray.cuh
@@ -3,6 +3,10 @@
 #define M_PI 3.1415926535897932384626433832795
 #endif
 
+#ifdef _MSC_VER
+typedef ptrdiff_t ssize_t;
+#endif
+
 // float16
 class float16
 {

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -7,8 +7,8 @@ from cupy.cuda cimport function
 
 cdef struct _CArray:
     void* data
-    int size
-    int shape_and_strides[MAX_NDIM * 2]
+    Py_ssize_t size
+    Py_ssize_t shape_and_strides[MAX_NDIM * 2]
 
 
 cdef class CArray(cupy.cuda.function.CPointer):
@@ -17,7 +17,8 @@ cdef class CArray(cupy.cuda.function.CPointer):
         _CArray val
 
     def __init__(self, ndarray arr):
-        cdef Py_ssize_t i, ndim = arr.ndim
+        cdef Py_ssize_t i
+        cdef int ndim = arr.ndim
         self.val.data = <void*>arr.data.ptr
         self.val.size = arr.size
         for i in range(ndim):
@@ -27,8 +28,8 @@ cdef class CArray(cupy.cuda.function.CPointer):
 
 
 cdef struct _CIndexer:
-    int size
-    int shape_and_index[MAX_NDIM * 2]
+    Py_ssize_t size
+    Py_ssize_t shape_and_index[MAX_NDIM * 2]
 
 
 cdef class CIndexer(cupy.cuda.function.CPointer):

--- a/cupy/testing/attr.py
+++ b/cupy/testing/attr.py
@@ -1,6 +1,7 @@
 from nose.plugins import attrib
 
 gpu = attrib.attr('gpu')
+slow = attrib.attr('slow')
 
 
 def multi_gpu(gpu_num):

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -20,6 +20,12 @@ class TestArrayReduction(unittest.TestCase):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.max(axis=0)
 
+    @testing.for_dtypes(['?', 'b', 'h', 'e'])
+    @testing.numpy_cupy_allclose()
+    def test_max_axis_huge(self, xp, dtype):
+        a = testing.shaped_random((2, 1024, 1024), xp, dtype)
+        return a.max(axis=0)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_max_axis0(self, xp, dtype):
@@ -54,6 +60,12 @@ class TestArrayReduction(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_min_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
+        return a.min(axis=0)
+
+    @testing.for_dtypes(['?', 'b', 'h', 'e'])
+    @testing.numpy_cupy_allclose()
+    def test_min_axis_huge(self, xp, dtype):
+        a = testing.shaped_random((2, 1024, 1024), xp, dtype)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -20,10 +20,11 @@ class TestArrayReduction(unittest.TestCase):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.max(axis=0)
 
+    @testing.attr.slow
     @testing.for_dtypes(['?', 'b', 'h', 'e'])
     @testing.numpy_cupy_allclose()
     def test_max_axis_huge(self, xp, dtype):
-        a = testing.shaped_random((2, 1024, 1024), xp, dtype)
+        a = testing.shaped_random((2048, 1024, 1024), xp, dtype)
         return a.max(axis=0)
 
     @testing.for_all_dtypes()
@@ -62,10 +63,11 @@ class TestArrayReduction(unittest.TestCase):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.min(axis=0)
 
+    @testing.attr.slow
     @testing.for_dtypes(['?', 'b', 'h', 'e'])
     @testing.numpy_cupy_allclose()
     def test_min_axis_huge(self, xp, dtype):
-        a = testing.shaped_random((2, 1024, 1024), xp, dtype)
+        a = testing.shaped_random((2048, 1024, 1024), xp, dtype)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -18,6 +18,7 @@ class TestBasic(unittest.TestCase):
         a.fill(0)
         return a
 
+    @testing.slow
     @testing.for_dtypes(['?', 'b', 'h', 'e'])
     @testing.numpy_cupy_array_equal()
     def test_empty_huge(self, xp, dtype):
@@ -39,6 +40,7 @@ class TestBasic(unittest.TestCase):
         a.fill(0)
         return a
 
+    @testing.slow
     @testing.for_dtypes(['?', 'b', 'h', 'e'])
     @testing.numpy_cupy_array_equal()
     def test_empty_huge_int(self, xp, dtype):

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -18,6 +18,13 @@ class TestBasic(unittest.TestCase):
         a.fill(0)
         return a
 
+    @testing.for_dtypes(['?', 'b', 'h', 'e'])
+    @testing.numpy_cupy_array_equal()
+    def test_empty_huge(self, xp, dtype):
+        a = xp.empty((1024, 1024, 2048), dtype=dtype)
+        a.fill(0)
+        return a
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_scalar(self, xp, dtype):
@@ -29,6 +36,13 @@ class TestBasic(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_empty_int(self, xp, dtype):
         a = xp.empty(3, dtype=dtype)
+        a.fill(0)
+        return a
+
+    @testing.for_dtypes(['?', 'b', 'h', 'e'])
+    @testing.numpy_cupy_array_equal()
+    def test_empty_huge_int(self, xp, dtype):
+        a = xp.empty(2 ** 31, dtype=dtype)
         a.fill(0)
         return a
 

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -18,7 +18,7 @@ class TestBasic(unittest.TestCase):
         a.fill(0)
         return a
 
-    @testing.slow
+    @testing.attr.slow
     @testing.for_dtypes(['?', 'b', 'h', 'e'])
     @testing.numpy_cupy_array_equal()
     def test_empty_huge(self, xp, dtype):
@@ -40,7 +40,7 @@ class TestBasic(unittest.TestCase):
         a.fill(0)
         return a
 
-    @testing.slow
+    @testing.attr.slow
     @testing.for_dtypes(['?', 'b', 'h', 'e'])
     @testing.numpy_cupy_array_equal()
     def test_empty_huge_int(self, xp, dtype):


### PR DESCRIPTION
In current CuPy implementation cannot treat arrays whose element size larger than `2**31 - 1`,
this is because CuPy uses `int` for `size`/`shape`/`strides`.

For example:

```
>>> from chainer.cuda import cupy as xp
>>> arr = xp.empty(2**31 - 1, dtype='b')
>>> arr += 1 # it works
>>> arr = xp.empty(2**31, dtype='b')
>>> arr += 1 # raise Exception
Traceback (most recent call last):
...
TypeError: Unsupported type <class 'cupy.core.core.Indexer'>
```

This pull request remove this restriction by replacing these `int` with `ssize_t` or `Py_ssize_t`, as same as Python and NumPy does.

See also [PEP 353 - Using ssize_t as the index type](https://www.python.org/dev/peps/pep-0353/)