### PR TITLE
Support cupy.where to take arguments that only has condition

### DIFF
--- a/cupy/sorting/search.py
+++ b/cupy/sorting/search.py
@@ -92,10 +92,7 @@ def flatnonzero(a):
 def where(condition, x=None, y=None):
     """Return elements, either from x or y, depending on condition.
 
-    .. note::
-
-       Currently CuPy doesn't support ``where(condition)``, that NumPy
-       supports.
+    If only condition is given, return ``condition.nonzero()``.
 
     Args:
         condition (cupy.ndarray): When True, take x, otherwise take y.
@@ -104,7 +101,9 @@ def where(condition, x=None, y=None):
 
     Returns:
         cupy.ndarray: Each element of output contains elements of ``x`` when
-            ``condition`` is ``True``, otherwise elements of ``y``.
+            ``condition`` is ``True``, otherwise elements of ``y``. If only
+            ``condition`` is given, return the tuple ``condition.nonzero()``,
+            the indices where ``condition`` is True.
 
     """
 
@@ -113,8 +112,7 @@ def where(condition, x=None, y=None):
     if missing == 1:
         raise ValueError("Must provide both 'x' and 'y' or neither.")
     if missing == 2:
-        # TODO(unno): return nonzero(cond)
-        return NotImplementedError()
+        return nonzero(condition)
 
     return _where_ufunc(condition.astype('?'), x, y)
 

--- a/cupy/sorting/search.py
+++ b/cupy/sorting/search.py
@@ -105,6 +105,8 @@ def where(condition, x=None, y=None):
             ``condition`` is given, return the tuple ``condition.nonzero()``,
             the indices where ``condition`` is True.
 
+    .. seealso:: :func:`numpy.where`
+
     """
 
     missing = (x is None, y is None).count(True)

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -114,12 +114,12 @@ class TestSearch(unittest.TestCase):
     {'cond_shape': (3, 4),    'x_shape': (2, 3, 4), 'y_shape': (4,)},
 )
 @testing.gpu
-class TestWhere(unittest.TestCase):
+class TestWhereTwoArrays(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(
         names=['cond_type', 'x_type', 'y_type'])
     @testing.numpy_cupy_allclose()
-    def test_where(self, xp, cond_type, x_type, y_type):
+    def test_where_two_arrays(self, xp, cond_type, x_type, y_type):
         m = testing.shaped_random(self.cond_shape, xp, xp.bool_)
         # Almost all values of a matrix `shaped_random` makes are not zero.
         # To make a sparse matrix, we need multiply `m`.
@@ -127,6 +127,23 @@ class TestWhere(unittest.TestCase):
         x = testing.shaped_random(self.x_shape, xp, x_type)
         y = testing.shaped_random(self.y_shape, xp, y_type)
         return xp.where(cond, x, y)
+
+
+@testing.parameterize(
+    {'cond_shape': (2, 3, 4)},
+    {'cond_shape': (4,)},
+    {'cond_shape': (2, 3, 4)},
+    {'cond_shape': (3, 4)},
+)
+@testing.gpu
+class TestWhereCond(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_where_cond(self, xp, dtype):
+        m = testing.shaped_random(self.cond_shape, xp, xp.bool_)
+        cond = testing.shaped_random(self.cond_shape, xp, dtype) * m
+        return xp.where(cond)
 
 
 @testing.gpu


### PR DESCRIPTION
Currently, `cupy.where` does not support arguments with only `condition`.
This PR handles that case by calling `ndarray.nonzeros`.

example
```python
>>> cond = cupy.array([True, False, True])  
>>> cupy.where(cond)
(array([0, 2]),)
```