### PR TITLE
raise error when array is included in slices of __setitem__

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1160,6 +1160,14 @@ cdef class ndarray:
 
     def __setitem__(self, slices, value):
         cdef ndarray v, x, y
+        if not isinstance(slices, tuple):
+            slices = (slices,)
+
+        for i, s in enumerate(slices):
+            if isinstance(s, (list, numpy.ndarray, ndarray)):
+                raise IndexError(
+                    'Only basic indexing is supported for __setitem__')
+
         v = self[slices]
         if isinstance(value, ndarray):
             y, x = broadcast(v, value).values

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1163,7 +1163,7 @@ cdef class ndarray:
         if not isinstance(slices, tuple):
             slices = (slices,)
 
-        for i, s in enumerate(slices):
+        for s in slices:
             if isinstance(s, (list, numpy.ndarray, ndarray)):
                 raise IndexError(
                     'Only basic indexing is supported for __setitem__')


### PR DESCRIPTION
`__setitem__` does not support slices with arrays, but no error is raised.
Previously, `__getitem__` raised error in such cases, but since #1832 it no longer raise error.

This PR makes `__setitem__` raise error without depending on `__getitem__`.