### PR TITLE
Add additional information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ The Twenty-ninth Annual Conference on Neural Information Processing Systems (NIP
 - Forum (Japanese): https://groups.google.com/forum/#!forum/chainer-jp
 - Twitter: https://twitter.com/ChainerOfficial
 - Twitter (Japanese): https://twitter.com/chainerjp
+- External examples: https://github.com/pfnet/chainer/wiki/External-examples
+- Research projects using Chainer: https://github.com/pfnet/chainer/wiki/Research-projects-using-Chainer
 
 ## License
 


### PR DESCRIPTION
Add links to "External examples" and "Research projects using Chainer" pages in wiki to README.md.