### PR TITLE
Add layer normalization

### DIFF
--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -28,6 +28,7 @@ from chainer.links.loss import hierarchical_softmax  # NOQA
 from chainer.links.loss import negative_sampling  # NOQA
 from chainer.links.model import classifier  # NOQA
 from chainer.links.normalization import batch_normalization  # NOQA
+from chainer.links.normalization import layer_normalization  # NOQA
 
 
 # import class and function
@@ -63,3 +64,4 @@ from chainer.links.model.classifier import Classifier  # NOQA
 from chainer.links.model.vision.resnet import ResNet50Layers  # NOQA
 from chainer.links.model.vision.vgg import VGG16Layers  # NOQA
 from chainer.links.normalization.batch_normalization import BatchNormalization  # NOQA
+from chainer.links.normalization.layer_normalization import LayerNormalization  # NOQA

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,6 +1,7 @@
 from chainer import cuda
 from chainer import initializers
 from chainer import link
+from chainer import utils
 
 from chainer.functions.array import broadcast
 from chainer.functions.math import bias
@@ -54,6 +55,8 @@ class LayerNormalization(link.Chain):
             initial_beta = initializers.Zero()
         self._beta_initializer = initial_beta
         self.eps = eps
+        utils.experimental(
+            'chainer.links.normalization.layer_normalization.py')
 
     def _initialize_params(self, size):
         self.add_param('gamma', size)

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,10 +1,10 @@
-import chainer
+from chainer import initializers
+from chainer import link
+
 from chainer.functions.array import broadcast
 from chainer.functions.math import sqrt
 from chainer.functions.math import square
 from chainer.functions.math import sum
-from chainer import initializers
-from chainer import link
 from chainer.links.connection import scale
 
 
@@ -12,8 +12,8 @@ class LayerNormalization(link.Chain):
 
     """Layer normalization layer on outputs of linear functions.
 
-    This is a link of "Layer Normalization". This layer
-    normalizes, scales and shifts input units with :link:`~chainer.links.Scale`.
+    This is a link of "Layer Normalization". This layer normalizes,
+    scales and shifts input units with :link:`~chainer.links.Scale`.
 
     Args:
         size (int): Size of input units.

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -12,11 +12,17 @@ class LayerNormalization(link.Chain):
 
     """Layer normalization layer on outputs of linear functions.
 
-    This is a link of "Layer Normalization". This layer normalizes,
-    scales and shifts input units with :link:`~chainer.links.Scale`.
+    This is a link of "Layer Normalization". This layer
+    normalizes input units by statistics along the second axis,
+    scales and shifts them with :class:`~chainer.links.Scale`.
 
     Args:
         size (int): Size of input units.
+
+    Attributes:
+        scale (~chainer.links.Scale): Layer to scale and shift
+            units after normalization.
+        eps (float): Epsilon value for numerical stability.
 
     See: `Layer Normalization <https://arxiv.org/abs/1607.06450>`_
     """

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -12,9 +12,10 @@ class LayerNormalization(link.Chain):
 
     """Layer normalization layer on outputs of linear functions.
 
-    This is a link of "Layer Normalization". This layer
-    normalizes input units by statistics along the second axis,
-    scales and shifts them with :class:`~chainer.links.Scale`.
+    This link implements a "layer normalization" layer
+    which normalizes the input units by statistics
+    that are computed along the second axis,
+    scales and shifts them with :class:~chainer.links.Scale.
 
     Args:
         size (int): Size of input units.

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -15,7 +15,7 @@ class LayerNormalization(link.Chain):
     This link implements a "layer normalization" layer
     which normalizes the input units by statistics
     that are computed along the second axis,
-    scales and shifts them with :class:~chainer.links.Scale.
+    scales and shifts them with :class:`~chainer.links.Scale`.
 
 
     Args:

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -17,15 +17,16 @@ class LayerNormalization(link.Chain):
     that are computed along the second axis,
     scales and shifts them with :class:~chainer.links.Scale.
 
+
     Args:
         size (int): Size of input units.
-        eps (float): Epsilon value for numerical stability of the normalization.
-        initial_gumma (~chainer.Initializer): Initializer for the scale vector.
+        eps (float): Epsilon value for numerical stability of normalization.
+        initial_gumma (~chainer.Initializer): Initializer for scaling vector.
             If ``None``, then the vector is initialized
             by :class:`~chainer.initializers.HeNormal`.
             If a scalar, the vectors are filled by it.
             If ``numpy.ndarray``, the vectors are set by it.
