### PR TITLE
Fix cleagrads and zerograds when use uninitialized params

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -430,8 +430,9 @@ class Link(object):
         """
         for param in self.params():
             param.cleargrad()
-        for param in self._uninitialized_params.values():
-            param._cleared = True
+        for link in self.links():
+            for param in link._uninitialized_params.values():
+                param._cleared = True
 
     def zerograds(self):
         """Initializes all gradient arrays by zero.
@@ -448,8 +449,9 @@ class Link(object):
             DeprecationWarning)
         for param in self.params():
             param.zerograd()
-        for param in self._uninitialized_params:
-            param._zeroed = True
+        for link in self.links():
+            for param in link._uninitialized_params.values():
+                param._zeroed = True
 
     def addgrads(self, link):
         """Accumulates gradient values from given link.

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -469,6 +469,7 @@ class TestChainList(unittest.TestCase):
 
     def setUp(self):
         self.l1 = chainer.Link(x=(2, 3))
+        self.l1.add_uninitialized_param('y')
         self.l2 = chainer.Link(x=2)
         self.l3 = chainer.Link(x=3)
         self.c1 = chainer.ChainList(self.l1)
@@ -667,6 +668,16 @@ class TestChainList(unittest.TestCase):
         numpy.testing.assert_array_equal(self.l2.x.grad, numpy.zeros(2))
         numpy.testing.assert_array_equal(self.l3.x.grad, numpy.zeros(3))
 
+        self.assertTrue(self.l1._uninitialized_params['y']._zeroed)
+
+    def test_cleargrads(self):
+        self.c2.cleargrads()
+        self.assertIsNone(self.l1.x.grad)
+        self.assertIsNone(self.l2.x.grad)
+        self.assertIsNone(self.l3.x.grad)
+
+        self.assertTrue(self.l1._uninitialized_params['y']._cleared)
+
     def test_addgrads(self):
         l1 = chainer.Link(x=(2, 3))
         l2 = chainer.Link(x=2)
@@ -687,6 +698,7 @@ class TestChainList(unittest.TestCase):
         numpy.testing.assert_array_equal(self.l3.x.grad, numpy.zeros(3))
 
     def test_serialize(self):
+        self.l1.add_param('y', (1, 1))
         mocks = {'0': mock.MagicMock(), '1': mock.MagicMock()}
         serializer = mock.MagicMock()
         serializer.__getitem__.side_effect = lambda k: mocks[k]
@@ -697,7 +709,7 @@ class TestChainList(unittest.TestCase):
         serializer.__getitem__.assert_any_call('0')
         serializer.__getitem__.assert_any_call('1')
 
-        mocks['0'].assert_called_with('x', self.l1.x.data)
+        mocks['0'].assert_called_with('y', self.l1.y.data)
         mocks['1'].assert_called_with('x', self.l2.x.data)
 
 


### PR DESCRIPTION
This bug causes a very confusing problem.
If `Chain` object contains `Link` object, `grad` of uninitialized parameter in the `Link` object will be initialized by `NaN`.