### PR TITLE
Add nonzero and flatnonzero to the overview page of CuPy document

### DIFF
--- a/docs/source/cupy-reference/overview.rst
+++ b/docs/source/cupy-reference/overview.rst
@@ -373,6 +373,8 @@ Sorting, searching, and counting
 :func:`argmax`
 :func:`argmin`
 :func:`count_nonzero`
+:func:`nonzero`
+:func:`flatnonzero`
 :func:`where`
 
 Statistics


### PR DESCRIPTION
I think `nonzero` and `flatnonzero` are missing from the list in the overview page of CuPy document. This PR adds them there.

http://docs.chainer.org/en/stable/cupy-reference/overview.html#sorting-searching-and-counting
![image](https://cloud.githubusercontent.com/assets/469803/20788319/a3b598ac-b7f3-11e6-9851-b164058d13e2.png)
