### PR TITLE
Add CIFAR-10/100 convnet example

### DIFF
--- a/examples/cifar/README.md
+++ b/examples/cifar/README.md
@@ -5,7 +5,7 @@ This is a an example of a convolutional neural network (convnet) applied to an i
 Specifically, there are 50000 color training images of size 32x32 pixels with either 10 class labels (for CIFAR-10) or 100 class labels (for CIFAR-100).
 
 For CIFAR-10, state of the art methods without data augmentation can achieve similar to human-level classification accuracy of around 94%.
-For CIFAR-100, state of the art without data augmentation is around 20% (DenseNet) but we are not aware of any estimates of human-level accuracy for comparison.
+For CIFAR-100, state of the art without data augmentation is around 20% (DenseNet).
 
 The code consists of three parts: dataset preparation, network and optimizer definition and learning loop, similar to the MNIST example.
 

--- a/examples/cifar/README.md
+++ b/examples/cifar/README.md
@@ -1,6 +1,6 @@
-# Convolutional nueral networks for CIFAR-10 and CIFAR-100 Classification
+# Convolutional neural networks for CIFAR-10 and CIFAR-100 Classification
 
-This is a an example of a convolutional neural network (convnet) applied to an image classification task using the CIFAR-10 or CIFAR-100 dataset. The CIFAR datasets can be a good choice for initial experiments with convnets because the size and number of images is small enough to allow typical models to be trained in a reasonable amount of time. However, the classification task is still challenging because natural images are used.
+This is an example of a convolutional neural network (convnet) applied to an image classification task using the CIFAR-10 or CIFAR-100 dataset. The CIFAR datasets can be a good choice for initial experiments with convnets because the size and number of images is small enough to allow typical models to be trained in a reasonable amount of time. However, the classification task is still challenging because natural images are used.
 
 Specifically, there are 50000 color training images of size 32x32 pixels with either 10 class labels (for CIFAR-10) or 100 class labels (for CIFAR-100).
 
@@ -13,7 +13,7 @@ More models may be added in the future, but currently only one model is availabl
 
 No data augmentation is used and the classification accuracy on the CIFAR-10 test set for the VGG-style model should reach approximately 89% after 200 iterations or so.
 
-If you want to run this example on the N-th GPU, pass `--gpu=N` to the script.
+If you want to run this example on the N-th GPU, pass `--gpu=N` to the script. To run on CPU, pass `--gpu=-1`.
 
 For example, to run the default model, which uses CIFAR-10 and GPU 0:
 ```

--- a/examples/cifar/README.md
+++ b/examples/cifar/README.md
@@ -1,18 +1,26 @@
-# Convolutional nueral networks for CIFAR Classification
+# Convolutional nueral networks for CIFAR-10 and CIFAR-100 Classification
 
-This is a an example of convolutional neural networks (convnets) applied to and image classification task using the CIFAR-10 or CIFAR-100 dataset. The CIFAR datasets can be a good choice for initial prototyping with convnets because the image size and number of images is still small enough that training can be completed in a reasonable amount of time on a single mid-range GPU. Specifically, there are 50000 color training images of size 32x32 pixels with either 10 class labels (for CIFAR-10) or 100 class labels (for CIFAR-100). These datasets are also challenging because natural images are used.
+This is a an example of a convolutional neural network (convnet) applied to an image classification task using the CIFAR-10 or CIFAR-100 dataset. The CIFAR datasets can be a good choice for initial experiments with convnets because the size and number of images is small enough to allow typical models to be trained in a reasonable amount of time. However, the classification task is still challenging because natural images are used.
+
+Specifically, there are 50000 color training images of size 32x32 pixels with either 10 class labels (for CIFAR-10) or 100 class labels (for CIFAR-100).
 
 For CIFAR-10, state of the art methods without data augmentation can achieve similar to human-level classification accuracy of around 94%.
-For CIFAR-100, state of the art without data augmentation is around 20% (DenseNet) but we are not aware of any estimates of human level accuracy for comparison.
+For CIFAR-100, state of the art without data augmentation is around 20% (DenseNet) but we are not aware of any estimates of human-level accuracy for comparison.
 
-The code consists of three parts: dataset preparation, network and optimizer definition and learning loop.
-This is a common routine to write a learning process of networks with dataset that is small enough to fit into memory.
+The code consists of three parts: dataset preparation, network and optimizer definition and learning loop, similar to the MNIST example.
+
+More models may be added in the future, but currently only one model is available that uses the VGG-style network from [here](http://torch.ch/blog/2015/07/30/cifar.html) which is based on the network architecture from the paper from [here](http://arxiv.org/pdf/1409.1556v6.pdf).
+
+No data augmentation is used and the classification accuracy on the CIFAR-10 test set for the VGG-style model should reach approximately 89% after 200 iterations or so.
 
 If you want to run this example on the N-th GPU, pass `--gpu=N` to the script.
 
-For example, to run the CIFAR-10 dataset on GPU 0:
+For example, to run the default model, which uses CIFAR-10 and GPU 0:
 ```