-        initial_beta (~chainer.Initializer): Initializer for the shift vector.
+        initial_beta (~chainer.Initializer): Initializer for shifting vector.
             If ``None``, then the vector is initialized
             by :class:`~chainer.initializers.HeNormal`.
             If a scalar, the vectors are filled by it.
@@ -62,4 +63,15 @@ class LayerNormalization(link.Chain):
         return (x - mean) / std
 
     def __call__(self, x):
+        """Apply layer normalization to given input.
+
+        Args:
+            x (~chainer.Variable): Batch vectors.
+                Shape of this value must be `(batch_size, unit_size)`,
+                e.g., the output of :func:`~chainer.functions.linear`.
+
+        Returns:
+            ~chainer.Variable: Output of the layer normalization.
+
+        """
         return self.scale(self._normalize(x))

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -51,7 +51,7 @@ class LayerNormalization(link.Chain):
         initializers.init_weight(self.scale.bias.b.data, initial_beta)
         self.eps = eps
 
-    def normalize(self, x):
+    def _normalize(self, x):
         size = x.shape[1]
         mean = broadcast.broadcast_to(
             (sum.sum(x, axis=1) / size)[:, None],
@@ -62,4 +62,4 @@ class LayerNormalization(link.Chain):
         return (x - mean) / std
 
     def __call__(self, x):
-        return self.scale(self.normalize(x))
+        return self.scale(self._normalize(x))

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -19,6 +19,17 @@ class LayerNormalization(link.Chain):
 
     Args:
         size (int): Size of input units.
+        eps (float): Epsilon value for numerical stability of the normalization.
+        initial_gumma (~chainer.Initializer): Initializer for the scale vector.
+            If ``None``, then the vector is initialized
+            by :class:`~chainer.initializers.HeNormal`.
+            If a scalar, the vectors are filled by it.
+            If ``numpy.ndarray``, the vectors are set by it.
+        initial_beta (~chainer.Initializer): Initializer for the shift vector.
+            If ``None``, then the vector is initialized
+            by :class:`~chainer.initializers.HeNormal`.
+            If a scalar, the vectors are filled by it.
+            If ``numpy.ndarray``, the vectors are set by it.
 
     Attributes:
         scale (~chainer.links.Scale): Layer to scale and shift

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -26,15 +26,13 @@ class LayerNormalization(link.Chain):
     Args:
         eps (float): Epsilon value for numerical stability of normalization.
         initial_gamma (~chainer.Initializer): Initializer for scaling vector.
-            If ``None``, then the vector is initialized
-            by :class:`~chainer.initializers.HeNormal`.
-            If a scalar, the vectors are filled by it.
-            If ``numpy.ndarray``, the vectors are set by it.
+            If ``None``, then the vector is filled by 1.
+            If a scalar, the vector is filled by it.
+            If ``numpy.ndarray``, the vector is set by it.
         initial_beta (~chainer.Initializer): Initializer for shifting vector.
-            If ``None``, then the vector is initialized
-            by :class:`~chainer.initializers.HeNormal`.
-            If a scalar, the vectors are filled by it.
-            If ``numpy.ndarray``, the vectors are set by it.
+            If ``None``, then the vector is filled by 0.
+            If a scalar, the vector is filled by it.
+            If ``numpy.ndarray``, the vector is set by it.
 
     Attributes:
         gamma (~chainer.Variable): Scaling parameter.

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,0 +1,43 @@
+from chainer import functions
+from chainer import initializers
+from chainer import link
+from chainer import links
+
+
+class LayerNormalization(link.Chain):
+
+    """Layer normalization layer on outputs of linear functions.
+
+    This is a link of "Layer Normalization". This layer
+    normalizes, scales and shifts input units with :link:`~chainer.links.Scale`.
+
+    Args:
+        size (int): Size of input units.
+
+    See: `Layer Normalization <https://arxiv.org/abs/1607.06450>`_
+    """
+
+    def __init__(self, size, eps=1e-6, initial_gamma=None, initial_beta=None):
+        super(LayerNormalization, self).__init__(
+            scale=links.Scale(axis=1, W_shape=(size, ), bias_term=True),
+        )
+        if initial_gamma is None:
+            initial_gamma = initializers.One()
+        initializers.init_weight(self.scale.W.data, initial_gamma)
+        if initial_beta is None:
+            initial_beta = initializers.Zero()
+        initializers.init_weight(self.scale.bias.b.data, initial_beta)
+        self.eps = eps
+
+    def normalize(self, x):
+        size = x.shape[1]
+        mean = functions.broadcast_to(
+            (functions.sum(x, axis=1) / size)[:, None],
+            x.shape)
+        std = functions.broadcast_to(functions.sqrt(
+            functions.sum(functions.square(x - mean), axis=1) / size)[:, None],
+            x.shape) + self.eps
+        return (x - mean) / std
+
+    def __call__(self, x):
+        return self.scale(self.normalize(x))

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,7 +1,11 @@
-from chainer import functions
+import chainer
+from chainer.functions.array import broadcast
+from chainer.functions.math import sqrt
+from chainer.functions.math import square
+from chainer.functions.math import sum
 from chainer import initializers
 from chainer import link
-from chainer import links
+from chainer.links.connection import scale
 
 
 class LayerNormalization(link.Chain):
@@ -19,7 +23,7 @@ class LayerNormalization(link.Chain):
 
     def __init__(self, size, eps=1e-6, initial_gamma=None, initial_beta=None):
         super(LayerNormalization, self).__init__(
-            scale=links.Scale(axis=1, W_shape=(size, ), bias_term=True),
+            scale=scale.Scale(axis=1, W_shape=(size, ), bias_term=True),
         )
         if initial_gamma is None:
             initial_gamma = initializers.One()
@@ -31,11 +35,11 @@ class LayerNormalization(link.Chain):
 
     def normalize(self, x):
         size = x.shape[1]
-        mean = functions.broadcast_to(
-            (functions.sum(x, axis=1) / size)[:, None],
+        mean = broadcast.broadcast_to(
+            (sum.sum(x, axis=1) / size)[:, None],
             x.shape)
-        std = functions.broadcast_to(functions.sqrt(
-            functions.sum(functions.square(x - mean), axis=1) / size)[:, None],
+        std = broadcast.broadcast_to(sqrt.sqrt(
+            sum.sum(square.square(x - mean), axis=1) / size)[:, None],
             x.shape) + self.eps
         return (x - mean) / std
 

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,3 +1,4 @@
+from chainer import cuda
 from chainer import initializers
 from chainer import link
 
@@ -17,10 +18,11 @@ class LayerNormalization(link.Chain):
     which normalizes the input units by statistics
     that are computed along the second axis,
     scales and shifts them.
+    Parameter initialization will be deferred until
+    the first forward data pass at which time the size will be determined.
 
 
     Args:
-        size (int): Size of input units.
         eps (float): Epsilon value for numerical stability of normalization.
         initial_gamma (~chainer.Initializer): Initializer for scaling vector.
             If ``None``, then the vector is initialized
@@ -41,18 +43,23 @@ class LayerNormalization(link.Chain):
     See: `Layer Normalization <https://arxiv.org/abs/1607.06450>`_
     """
 
-    def __init__(self, size, eps=1e-6, initial_gamma=None, initial_beta=None):
+    def __init__(self, eps=1e-6, initial_gamma=None, initial_beta=None):
         super(LayerNormalization, self).__init__()
-        self.add_param('gamma', size)
+        self.add_uninitialized_param('gamma')
+        self.add_uninitialized_param('beta')
         if initial_gamma is None:
             initial_gamma = initializers.One()
-        initializers.init_weight(self.gamma.data, initial_gamma)
-
-        self.add_param('beta', size)
+        self._gamma_initializer = initial_gamma
         if initial_beta is None:
             initial_beta = initializers.Zero()
-        initializers.init_weight(self.beta.data, initial_beta)
+        self._beta_initializer = initial_beta
         self.eps = eps
+
+    def _initialize_params(self, size):
+        self.add_param('gamma', size)
+        initializers.init_weight(self.gamma.data, self._gamma_initializer)
+        self.add_param('beta', size)
+        initializers.init_weight(self.beta.data, self._beta_initializer)
 
     def _normalize(self, x):
         size = x.shape[1]
@@ -76,5 +83,9 @@ class LayerNormalization(link.Chain):
             ~chainer.Variable: Output of the layer normalization.
 
         """
+        if self.has_uninitialized_params:
+            with cuda.get_device(self._device_id):
+                self._initialize_params(x.size // x.shape[0])
+
         normalized = self._normalize(x)
         return bias.bias(scale.scale(normalized, self.gamma), self.beta)

--- a/docs/source/reference/links.rst
+++ b/docs/source/reference/links.rst
@@ -119,6 +119,11 @@ BatchNormalization
 .. autoclass:: BatchNormalization
    :members:
 
+LayerNormalization
+~~~~~~~~~~~~~~~~~~
+.. autoclass:: LayerNormalization
+   :members:
+
 BinaryHierarchicalSoftmax
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: BinaryHierarchicalSoftmax

--- a/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import six
 
 import chainer
 from chainer import cuda
@@ -14,12 +13,7 @@ from chainer.utils import type_check
 
 
 @testing.parameterize(*(testing.product({
-    'volatile': ['on'],
-    'batchsize': [1, 5],
-    'size': [10, 100],
-    'dtype': [numpy.float32],
-}) + testing.product({
-    'volatile': ['off'],
+    'volatile': ['on', 'off'],
     'batchsize': [1, 5],
     'size': [10, 100],
     'dtype': [numpy.float32],

--- a/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
@@ -72,7 +72,7 @@ class LayerNormalizationTest(unittest.TestCase):
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             self.link, x_data, y_grad,
-            (self.link.scale.W, self.link.scale.bias.b),
+            (self.link.gamma, self.link.beta),
             eps=1e-2, **self.check_backward_optionss)
 
     @condition.retry(3)
@@ -112,15 +112,15 @@ class TestInitialize(unittest.TestCase):
 
     @condition.retry(3)
     def test_initialize_cpu(self):
-        testing.assert_allclose(self.initial_gamma, self.link.scale.W.data)
-        testing.assert_allclose(self.initial_beta, self.link.scale.bias.b.data)
+        testing.assert_allclose(self.initial_gamma, self.link.gamma.data)
+        testing.assert_allclose(self.initial_beta, self.link.beta.data)
 
     @attr.gpu
     @condition.retry(3)
     def test_initialize_gpu(self):
         self.link.to_gpu()
-        testing.assert_allclose(self.initial_gamma, self.link.scale.W.data)
-        testing.assert_allclose(self.initial_beta, self.link.scale.bias.b.data)
+        testing.assert_allclose(self.initial_gamma, self.link.gamma.data)
+        testing.assert_allclose(self.initial_beta, self.link.beta.data)
 
 
 class TestDefaultInitializer(unittest.TestCase):
@@ -130,16 +130,16 @@ class TestDefaultInitializer(unittest.TestCase):
         self.link = links.LayerNormalization(self.size)
 
     def test_initialize_cpu(self):
-        testing.assert_allclose(numpy.ones(self.size), self.link.scale.W.data)
+        testing.assert_allclose(numpy.ones(self.size), self.link.gamma.data)
         testing.assert_allclose(
-            numpy.zeros(self.size), self.link.scale.bias.b.data)
+            numpy.zeros(self.size), self.link.beta.data)
 
     @attr.gpu
     def test_initialize_gpu(self):
         self.link.to_gpu()
-        testing.assert_allclose(numpy.ones(self.size), self.link.scale.W.data)
+        testing.assert_allclose(numpy.ones(self.size), self.link.gamma.data)
         testing.assert_allclose(
-            numpy.zeros(self.size), self.link.scale.bias.b.data)
+            numpy.zeros(self.size), self.link.beta.data)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
@@ -1,0 +1,178 @@
+import unittest
+
+import numpy
+import six
+
+import chainer
+from chainer import cuda
+from chainer import gradient_check
+from chainer import links
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+from chainer.utils import type_check
+
+
+@testing.parameterize(*(testing.product({
+    'volatile': ['on'],
+    'batchsize': [1, 5],
+    'size': [10, 100],
+    'dtype': [numpy.float32],
+}) + testing.product({
+    'volatile': ['off'],
+    'batchsize': [1, 5],
+    'size': [10, 100],
+    'dtype': [numpy.float32],
+})))
+class LayerNormalizationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.LayerNormalization(self.size)
+        self.link.cleargrads()
+
+        shape = (self.batchsize, self.size)
+        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+
+        self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_optionss = {'atol': 5e-1, 'rtol': 1e-1}
+
+    def check_forward(self, x_data):
+        x = chainer.Variable(x_data, volatile=self.volatile)
+        y = self.link(x)
+        self.assertEqual(y.data.dtype, self.dtype)
+
+        unbatched_concat_y = chainer.functions.concat(
+            [self.link(x[None, ]) for x in x_data], axis=0)
+
+        testing.assert_allclose(
+            y.data, unbatched_concat_y.data, **self.check_forward_optionss)
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.link.to_gpu()
+        self.check_forward(cuda.to_gpu(self.x))
+
+    @attr.cudnn
+    def test_forward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_forward_gpu()
+
+    @attr.multi_gpu(2)
+    @condition.retry(3)
+    def test_forward_multi_gpu(self):
+        with cuda.get_device(1):
+            self.link.to_gpu()
+            x = cuda.to_gpu(self.x)
+        with cuda.get_device(0):
+            self.check_forward(x)
+
+    def check_backward(self, x_data, y_grad):
+        gradient_check.check_backward(
+            self.link, x_data, y_grad,
+            (self.link.scale.W, self.link.scale.bias.b),
+            eps=1e-2, **self.check_backward_optionss)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.link.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    @attr.cudnn
+    def test_backward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_backward_gpu()
+
+    @attr.cudnn
+    def test_backward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_backward_gpu()
+
+
+@testing.parameterize(*testing.product({
+    'size': [3, 50],
+}))
+class TestInitialize(unittest.TestCase):
+
+    def setUp(self):
+        self.initial_gamma = numpy.random.uniform(-1, 1, self.size)
+        self.initial_gamma = self.initial_gamma.astype(numpy.float32)
+        self.initial_beta = numpy.random.uniform(-1, 1, self.size)
+        self.initial_beta = self.initial_beta.astype(numpy.float32)
+        self.link = links.LayerNormalization(self.size,
+                                             initial_gamma=self.initial_gamma,
+                                             initial_beta=self.initial_beta)
+
+    @condition.retry(3)
+    def test_initialize_cpu(self):
+        testing.assert_allclose(self.initial_gamma, self.link.scale.W.data)
+        testing.assert_allclose(self.initial_beta, self.link.scale.bias.b.data)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_initialize_gpu(self):
+        self.link.to_gpu()
+        testing.assert_allclose(self.initial_gamma, self.link.scale.W.data)
+        testing.assert_allclose(self.initial_beta, self.link.scale.bias.b.data)
+
+
+class TestDefaultInitializer(unittest.TestCase):
+
+    def setUp(self):
+        self.size = 3
+        self.link = links.LayerNormalization(self.size)
+
+    def test_initialize_cpu(self):
+        testing.assert_allclose(numpy.ones(self.size), self.link.scale.W.data)
+        testing.assert_allclose(
+            numpy.zeros(self.size), self.link.scale.bias.b.data)
+
+    @attr.gpu
+    def test_initialize_gpu(self):
+        self.link.to_gpu()
+        testing.assert_allclose(numpy.ones(self.size), self.link.scale.W.data)
+        testing.assert_allclose(
+            numpy.zeros(self.size), self.link.scale.bias.b.data)
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(2, 4), (2, 5, 3, 4)],
+}))
+class TestInvalidInput(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.LayerNormalization(3)
+
+    def test_invalid_shape_cpu(self):
+        with self.assertRaises(type_check.InvalidType):
+            self.link(chainer.Variable(numpy.zeros(self.shape, dtype='f')))
+
+    @attr.gpu
+    def test_invalid_shape_gpu(self):
+        self.link.to_gpu()
+        # with self.assertRaises(type_check.InvalidType):
+        with self.assertRaises(type_check.InvalidType):
+            self.link(chainer.Variable(cuda.cupy.zeros(self.shape, dtype='f')))
+
+
+class TestInvalidInitialize(unittest.TestCase):
+
+    def test_invalid_type(self):
+        with self.assertRaises(TypeError):
+            self.link = links.LayerNormalization({})
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds a new link, LayerNormalization from "Layer Normalization." by Jimmy Lei Ba, Jamie Ryan Kiros and Geoffrey E. Hinton on https://arxiv.org/abs/1607.06450.

The paper says Layer Normalization is successful specially for internal layers in RNN including LSTM and GRU. Such RNN units with incorporated Layer Normalization (like [this](https://github.com/pfnet/chainer/blob/4df382824b6ff95a012643b7aacbc9ad3f738887/chainer/links/connection/zoneoutlstm.py)) are not included in this PR. After this PR is merged, I will begin to make them.