### PR TITLE
Fix ndarray.__getitem__ py2/py3 compatibility

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2089,7 +2089,7 @@ cpdef ndarray _adv_getitem(ndarray a, slices):
                 ri = i
 
     if do_transpose:
-        transp = range(a.ndim)
+        transp = list(range(a.ndim))
         p = 0
         for i, s in enumerate(list(slices)):
             if isinstance(s, ndarray):


### PR DESCRIPTION
This PR fixes the latest broken master with improving its py2/py3 compatibility,

https://ci-chainer.pfidev.jp/job/chainer-sakura/298/

which is confirmed to work in jenkins build # 302.

https://ci-chainer.pfidev.jp/job/chainer-sakura/302/