### PR TITLE
fix a doc error

### DIFF
--- a/chainer/datasets/tuple_dataset.py
+++ b/chainer/datasets/tuple_dataset.py
@@ -10,7 +10,7 @@ class TupleDataset(object):
 
     Args:
         datasets: Underlying datasets. The ``i``-th one is used for the
-            ``i``-th item of each example. All datasets must have the
+            ``i``-th item of each example. All datasets must have the same
             length.
 
     """


### PR DESCRIPTION
TupleDataset.__init__() checks whether all items in the datasets argument
have the same length as datasets[0], but the doc says all datasets must
have (some) length, which should be a mistake.