### PR TITLE
allow adding lambda functions as an extension

### DIFF
--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -19,9 +19,9 @@ class Extension(object):
     flexibility (for example, it can have methods to configure the behavior).
     Using a lambda function allows one-line coding for simple purposes, but
     users have to specify the configurations in :meth:`Trainer.extend` by
-    themselves. If a callable class not inheriting this class is used, it must
-    have `name` attribute (for a lambda function, the name of the function is
-    automatically used).
+    themselves. For a callable class not inheriting this class, the default
+    configurations of this class are used unless the user explicitly specifies
+    them in :meth:`Trainer.extend` method.
 
     Attributes:
         trigger: Default value of trigger for this extension. It is set to

--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -12,11 +12,13 @@ class Extension(object):
     attributes, e.g. the default trigger and the default priority. This class
     provides a set of typical default values for these attributes.
 
-    There are two ways to define users' own extensions: inheriting this class,
-    or decorating closures by :func:`make_extension`. Decorator can slightly
-    reduce the overhead and is much easier to use, while this class provides
-    more flexibility (for example, it can have methods to configure the
-    behavior).
+    There are three ways to define users' own extensions: inheriting this class,
+    decorating closures by :func:`make_extension`, or using any callable including
+    lambda functions as extensions. Decorator can slightly reduce the overhead
+    and is much easier to use, while this class provides more flexibility
+    (for example, it can have methods to configure the behavior). Using a lambda
+    function allows one-line coding for simple purposes, but users have to specify
+    the configurations in :meth:`Trainer.extend` by themselves.
 
     Attributes:
         trigger: Default value of trigger for this extension. It is set to

--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -12,15 +12,16 @@ class Extension(object):
     attributes, e.g. the default trigger and the default priority. This class
     provides a set of typical default values for these attributes.
 
-    There are three ways to define users' own extensions: inheriting this class,
-    decorating closures by :func:`make_extension`, or using any callable including
-    lambda functions as extensions. Decorator can slightly reduce the overhead
-    and is much easier to use, while this class provides more flexibility
-    (for example, it can have methods to configure the behavior). Using a lambda
-    function allows one-line coding for simple purposes, but users have to specify
-    the configurations in :meth:`Trainer.extend` by themselves. If a callable
-    class not inheriting this class is used, it must have `name` attribute (for
-    a lambda function, the name of the function is automatically used).
+    There are three ways to define users' own extensions: inheriting this
+    class, decorating closures by :func:`make_extension`, or using any callable
+    including lambda functions as extensions. Decorator can slightly reduce the
+    overhead and is much easier to use, while this class provides more
+    flexibility (for example, it can have methods to configure the behavior).
+    Using a lambda function allows one-line coding for simple purposes, but
+    users have to specify the configurations in :meth:`Trainer.extend` by
+    themselves. If a callable class not inheriting this class is used, it must
+    have `name` attribute (for a lambda function, the name of the function is
+    automatically used).
 
     Attributes:
         trigger: Default value of trigger for this extension. It is set to

--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -18,10 +18,10 @@ class Extension(object):
     overhead and is much easier to use, while this class provides more
     flexibility (for example, it can have methods to configure the behavior).
     Using a lambda function allows one-line coding for simple purposes, but
-    users have to specify the configurations in :meth:`Trainer.extend` by
-    themselves. For a callable class not inheriting this class, the default
-    configurations of this class are used unless the user explicitly specifies
-    them in :meth:`Trainer.extend` method.
+    users have to specify the configurations as arguments to
+    :meth:`Trainer.extend`. For a callable not inheriting this class, the
+    default configurations of this class are used unless the user explicitly
+    specifies them in :meth:`Trainer.extend` method.
 
     Attributes:
         trigger: Default value of trigger for this extension. It is set to

--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -18,7 +18,9 @@ class Extension(object):
     and is much easier to use, while this class provides more flexibility
     (for example, it can have methods to configure the behavior). Using a lambda
     function allows one-line coding for simple purposes, but users have to specify
-    the configurations in :meth:`Trainer.extend` by themselves.
+    the configurations in :meth:`Trainer.extend` by themselves. If a callable
+    class not inheriting this class is used, it must have `name` attribute (for
+    a lambda function, the name of the function is automatically used).
 
     Attributes:
         trigger: Default value of trigger for this extension. It is set to

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -295,7 +295,10 @@ class Trainer(object):
                             entry.extension(self)
         finally:
             for _, entry in extensions:
-                finalize = entry.extension.finalize
+                if isinstance(entry.extension, types.FunctionType):
+                    finalize = None
+                else:
+                    finalize = entry.extension.finalize
                 if finalize:
                     finalize()
             self.updater.finalize()

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -39,10 +39,12 @@ class Trainer(object):
       should be called or not.
 
     Extensions are callable objects that take the trainer object as the
