### PR TITLE
Check contiguous to reduce memory usage

### DIFF
--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -32,6 +32,7 @@ class ReLU(function.Function):
 
     def forward_gpu(self, x):
         if (cuda.cudnn_enabled and self.use_cudnn and
+                x[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             y = cudnn.activation_forward(x[0], _mode)
             self.y = y
@@ -44,6 +45,7 @@ class ReLU(function.Function):
 
     def backward_gpu(self, x, gy):
         if (cuda.cudnn_enabled and self.use_cudnn and
+                x[0].flags.c_contiguous and gy[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             gx = cudnn.activation_backward(x[0], self.y, gy[0], _mode)
         else:

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -30,7 +30,7 @@ class Sigmoid(function.Function):
 
     def forward_gpu(self, inputs):
         x = inputs[0]
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and self.use_cudnn and x.flags.c_contiguous and
                 (_cudnn_version >= 3000 or x.dtype != numpy.float16)):
             self.y = cuda.cupy.cudnn.activation_forward(x, _mode)
         else:
@@ -46,7 +46,8 @@ class Sigmoid(function.Function):
     def backward_gpu(self, inputs, grads):
         x = inputs[0]
         gy = grads[0]
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and self.use_cudnn and x.flags.c_contiguous and
+                gy.flags.c_contiguous and
                 (_cudnn_version >= 3000 or x.dtype != numpy.float16)):
             gx = cuda.cupy.cudnn.activation_backward(x, self.y, gy, _mode)
         else:

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -29,6 +29,7 @@ class Tanh(function.Function):
 
     def forward_gpu(self, x):
         if (cuda.cudnn_enabled and self.use_cudnn and
+                x[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             self.y = cudnn.activation_forward(x[0], _mode)
         else:
@@ -42,6 +43,7 @@ class Tanh(function.Function):
 
     def backward_gpu(self, x, gy):
         if (cuda.cudnn_enabled and self.use_cudnn and
+                x[0].flags.c_contiguous and gy[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             gx = cudnn.activation_backward(x[0], self.y, gy[0], _mode)
         else:


### PR DESCRIPTION
`activation_forward` calls `ascontiguousarray`.
If input array is not c contiguous, Chainer uses ElementwiseKernel to reduce memory usage and calculation time.

