### PR TITLE
Support copyparams to uninitialized parameters

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -414,6 +414,12 @@ class Link(object):
         dst = self.__dict__
         for name in self._params:
             dst[name].copydata(src[name])
+        # tuple() here is needed to avoid conflicts with add_param
+        for name in tuple(self._uninitialized_params):
+            if name in src:
+                src_param = src[name]
+                self.add_param(name, src_param.shape, src_param.dtype)
+                dst[name].copydata(src_param)
 
     def cleargrads(self):
         """Clears all gradient arrays.

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -138,6 +138,16 @@ class TestLink(unittest.TestCase):
         numpy.testing.assert_array_equal(self.link.y.data, l.y.data)
         numpy.testing.assert_array_equal(self.link.y.grad, gy)
 
+    def test_copyparams_uninitialized(self):
+        l = chainer.Link(x=(2, 3))
+        l.add_uninitialized_param('y')
+        self.link.x.data.fill(2)
+        self.link.y.data.fill(4)
+        l.copyparams(self.link)
+        numpy.testing.assert_array_equal(l.x.data, self.link.x.data)
+        self.assertTrue(hasattr(l, 'y'))
+        numpy.testing.assert_array_equal(l.y.data, self.link.y.data)
+
     def test_cleargrads(self):
         self.link.cleargrads()
         self.assertIsNone(self.link.x.grad)


### PR DESCRIPTION
`link_a.copyparams(link_b)` skips uninitialized parameters of `link_a`, even if the corresponding parameters of `link_b` are already initialized. With this PR, these parameters are also copied to `link_a`.