### PR TITLE
Support 0d array as argument of ndarray.__getitem__

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2062,7 +2062,7 @@ cpdef ndarray _diagonal(ndarray a, Py_ssize_t offset=0, Py_ssize_t axis1=0,
 
 
 cpdef ndarray _adv_getitem(ndarray a, slices):
-    # slices consist of either None or ndarray of dim>=1
+    # slices consist of either slice(None) or ndarray
     cdef int i, p, li, ri
     cdef ndarray take_idx, input_flat, out_flat, o
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1089,7 +1089,9 @@ cdef class ndarray:
                     adv_slices.append(s)
                 elif isinstance(s, int):
                     basic_slices.append(slice(None))
-                    adv_slices.append(array(s, ndmin=0))
+                    scalar_array = ndarray((), dtype=numpy.int64)
+                    scalar_array.fill(s)
+                    adv_slices.append(scalar_array)
                 else:
                     raise IndexError(
                         'only integers, slices (`:`), ellipsis (`...`),'

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1086,12 +1086,10 @@ cdef class ndarray:
                 elif (isinstance(s, ndarray) and
                         issubclass(s.dtype.type, numpy.integer)):
                     basic_slices.append(slice(None))
-                    if s.ndim == 0:
-                        s = s.reshape((1,))
                     adv_slices.append(s)
                 elif isinstance(s, int):
                     basic_slices.append(slice(None))
-                    adv_slices.append(array(s, ndmin=1))
+                    adv_slices.append(array(s, ndmin=0))
                 else:
                     raise IndexError(
                         'only integers, slices (`:`), ellipsis (`...`),'

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -27,7 +27,10 @@ def perm(iterable):
             perm(([1, 0], [2, 1], [3, 1])) +
             perm(([1, 0], 1, [3, 1])) +
             perm(([1, 2], [[1, 0], [0, 1], [-1, 1]], slice(None))) +
-            perm((None, [1, 2], [1, 0]))
+            perm((None, [1, 2], [1, 0])) +
+            perm((numpy.array(0), numpy.array(-1))) +
+            perm((numpy.array(0), None)) +
+            perm((1, numpy.array(2), slice(None)))
         )
     })
 )
@@ -42,6 +45,7 @@ class TestArrayAdvancedIndexingPerm(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'shape': (2, 3, 4), 'indexes': numpy.array(-1)},
     {'shape': (2, 3, 4), 'indexes': (None, [1, 0], [0, 2], slice(None))},
     {'shape': (2, 3, 4), 'indexes': (None, [0, 1], None, [2, 1], slice(None))}
 )


### PR DESCRIPTION
This PR make `ndarray.__getitem__` behave consistently with NumPy when there is 0d array in `slices`.