-train_cifar.py --gpu=0 --dataset='cifar10'
+train_cifar.py
 ```
 
-todo: select between models.
+to run the CIFAR-100 dataset on GPU 1:
+```
+train_cifar.py --gpu=1 --dataset='cifar100'
+```

--- a/examples/cifar/README.md
+++ b/examples/cifar/README.md
@@ -1,0 +1,18 @@
+# Convolutional nueral networks for CIFAR Classification
+
+This is a an example of convolutional neural networks (convnets) applied to and image classification task using the CIFAR-10 or CIFAR-100 dataset. The CIFAR datasets can be a good choice for initial prototyping with convnets because the image size and number of images is still small enough that training can be completed in a reasonable amount of time on a single mid-range GPU. Specifically, there are 50000 color training images of size 32x32 pixels with either 10 class labels (for CIFAR-10) or 100 class labels (for CIFAR-100). These datasets are also challenging because natural images are used.
+
+For CIFAR-10, state of the art methods without data augmentation can achieve similar to human-level classification accuracy of around 94%.
+For CIFAR-100, state of the art without data augmentation is around 20% (DenseNet) but we are not aware of any estimates of human level accuracy for comparison.
+
+The code consists of three parts: dataset preparation, network and optimizer definition and learning loop.
+This is a common routine to write a learning process of networks with dataset that is small enough to fit into memory.
+
+If you want to run this example on the N-th GPU, pass `--gpu=N` to the script.
+
+For example, to run the CIFAR-10 dataset on GPU 0:
+```
+train_cifar.py --gpu=0 --dataset='cifar10'
+```
+
+todo: select between models.

--- a/examples/cifar/models/VGG.py
+++ b/examples/cifar/models/VGG.py
@@ -1,0 +1,114 @@
+from __future__ import print_function
+
+import chainer
+import chainer.functions as F
+import chainer.links as L
+
+
+class Block(chainer.Chain):
+    """
+    A block in a feedforward network that performs a
+    convolution followed by batch normalization followed
+    by a ReLU activation.
+
+    For the convolution operation, a square filter size is used.
+
+    Args:
+        out_channels (int): The number of output channels.
+        ksize (int): The size of the filter is ksize x ksize.
+        pad (int): The padding to use for the convolution.
+    """
+    def __init__(self, out_channels, ksize, pad=1):
+        super(Block, self).__init__(
+            conv=L.Convolution2D(None, out_channels, ksize, pad=pad, nobias=True),
+            bn=L.BatchNormalization(out_channels)
+        )
+
+    def __call__(self, x, train=True):
+        h = self.conv(x)
+        h = self.bn(h, test=not train)
+        return F.relu(h)
+
+
+class VGG(chainer.Chain):
+    """
+    This model is based on the VGG-style model from the
+    Torch7 blog:
+    http://torch.ch/blog/2015/07/30/cifar.html
+    which is based on the network architecture from the paper:
+    http://arxiv.org/pdf/1409.1556v6.pdf
+
+    This model is intended to be used with either RGB or greyscale input
+    images that are of size 32x32 pixels, such as those in the CIFAR10
+    and CIFAR100 datasets.
+
+    On CIFAR10, it achieves approximately 86% accuracy on the test set.
+
+    Args:
+        class_labels (int): The number of class labels.
+    """
+
+    def __init__(self, class_labels=10):
+        super(VGG, self).__init__(
+            block1_1 = Block(64, 3),
+            block1_2 = Block(64, 3),
+            block2_1=Block(128, 3),
+            block2_2=Block(128, 3),
+            block3_1=Block(256, 3),
+            block3_2=Block(256, 3),
+            block3_3=Block(256, 3),
+            block4_1=Block(512, 3),
+            block4_2=Block(512, 3),
+            block4_3=Block(512, 3),
+            block5_1=Block(512, 3),
+            block5_2=Block(512, 3),
+            block5_3=Block(512, 3),
+            fc1=L.Linear(None, 512, nobias=True),
+            bn_fc1=L.BatchNormalization(512),
+            fc2=L.Linear(None, class_labels, nobias=True)
+        )
+        self.train = True
+
+    def __call__(self, x):
+        # 64 channel blocks:
+        h = self.block1_1(x, self.train)
+        h = F.dropout(h, ratio=0.3, train=self.train)
+        h = self.block1_2(h, self.train)
+        h = F.max_pooling_2d(h, 2, 2)
+
+        # 128 channel blocks:
+        h = self.block2_1(h, self.train)
+        h = F.dropout(h, ratio=0.4, train=self.train)
+        h = self.block2_2(h, self.train)
+        h = F.max_pooling_2d(h, 2, 2)
+
+        # 256 channel blocks:
+        h = self.block3_1(h, self.train)
+        h = F.dropout(h, ratio=0.4, train=self.train)
+        h = self.block3_2(h, self.train)
+        h = F.dropout(h, ratio=0.4, train=self.train)
+        h = self.block3_3(h, self.train)
+        h = F.max_pooling_2d(h, 2, 2)
+
+        # 512 channel blocks:
+        h = self.block4_1(h, self.train)
+        h = F.dropout(h, ratio=0.4, train=self.train)
+        h = self.block4_2(h, self.train)
+        h = F.dropout(h, ratio=0.4, train=self.train)
+        h = self.block4_3(h, self.train)
+        h = F.max_pooling_2d(h, 2, 2)
+
+        # 512 channel blocks:
+        h = self.block5_1(h, self.train)
+        h = F.dropout(h, ratio=0.4, train=self.train)
+        h = self.block5_2(h, self.train)
+        h = F.dropout(h, ratio=0.4, train=self.train)
+        h = self.block5_3(h, self.train)
+        h = F.max_pooling_2d(h, 2, 2)
+
+        h = F.dropout(h, ratio=0.5, train=self.train)
+        h = self.fc1(h)
+        h = self.bn_fc1(h, test=not self.train)
+        h = F.relu(h)
+        h = F.dropout(h, ratio=0.5, train=self.train)
+        return self.fc2(h)

--- a/examples/cifar/models/VGG.py
+++ b/examples/cifar/models/VGG.py
@@ -6,7 +6,8 @@ import chainer.links as L
 
 
 class Block(chainer.Chain):
-    """
+    """A convolution, batch norm, ReLU block.
+
     A block in a feedforward network that performs a
     convolution followed by batch normalization followed
     by a ReLU activation.
@@ -44,6 +45,9 @@ class VGG(chainer.Chain):
     and CIFAR100 datasets.
 
     On CIFAR10, it achieves approximately 89% accuracy on the test set with
+    no data augmentation.
+
+    On CIFAR100, it achieves approximately 63% accuracy on the test set with
     no data augmentation.
 
     Args:

--- a/examples/cifar/models/VGG.py
+++ b/examples/cifar/models/VGG.py
@@ -20,7 +20,8 @@ class Block(chainer.Chain):
     """
     def __init__(self, out_channels, ksize, pad=1):
         super(Block, self).__init__(
-            conv=L.Convolution2D(None, out_channels, ksize, pad=pad, nobias=True),
+            conv=L.Convolution2D(None, out_channels, ksize, pad=pad,
+                                 nobias=True),
             bn=L.BatchNormalization(out_channels)
         )
 
@@ -31,9 +32,9 @@ class Block(chainer.Chain):
 
 
 class VGG(chainer.Chain):
-    """
-    This model is based on the VGG-style model from the
-    Torch7 blog:
+    """A VGG-style network for very small images.
+
+    This model is based on the VGG-style model from
     http://torch.ch/blog/2015/07/30/cifar.html
     which is based on the network architecture from the paper:
     http://arxiv.org/pdf/1409.1556v6.pdf
@@ -42,7 +43,8 @@ class VGG(chainer.Chain):
     images that are of size 32x32 pixels, such as those in the CIFAR10
     and CIFAR100 datasets.
 
-    On CIFAR10, it achieves approximately 86% accuracy on the test set.
+    On CIFAR10, it achieves approximately 89% accuracy on the test set with
+    no data augmentation.
 
     Args:
         class_labels (int): The number of class labels.
@@ -50,8 +52,8 @@ class VGG(chainer.Chain):
 
     def __init__(self, class_labels=10):
         super(VGG, self).__init__(
-            block1_1 = Block(64, 3),
-            block1_2 = Block(64, 3),
+            block1_1=Block(64, 3),
+            block1_2=Block(64, 3),
             block2_1=Block(128, 3),
             block2_2=Block(128, 3),
             block3_1=Block(256, 3),

--- a/examples/cifar/models/VGG.py
+++ b/examples/cifar/models/VGG.py
@@ -18,6 +18,7 @@ class Block(chainer.Chain):
         out_channels (int): The number of output channels.
         ksize (int): The size of the filter is ksize x ksize.
         pad (int): The padding to use for the convolution.
+
     """
     def __init__(self, out_channels, ksize, pad=1):
         super(Block, self).__init__(
@@ -52,8 +53,8 @@ class VGG(chainer.Chain):
 
     Args:
         class_labels (int): The number of class labels.
-    """
 
+    """
     def __init__(self, class_labels=10):
         super(VGG, self).__init__(
             block1_1=Block(64, 3),
@@ -80,13 +81,13 @@ class VGG(chainer.Chain):
         h = self.block1_1(x, self.train)
         h = F.dropout(h, ratio=0.3, train=self.train)
         h = self.block1_2(h, self.train)
-        h = F.max_pooling_2d(h, 2, 2)
+        h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 128 channel blocks:
         h = self.block2_1(h, self.train)
         h = F.dropout(h, ratio=0.4, train=self.train)
         h = self.block2_2(h, self.train)
-        h = F.max_pooling_2d(h, 2, 2)
+        h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 256 channel blocks:
         h = self.block3_1(h, self.train)
@@ -94,7 +95,7 @@ class VGG(chainer.Chain):
         h = self.block3_2(h, self.train)
         h = F.dropout(h, ratio=0.4, train=self.train)
         h = self.block3_3(h, self.train)
-        h = F.max_pooling_2d(h, 2, 2)
+        h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 512 channel blocks:
         h = self.block4_1(h, self.train)
@@ -102,7 +103,7 @@ class VGG(chainer.Chain):
         h = self.block4_2(h, self.train)
         h = F.dropout(h, ratio=0.4, train=self.train)
         h = self.block4_3(h, self.train)
-        h = F.max_pooling_2d(h, 2, 2)
+        h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 512 channel blocks:
         h = self.block5_1(h, self.train)
@@ -110,7 +111,7 @@ class VGG(chainer.Chain):
         h = self.block5_2(h, self.train)
         h = F.dropout(h, ratio=0.4, train=self.train)
         h = self.block5_3(h, self.train)
-        h = F.max_pooling_2d(h, 2, 2)
+        h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         h = F.dropout(h, ratio=0.5, train=self.train)
         h = self.fc1(h)

--- a/examples/cifar/train_cifar.py
+++ b/examples/cifar/train_cifar.py
@@ -1,0 +1,105 @@
+from __future__ import print_function
+import argparse
+
+import chainer
+import chainer.links as L
+from chainer import training
+from chainer.training import extensions
+
+from chainer.datasets import get_cifar10
+from chainer.datasets import get_cifar100
+
+import models.VGG
+
+
+class TestModeEvaluator(extensions.Evaluator):
+
+    def evaluate(self):
+        model = self.get_target('main')
+        model.train = False
+        ret = super(TestModeEvaluator, self).evaluate()
+        model.train = True
+        return ret
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Chainer example: CIFAR10')
+    parser.add_argument('--dataset', '-d', default='cifar10',
+                        help='The dataset to use. Choices are cifar10 or cifar100')
+    parser.add_argument('--batchsize', '-b', type=int, default=128,
+                        help='Number of images in each mini-batch')
+    parser.add_argument('--epoch', '-e', type=int, default=300,
+                        help='Number of sweeps over the dataset to train')
+    parser.add_argument('--gpu', '-g', type=int, default=0,
+                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--out', '-o', default='result',
+                        help='Directory to output the result')
+    parser.add_argument('--resume', '-r', default='',
+                        help='Resume the training from snapshot')
+    args = parser.parse_args()
+
+    print('GPU: {}'.format(args.gpu))
+    print('# Minibatch-size: {}'.format(args.batchsize))
+    print('# epoch: {}'.format(args.epoch))
+    print('')
+
+    # Set up a neural network to train.
+    # Classifier reports softmax cross entropy loss and accuracy at every
+    # iteration, which will be used by the PrintReport extension below.
+    if args.dataset == 'cifar10':
+        print('Using CIFAR10 dataset.')
+        class_labels = 10
+        train, test = get_cifar10()
+    elif args.dataset == 'cifar100':
+        print('Using CIFAR100 dataset.')
+        class_labels = 100
+        train, test = get_cifar100()
+    else:
+        raise RuntimeError('Invalid dataset choice.')
+    model = L.Classifier(models.VGG.VGG(class_labels))
+    if args.gpu >= 0:
+        chainer.cuda.get_device(args.gpu).use()  # Make a specified GPU current
+        model.to_gpu()  # Copy the model to the GPU
+
+    # Setup an optimizer
+    optimizer = chainer.optimizers.Adam(alpha=1e-3)
+    optimizer.setup(model)
+
+    train_iter = chainer.iterators.SerialIterator(train, args.batchsize)
+    test_iter = chainer.iterators.SerialIterator(test, args.batchsize,
+                                                 repeat=False, shuffle=False)
+    # Set up a trainer
+    updater = training.StandardUpdater(train_iter, optimizer, device=args.gpu)
+    trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
+
+    # Evaluate the model with the test dataset for each epoch
+    trainer.extend(TestModeEvaluator(test_iter, model, device=args.gpu))
+
+    # Dump a computational graph from 'loss' variable at the first iteration
+    # The "main" refers to the target link of the "main" optimizer.
+    trainer.extend(extensions.dump_graph('main/loss'))
+
+    # Write a log of evaluation statistics for each epoch
+    trainer.extend(extensions.LogReport())
+
+    # Print selected entries of the log to stdout
+    # Here "main" refers to the target link of the "main" optimizer again, and
+    # "validation" refers to the default name of the Evaluator extension.
+    # Entries other than 'epoch' are reported by the Classifier link, called by
+    # either the updater or the evaluator.
+    trainer.extend(extensions.PrintReport(
+        ['epoch', 'main/loss', 'validation/main/loss',
+         'main/accuracy', 'validation/main/accuracy', 'elapsed_time']))
+
+    # Print a progress bar to stdout
+    trainer.extend(extensions.ProgressBar())
+
+    if args.resume:
+        # Resume from a snapshot
+        chainer.serializers.load_npz(args.resume, trainer)
+
+    # Run the training
+    trainer.run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Chainer already has dataset loaders for CIFAR-10 and CIFAR-100 but no corresponding examples. This PR adds an example to train a convolutional neural network on either of these datasets.