### PR TITLE
Include non tuple to test cases of ndarray.__getitem__

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -43,7 +43,9 @@ class TestArrayAdvancedIndexingPerm(unittest.TestCase):
 
 @testing.parameterize(
     {'shape': (2, 3, 4), 'indexes': (None, [1, 0], [0, 2], slice(None))},
-    {'shape': (2, 3, 4), 'indexes': (None, [0, 1], None, [2, 1], slice(None))}
+    {'shape': (2, 3, 4), 'indexes': (None, [0, 1], None, [2, 1], slice(None))},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([1, 0])},
+    {'shape': (2, 3, 4), 'indexes': [1, -1]},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingParametrized(unittest.TestCase):


### PR DESCRIPTION
This PR adds a test case where argument `slices` of `__getitem__` is **not** tuple.
This is already supported in the current code, but the test missed this case.