### PR TITLE
Improve doc of element-wise sigmoid logistic function

### DIFF
--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -67,7 +67,8 @@ def sigmoid(x, use_cudnn=True):
 
         >>> x = np.random.uniform(0, 1, (3, 4)).astype('f')
         >>> y = F.sigmoid(x)
-        >>> assert y.shape == (3, 4)
+        >>> y.shape
+        (3, 4)
 
     Args:
         x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -59,15 +59,26 @@ class Sigmoid(function.Function):
 
 
 def sigmoid(x, use_cudnn=True):
-    """Elementwise sigmoid logistic function :math:`f(x)=(1 + \\exp(-x))^{-1}`.
+    """Element-wise sigmoid logistic function.
+
+     .. math:: f(x)=(1 + \\exp(-x))^{-1}.
+
+    Example::
+
+        >>> x = np.random.uniform(0, 1, (3, 4)).astype('f')
+        >>> y = F.sigmoid(x)
+        >>> assert y.shape == (3, 4)
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 
     Returns:
-        ~chainer.Variable: Output variable.
+        ~chainer.Variable: Output variable. A
+        :math:`(s_1, s_2, ..., s_n)`-shaped float array.
 
     """
     return Sigmoid(use_cudnn)(x)


### PR DESCRIPTION
This PR improves the documentation of the element-wise sigmoid logistic function by adding a usage example.

Adding plots using sphinx extensions will be left for future PRs :).

EDIT: previously `[WIP] Add example usage to docstrings of functions and links`:
PRs welcome!

Part of improving documentaion effort. See also https://github.com/pfnet/chainer/issues/1867

TODO (finish this list):

Functions:
- [ ] linear
- [x] sigmoid
- [ ] ...

Links:
- [ ] Bilinear
- [ ] Maxout
- [ ] ...