### PR TITLE
Fix doc of function_hooks.PrintHook to have proper import

### DIFF
--- a/chainer/function_hooks/debug_print.py
+++ b/chainer/function_hooks/debug_print.py
@@ -16,9 +16,10 @@ class PrintHook(function.FunctionHook):
     The basic usage is to use it with ``with`` statement.
 
     >>> import chainer, chainer.functions as F, chainer.links as L
+    ... from chainer import function_hooks
     ... l = L.Linear(10, 10)
     ... x = chainer.Variable(numpy.zeros((1, 10), 'f'))
-    ... with chainer.function_hooks.PrintHook():
+    ... with function_hooks.PrintHook():
     ...     y = l(x)
     ...     z = F.sum(y)
     ...     z.backward()


### PR DESCRIPTION
I found an example code in docstring of `chainer.function_hooks.PrintHook` to fail to work.

It fails to call `chainer.function_hooks.PrintHook()` because `chainer/__init__.py` does not contain `from chainer import function_hooks`.

I am not sure if the doc is wrong, or it is a bug and the `from chainer import function_hooks` is simply forgotten in `chainer/__init__.py`.