### PR TITLE
Suppress cudaMalloc before fork in test

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -42,7 +42,7 @@ class TestArrayAdvancedIndexingParametrizedTransp(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'shape': (2, 3, 4), 'indexes': (slice(None), cupy.array([1, 0]))},
+    {'shape': (2, 3, 4), 'indexes': (slice(None),)},
     {'shape': (2, 3, 4), 'indexes': (numpy.array([1, 0],))},
 )
 @testing.gpu


### PR DESCRIPTION
This PR suppresses `cudaMalloc` before fork in test. I am not sure whether this change is acceptable, but we must not call `cudaMalloc` in global scope.