### PR TITLE
Add mean_absolute_error to the reference

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -280,6 +280,10 @@ huber_loss
 ~~~~~~~~~~
 .. autofunction:: huber_loss
 
+mean_absolute_error
+~~~~~~~~~~~~~~~~~~
+.. autofunction:: mean_absolute_error
+
 mean_squared_error
 ~~~~~~~~~~~~~~~~~~
 .. autofunction:: mean_squared_error


### PR DESCRIPTION
This small PR aims to add ``mean_absolute_error`` loss function merged in #1881 to the reference.
(Sorry I forgot to add it to the reference)