-    argument. There are two ways to define custom extensions: inheriting the
-    :class:`Extension` class, and decorating functions by
-    :func:`make_extension`. See :class:`Extension` for more details on custom
-    extensions.
+    argument. There are three ways to define custom extensions: inheriting the
+    :class:`Extension` class, decorating functions by :func:`make_extension`,
+    and defining any callable including lambda functions. The default
+    configurations of an extension is used in the former two cases, and users
+    have to add the trigger configuration in the :meth:`extend` method in the
+    last case. See :class:`Extension` for more details on custom extensions.
 
     Users can register extensions to the trainer by calling the :meth:`extend`
     method, where some configurations can be added.

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -1,7 +1,6 @@
 import collections
 import os
 import time
-import types
 
 import six
 
@@ -199,14 +198,14 @@ class Trainer(object):
                 recover the configuration before any updates.
 
         """
-        if isinstance(extension, types.FunctionType):
-            name = "lambda"
         if name is None:
             name = getattr(extension, 'name', None)
             if name is None:
                 name = getattr(extension, 'default_name', None)
                 if name is None:
-                    raise TypeError('name is not given for the extension')
+                    name = getattr(extension, '__name__', None)
+                    if name is None:
+                        raise TypeError('name is not given for the extension')
         if name == 'training':
             raise ValueError(
                 'the name "training" is prohibited as an extension name')
@@ -295,10 +294,7 @@ class Trainer(object):
                             entry.extension(self)
         finally:
             for _, entry in extensions:
-                if isinstance(entry.extension, types.FunctionType):
-                    finalize = None
-                else:
-                    finalize = entry.extension.finalize
+                finalize = getattr(entry.extension, 'finalize', None)
                 if finalize:
                     finalize()
             self.updater.finalize()

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -187,7 +187,7 @@ class Trainer(object):
                 is used instead. If the trigger is not callable, it is passed
                 to :class:`IntervalTrigger` to build an interval trigger. If
                 it is ``None`` and the extension does not have the trigger
-                attirbute, the extension is triggered at every iteration as
+                attribute, the extension is triggered at every iteration as
                 default.
             priority (int): Invocation priority of the extension. Extensions
                 are invoked in the descending order of priorities in each

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -186,7 +186,9 @@ class Trainer(object):
             trigger (tuple or Trigger): Trigger object that determines when to
                 invoke the extension. If it is ``None``, ``extension.trigger``
                 is used instead. If the trigger is not callable, it is passed
-                to :class:`IntervalTrigger` to build an interval trigger.
+                to :class:`IntervalTrigger` to build an interval trigger. If
+                ``extension.trigger`` is ``None``, the extension is triggered
+                at every iteration as default.
             priority (int): Invocation priority of the extension. Extensions
                 are invoked in the descending order of priorities in each
                 iteration. If this is ``None``, ``extension.priority`` is used
@@ -213,7 +215,7 @@ class Trainer(object):
                 'the name "training" is prohibited as an extension name')
 
         if trigger is None:
-            trigger = getattr(extension, 'trigger', None)
+            trigger = getattr(extension, 'trigger', (1, 'iteration'))
         trigger = trigger_module.get_trigger(trigger)
 
         if priority is None:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -41,9 +41,9 @@ class Trainer(object):
     Extensions are callable objects that take the trainer object as the
     argument. There are three ways to define custom extensions: inheriting the
     :class:`Extension` class, decorating functions by :func:`make_extension`,
-    and defining any callable including lambda functions. The default
-    configurations of an extension is used in the former two cases. See
-    :class:`Extension` for more details on custom extensions.
+    and defining any callable including lambda functions. See
+    :class:`Extension` for more details on custom extensions and how to
+    configure them.
 
     Users can register extensions to the trainer by calling the :meth:`extend`
     method, where some configurations can be added.
@@ -184,11 +184,11 @@ class Trainer(object):
                 duplicated names as explained above.
             trigger (tuple or Trigger): Trigger object that determines when to
                 invoke the extension. If it is ``None``, ``extension.trigger``
-                is used instead. If the trigger is not callable, it is passed
-                to :class:`IntervalTrigger` to build an interval trigger. If
-                it is ``None`` and the extension does not have the trigger
-                attribute, the extension is triggered at every iteration as
-                default.
+                is used instead. If it is ``None`` and the extension does not
+                have the trigger attribute, the extension is triggered at every
+                iteration by default. If the trigger is not callable, it is
+                passed to :class:`IntervalTrigger` to build an interval
+                trigger.
             priority (int): Invocation priority of the extension. Extensions
                 are invoked in the descending order of priorities in each
                 iteration. If this is ``None``, ``extension.priority`` is used

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import time
+import types
 
 import six
 
@@ -198,6 +199,8 @@ class Trainer(object):
                 recover the configuration before any updates.
 
         """
