### PR TITLE
Add slow flag to test_vision for CI

### DIFF
--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -11,6 +11,7 @@ from chainer.variable import Variable
 
 
 @unittest.skipUnless(resnet.available, 'Pillow is required')
+@attr.slow
 class TestResNet50Layers(unittest.TestCase):
 
     def setUp(self):
@@ -120,6 +121,7 @@ class TestResNet50Layers(unittest.TestCase):
 
 
 @unittest.skipUnless(resnet.available, 'Pillow is required')
+@attr.slow
 class TestVGG16Layers(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This PR fixes test so that CI will succeed.

`test_vision.py` includes downloading large file.
Travis CI cannot run long time job.
https://travis-ci.org/pfnet/chainer/jobs/181078547#L768

