### PR TITLE
Add binary_accuracy function to the reference manual

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -231,6 +231,10 @@ accuracy
 ~~~~~~~~
 .. autofunction:: accuracy
 
+binary_accuracy
+~~~~~~~~
+.. autofunction:: binary_accuracy
+
 
 Loss functions
 --------------


### PR DESCRIPTION
`F.binary_accuracy` is implemented at #757 but missing in the manual.