+        if isinstance(extension, types.FunctionType):
+            name = "lambda"
         if name is None:
             name = getattr(extension, 'name', None)
             if name is None:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -186,8 +186,9 @@ class Trainer(object):
                 invoke the extension. If it is ``None``, ``extension.trigger``
                 is used instead. If the trigger is not callable, it is passed
                 to :class:`IntervalTrigger` to build an interval trigger. If
-                ``extension.trigger`` is ``None``, the extension is triggered
-                at every iteration as default.
+                it is ``None`` and the extension does not have the trirger
+                attirbute, the extension is triggered at every iteration as
+                default.
             priority (int): Invocation priority of the extension. Extensions
                 are invoked in the descending order of priorities in each
                 iteration. If this is ``None``, ``extension.priority`` is used

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -42,9 +42,8 @@ class Trainer(object):
     argument. There are three ways to define custom extensions: inheriting the
     :class:`Extension` class, decorating functions by :func:`make_extension`,
     and defining any callable including lambda functions. The default
-    configurations of an extension is used in the former two cases, and users
-    have to add the trigger configuration in the :meth:`extend` method in the
-    last case. See :class:`Extension` for more details on custom extensions.
+    configurations of an extension is used in the former two cases. See
+    :class:`Extension` for more details on custom extensions.
 
     Users can register extensions to the trainer by calling the :meth:`extend`
     method, where some configurations can be added.

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -186,7 +186,7 @@ class Trainer(object):
                 invoke the extension. If it is ``None``, ``extension.trigger``
                 is used instead. If the trigger is not callable, it is passed
                 to :class:`IntervalTrigger` to build an interval trigger. If
-                it is ``None`` and the extension does not have the trirger
+                it is ``None`` and the extension does not have the trigger
                 attirbute, the extension is triggered at every iteration as
                 default.
             priority (int): Invocation priority of the extension. Extensions

--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -24,6 +24,29 @@ class DummyExtension(training.extension.Extension):
         self.is_finalized = True
 
 
+class DummyCallableClass():
+
+    def __init__(self):
+        self.name = "DummyCallableClass"
+        self.is_called = False
+        self.is_finalized = False
+
+    def __call__(self, trainer):
+        self.is_called = True
+
+    def finalize(self):
+        self.is_finalized = True
+
+
+class DummyClass():
+
+    def __init__(self):
+        self.is_touched = False
+
+    def touch(self):
+        self.is_touched = True
+
+
 class TestTrainer(unittest.TestCase):
 
     def setUp(self):
@@ -56,12 +79,25 @@ class TestTrainer(unittest.TestCase):
         finally:
             shutil.rmtree(tempdir)
 
-    def test_add_class_extension(self):
+    def test_add_inherit_class_extension(self):
         dummy_extension = DummyExtension()
         self.trainer.extend(dummy_extension)
         self.trainer.run()
         self.assertTrue(dummy_extension.is_called)
         self.assertTrue(dummy_extension.is_finalized)
+
+    def test_add_callable_class_extension(self):
+        dummy_callable_class = DummyCallableClass()
+        self.trainer.extend(dummy_callable_class)
+        self.trainer.run()
+        self.assertTrue(dummy_callable_class.is_called)
+        self.assertTrue(dummy_callable_class.is_finalized)
+
+    def test_add_lambda_extension(self):
+        dummy_class = DummyClass()
+        self.trainer.extend(lambda x: dummy_class.touch())
+        self.trainer.run()
+        self.assertTrue(dummy_class.is_touched)
 
     def test_add_make_extension(self):
         self.is_called = False

--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -110,6 +110,16 @@ class TestTrainer(unittest.TestCase):
         self.trainer.run()
         self.assertTrue(self.is_called)
 
+    def test_add_function_extension(self):
+        self.is_called = False
+
+        def dummy_function(trainer):
+            self.is_called = True
+
+        self.trainer.extend(dummy_function)
+        self.trainer.run()
+        self.assertTrue(self.is_called)
+
     def test_add_two_extensions_default_priority(self):
         self.called_order = []
 

--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -24,7 +24,7 @@ class DummyExtension(training.extension.Extension):
         self.is_finalized = True
 
 
-class DummyCallableClass():
+class DummyCallableClass(object):
 
     def __init__(self):
         self.name = "DummyCallableClass"
@@ -38,7 +38,7 @@ class DummyCallableClass():
         self.is_finalized = True
 
 
-class DummyClass():
+class DummyClass(object):
 
     def __init__(self):
         self.is_touched = False


### PR DESCRIPTION
This PR allows adding a lambda function as an extension,
resulting in simpler coding for simple extensions such as printing some values for debugging.

Example usage:

    ...
    trainer.extend(lambda x: print(model.accuracy.data), trigger=(1, "iteration"))
    ...