### PR TITLE
Add packbits and unpackbits

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -160,6 +160,9 @@ invert = binary.elementwise.invert
 left_shift = binary.elementwise.left_shift
 right_shift = binary.elementwise.right_shift
 
+packbits = binary.packing.packbits
+unpackbits = binary.packing.unpackbits
+
 binary_repr = numpy.binary_repr
 
 # -----------------------------------------------------------------------------

--- a/cupy/binary/packing.py
+++ b/cupy/binary/packing.py
@@ -34,8 +34,13 @@ def packbits(myarray):
     cupy.ElementwiseKernel(
         'raw T myarray, raw int32 myarray_size', 'uint8 packed',
         '''for (int j = 0; j < 8; ++j) {
-            int k = i * 8 + j;
-            packed |= (k < myarray_size && myarray[k] ? 1 : 0) << (7 - j);
+            int k = i * 8 + j, x;
+            if (k < myarray_size && myarray[k] != 0) {
+                x = 1;
+            } else {
+                x = 0;
+            }
+            packed |= x << (7 - j);
         }''',
         'packbits_kernel'
     )(myarray, myarray.size, packed)

--- a/cupy/binary/packing.py
+++ b/cupy/binary/packing.py
@@ -21,7 +21,8 @@ def packbits(myarray):
     .. seealso:: :func:`numpy.packbits`
     """
     if myarray.dtype.kind not in 'biu':
-        raise TypeError('Expected an input array of integer or boolean data type')
+        raise TypeError(
+            'Expected an input array of integer or boolean data type')
 
     if myarray.size == 0:
         return cupy.empty_like(myarray)

--- a/cupy/binary/packing.py
+++ b/cupy/binary/packing.py
@@ -31,11 +31,10 @@ def packbits(myarray):
     packed = cupy.zeros((packed_size,), dtype=cupy.uint8)
 
     cupy.ElementwiseKernel(
-        'raw T myarray, raw int32 myarray_size',
-        'uint8 packed',
+        'raw T myarray, raw int32 myarray_size', 'uint8 packed',
         '''for (int j = 0; j < 8; ++j) {
             int k = i * 8 + j;
-            packed += (k < myarray_size && myarray[k] ? 1 : 0) << (7 - j);
+            packed |= (k < myarray_size && myarray[k] ? 1 : 0) << (7 - j);
         }''',
         'packbits_kernel'
     )(myarray, myarray.size, packed)

--- a/cupy/binary/packing.py
+++ b/cupy/binary/packing.py
@@ -1,7 +1,70 @@
-# flake8: NOQA
-# "flake8: NOQA" to suppress warning "H104  File contains nothing but comments"
-
-# TODO(okuta): Implement packbits
+import cupy
 
 
-# TODO(okuta): Implement unpackbits
+def packbits(myarray):
+    """Packs the elements of a binary-valued array into bits in a uint8 array.
+
+    This function currently does not support ``axis`` option.
+
+    Args:
+        myarray (cupy.ndarray): Input array.
+
+    Returns:
+        cupy.ndarray: The packed array.
+
+    .. note::
+        When the input array is empty, this function returns a copy of it,
+        i.e., the type of the output array is not necessarily always uint8.
+        This exactly follows the NumPy's behaviour (as of version 1.11),
+        alghough this is inconsistent to the documentation.
+
+    .. seealso:: :func:`numpy.packbits`
+    """
+    if myarray.dtype.kind not in 'biu':
+        raise TypeError('Expected an input array of integer or boolean data type')
+
+    if myarray.size == 0:
+        return cupy.empty_like(myarray)
+
+    myarray = myarray.ravel()
+    packed_size = (myarray.size + 7) // 8
+    packed = cupy.zeros((packed_size,), dtype=cupy.uint8)
+
+    cupy.ElementwiseKernel(
+        'raw T myarray, raw int32 myarray_size',
+        'uint8 packed',
+        '''for (int j = 0; j < 8; ++j) {
+            int k = i * 8 + j;
+            packed += (k < myarray_size && myarray[k] ? 1 : 0) << (7 - j);
+        }''',
+        'packbits_kernel'
+    )(myarray, myarray.size, packed)
+
+    return packed
+
+
+def unpackbits(myarray):
+    """Unpacks elements of a uint8 array into a binary-valued output array.
+
+    This function currently does not support ``axis`` option.
+
+    Args:
+        myarray (cupy.ndarray): Input array.
+
+    Returns:
+        cupy.ndarray: The unpacked array.
+
+    .. seealso:: :func:`numpy.unpackbits`
+    """
+    if myarray.dtype != cupy.uint8:
+        raise TypeError('Expected an input array of unsigned byte data type')
+
+    unpacked = cupy.ndarray((myarray.size * 8), dtype=cupy.uint8)
+
+    cupy.ElementwiseKernel(
+        'raw uint8 myarray', 'T unpacked',
+        'unpacked = (myarray[i / 8] >> (7 - i % 8)) & 1;',
+        'unpackbits_kernel'
+    )(myarray, unpacked)
+
+    return unpacked

--- a/cupy/binary/packing.py
+++ b/cupy/binary/packing.py
@@ -34,13 +34,9 @@ def packbits(myarray):
     cupy.ElementwiseKernel(
         'raw T myarray, raw int32 myarray_size', 'uint8 packed',
         '''for (int j = 0; j < 8; ++j) {
-            int k = i * 8 + j, x;
-            if (k < myarray_size && myarray[k] != 0) {
-                x = 1;
-            } else {
-                x = 0;
-            }
-            packed |= x << (7 - j);
+            int k = i * 8 + j;
+            int bit = k < myarray_size && myarray[k] != 0;
+            packed |= bit << (7 - j);
         }''',
         'packbits_kernel'
     )(myarray, myarray.size, packed)

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -1,3 +1,4 @@
+import numpy
 import unittest
 
 from cupy import testing
@@ -7,3 +8,30 @@ from cupy import testing
 class TestPacking(unittest.TestCase):
 
     _multiprocess_can_split_ = True
+
+    @testing.for_int_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def check_packbits(self, data, xp, dtype):
+        a = xp.array(data, dtype=dtype)
+        return xp.packbits(a)
+
+    @testing.numpy_cupy_array_equal()
+    def check_unpackbits(self, data, xp):
+        a = xp.array(data, dtype=xp.uint8)
+        return xp.unpackbits(a)
+
+    def test_packbits(self):
+        self.check_packbits([])
+        self.check_packbits([0])
+        self.check_packbits([1])
+        self.check_packbits([0, 1])
+        self.check_packbits([1, 0, 1, 1, 0, 1, 1, 1])
+        self.check_packbits([1, 0, 1, 1, 0, 1, 1, 1, 1])
+        self.check_packbits(numpy.arange(24).reshape((2, 3, 4)) % 2)
+
+    def test_unpackbits(self):
+        self.check_unpackbits([])
+        self.check_unpackbits([0])
+        self.check_unpackbits([1])
+        self.check_unpackbits([255])
+        self.check_unpackbits([100, 200, 123, 213])


### PR DESCRIPTION
This PR addresses two TODOs of CuPy by adding functions `packbits` and `unpackbits`. As confirmed in the tests, they exactly follows the behaviour of the counterparts of NumPy, except that `packbits` does not support `axis` option.