### PR TITLE
Add constant weights argument to softmax_cross_entropy function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 
 install:
   - pip install -U pip wheel
-  - pip install cython
+  - pip install 'cython!=0.25.2'
   - python setup.py sdist
   - pip install dist/*.tar.gz
   - pip install h5py pillow

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -1,11 +1,12 @@
+import numpy
+import six
+
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.functions.activation import log_softmax
 from chainer.utils import type_check
 
-import chainer
-import numpy
-import six
 
 
 class SoftmaxCrossEntropy(function.Function):
@@ -207,7 +208,8 @@ def softmax_cross_entropy(
             with the second dimension. The shape of this array should be
             ``(x.shape[1],)``. If this is not ``None``, each class weight
             ``class_weight[i]`` is actually multiplied to the corresponding
-            softmax output ``y[i]`` before calculating the actual loss value.
+            log-softmax output ``y[i]`` before calculating the actual loss
+            value.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -24,8 +24,6 @@ class SoftmaxCrossEntropy(function.Function):
         if class_weight is not None:
             assert self.class_weight.ndim == 1
             assert self.class_weight.dtype.kind == 'f'
-            if isinstance(class_weight, chainer.Variable):
-                self.class_weight = class_weight.data
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -199,10 +197,12 @@ def softmax_cross_entropy(
         cache_score (bool): When it is ``True``, the function stores result
             of forward computation to use it on backward computation. It
             reduces computational cost though consumes more memory.
-        class_weight (~numpy.ndarray or ~cupy.ndarray or ~chainer.Variable): An
-            array that contains constant weights that will be multiplied with
-            the loss values along with the second dimension. The shape of this
-            array should be ``(x.shape[1],)``.
+        class_weight (~numpy.ndarray or ~cupy.ndarray): An array that contains
+            constant weights that will be multiplied with the loss values along
+            with the second dimension. The shape of this array should be
+            ``(x.shape[1],)``. If this is not ``None``, each class weight
+            ``class_weight[i]`` is actually multiplied to the corresponding
+            softmax output ``y[i]`` before calculating the actual loss value.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -1,11 +1,11 @@
-import numpy
-import six
-
-import chainer
 from chainer import cuda
 from chainer import function
 from chainer.functions.activation import log_softmax
 from chainer.utils import type_check
+
+import chainer
+import numpy
+import six
 
 
 class SoftmaxCrossEntropy(function.Function):
@@ -22,8 +22,13 @@ class SoftmaxCrossEntropy(function.Function):
         self.cache_score = cache_score
         self.class_weight = class_weight
         if class_weight is not None:
-            assert self.class_weight.ndim == 1
-            assert self.class_weight.dtype.kind == 'f'
+            if self.class_weight.ndim != 1:
+                raise ValueError('class_weight.ndim should be 1')
+            if self.class_weight.dtype.kind != 'f':
+                raise ValueError('The dtype of class_weight should be \'f\'')
+            if isinstance(self.class_weight, chainer.Variable):
+                raise ValueError('class_weight should be a numpy.ndarray or '
+                                 'cupy.ndarray, not a chainer.Variable')
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -202,13 +202,13 @@ def softmax_cross_entropy(
         cache_score (bool): When it is ``True``, the function stores result
             of forward computation to use it on backward computation. It
             reduces computational cost though consumes more memory.
-        class_weight (~numpy.ndarray or ~cupy.ndarray): An array that contains
-            constant weights that will be multiplied with the loss values along
-            with the second dimension. The shape of this array should be
-            ``(x.shape[1],)``. If this is not ``None``, each class weight
-            ``class_weight[i]`` is actually multiplied to the corresponding
-            log-softmax output ``y[i]`` before calculating the actual loss
-            value.
+        class_weight (~numpy.ndarray or ~chainer.cuda.cupy.ndarray): An array
+            that contains constant weights that will be multiplied with the
+            loss values along with the second dimension. The shape of this
+            array should be ``(x.shape[1],)``. If this is not ``None``, each
+            class weight ``class_weight[i]`` is actually multiplied to the
+            corresponding log-softmax output ``y[i]`` before calculating the
+            actual loss value.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -8,7 +8,6 @@ from chainer.functions.activation import log_softmax
 from chainer.utils import type_check
 
 
-
 class SoftmaxCrossEntropy(function.Function):
 
     """Softmax activation followed by a cross entropy loss."""

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -1,11 +1,11 @@
+import numpy
+import six
+
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.functions.activation import log_softmax
 from chainer.utils import type_check
-
-import chainer
-import numpy
-import six
 
 
 class SoftmaxCrossEntropy(function.Function):
@@ -20,10 +20,10 @@ class SoftmaxCrossEntropy(function.Function):
         self.use_cudnn = use_cudnn
         self.normalize = normalize
         self.cache_score = cache_score
-        self.class_weight = class_weight
-        if class_weight is not None:
-            assert self.class_weight.ndim == 1
-            assert self.class_weight.dtype.kind == 'f'
+        self._class_weight = class_weight
+        if self._class_weight is not None:
+            assert self._class_weight.ndim == 1
+            assert self._class_weight.dtype.kind == 'f'
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -54,12 +54,12 @@ class SoftmaxCrossEntropy(function.Function):
         log_y = log_softmax._log_softmax(x, self.use_cudnn)
         if self.cache_score:
             self.y = numpy.exp(log_y)
-        if self.class_weight is not None:
-            if self.class_weight.shape != x.shape:
+        if self._class_weight is not None:
+            if self._class_weight.shape != x.shape:
                 shape = [1 if d != 1 else -1 for d in six.moves.range(x.ndim)]
-                self.class_weight = numpy.broadcast_to(
-                    self.class_weight.reshape(shape), x.shape)
-            log_y *= self.class_weight
+                self._class_weight = numpy.broadcast_to(
+                    self._class_weight.reshape(shape), x.shape)
+            log_y *= self._class_weight
         log_yd = numpy.rollaxis(log_y, 1)
         log_yd = log_yd.reshape(len(log_yd), -1)
         log_p = log_yd[numpy.maximum(t.ravel(), 0), numpy.arange(t.size)]
@@ -85,10 +85,10 @@ class SoftmaxCrossEntropy(function.Function):
         log_y = log_softmax._log_softmax(x, self.use_cudnn)
         if self.cache_score:
             self.y = cupy.exp(log_y)
-        if self.class_weight is not None:
+        if self._class_weight is not None:
             shape = [1 if d != 1 else -1 for d in six.moves.range(x.ndim)]
             log_y *= cupy.broadcast_to(
-                self.class_weight.reshape(shape), x.shape)
+                self._class_weight.reshape(shape), x.shape)
         if self.normalize:
             coeff = cupy.maximum(1, (t != self.ignore_label).sum())
         else:
@@ -114,8 +114,8 @@ class SoftmaxCrossEntropy(function.Function):
         if y.ndim == 2:
             gx = y
             gx[numpy.arange(len(t)), numpy.maximum(t, 0)] -= 1
-            if self.class_weight is not None:
-                c = self.class_weight[
+            if self._class_weight is not None:
+                c = self._class_weight[
                     numpy.arange(len(t)), numpy.maximum(t, 0)]
                 gx *= numpy.broadcast_to(numpy.expand_dims(c, 1), gx.shape)
             gx *= (t != self.ignore_label).reshape((len(t), 1))
@@ -128,8 +128,8 @@ class SoftmaxCrossEntropy(function.Function):
             fst_index = numpy.arange(t.size) // n_unit
             trd_index = numpy.arange(t.size) % n_unit
             gx[fst_index, numpy.maximum(t.ravel(), 0), trd_index] -= 1
-            if self.class_weight is not None:
-                c = self.class_weight.reshape(gx.shape)
+            if self._class_weight is not None:
+                c = self._class_weight.reshape(gx.shape)
                 c = c[fst_index, numpy.maximum(t.ravel(), 0), trd_index]
                 c = c.reshape(y.shape[0], 1, -1)
                 gx *= numpy.broadcast_to(c, gx.shape)
@@ -149,7 +149,7 @@ class SoftmaxCrossEntropy(function.Function):
         gloss = grad_outputs[0]
         n_unit = t.size // len(t)
         coeff = gloss * self._coeff
-        if self.class_weight is None:
+        if self._class_weight is None:
             gx = cuda.elementwise(
                 'T y, S t, raw T coeff, S n_channel, S n_unit',
                 'T gx',
@@ -168,7 +168,7 @@ class SoftmaxCrossEntropy(function.Function):
                     gx = t == -1 ? 0 : coeff[0] * (y - (c == t)) * w[t];
                 ''',
                 'softmax_crossent_bwd')(
-                    y, self.class_weight, cupy.expand_dims(t, 1), coeff,
+                    y, self._class_weight, cupy.expand_dims(t, 1), coeff,
                     x.shape[1], n_unit)
         return gx, None
 

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -21,9 +21,11 @@ class SoftmaxCrossEntropy(function.Function):
         self.normalize = normalize
         self.cache_score = cache_score
         self.class_weight = class_weight
-        if self.class_weight is not None:
+        if class_weight is not None:
             assert self.class_weight.ndim == 1
             assert self.class_weight.dtype.kind == 'f'
+            if isinstance(class_weight, chainer.Variable):
+                self.class_weight = class_weight.data
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -197,10 +199,10 @@ def softmax_cross_entropy(
         cache_score (bool): When it is ``True``, the function stores result
             of forward computation to use it on backward computation. It
             reduces computational cost though consumes more memory.
-        class_weight (~numpy.ndarray or ~cupy.ndarray): An array that contains
-            constant weights that will be multiplied with the loss values along
-            with the second dimension. The shape of this array should be
-            ``(x.shape[1],)``.
+        class_weight (~numpy.ndarray or ~cupy.ndarray or ~chainer.Variable): An
+            array that contains constant weights that will be multiplied with
+            the loss values along with the second dimension. The shape of this
+            array should be ``(x.shape[1],)``.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -162,11 +162,7 @@ class SoftmaxCrossEntropy(function.Function):
                 'T gx',
                 '''
                     const int c = (i / n_unit % n_channel);
-                    if (t == -1) {
-                        gx = 0;
-                    } else {
-                        gx = coeff[0] * (y - (t == c)) * w[t];
-                    }
+                    gx = t == -1 ? 0 : coeff[0] * (y - (c == t)) * w[t];
                 ''',
                 'softmax_crossent_bwd')(
                     y, self.c, cupy.expand_dims(t, 1), coeff, x.shape[1],

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -206,9 +206,10 @@ def softmax_cross_entropy(
             that contains constant weights that will be multiplied with the
             loss values along with the second dimension. The shape of this
             array should be ``(x.shape[1],)``. If this is not ``None``, each
-            class weight ``class_weight[i]`` is actually multiplied to the
-            corresponding log-softmax output ``y[i]`` before calculating the
-            actual loss value.
+            class weight ``class_weight[i]`` is actually multiplied to
+            ``y[:, i]`` that is the corresponding log-softmax output of ``x``
+            and has the same shape as ``x`` before calculating the actual loss
+            value.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -174,6 +174,7 @@ class TestSoftmaxCrossEntropyValueCheck(unittest.TestCase):
             with self.assertRaises(ValueError):
                 functions.softmax_cross_entropy(x, t, use_cudnn)
 
+    # numpy.broadcast_to is available only from numpy>=1.10
     @testing.with_requires('numpy>=1.10')
     def test_value_check_cpu(self):
         self.check_value_check(self.x, self.t, False)
@@ -203,6 +204,7 @@ class TestSoftmaxCrossEntropyCudnnCall(unittest.TestCase):
         t = chainer.Variable(self.t)
         return functions.softmax_cross_entropy(x, t, self.use_cudnn)
 
+    # numpy.broadcast_to is available only from numpy>=1.10
     @testing.with_requires('numpy>=1.10')
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -217,4 +217,30 @@ class TestSoftmaxCrossEntropyCudnnCall(unittest.TestCase):
     # Note that SoftmaxCrossEntropy does not use cudnn on backward
 
 
+class TestClassWeightAssertion(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.array([[0, 1], [2, 3]])
+        self.t = numpy.array([0, 1])
+
+    def test_ndim_assertion(self):
+        wrong_ndim_class_weight = numpy.array([[0, 0]], dtype='f')
+        with self.assertRaises(ValueError):
+            functions.softmax_cross_entropy(
+                self.x, self.t, class_weight=wrong_ndim_class_weight)
+
+    def test_dtype_assertion(self):
+        wrong_dtype_class_weight = numpy.array([0, 0], dtype=numpy.int32)
+        with self.assertRaises(ValueError):
+            functions.softmax_cross_entropy(
+                self.x, self.t, class_weight=wrong_dtype_class_weight)
+
+    def test_variable_assertion(self):
+        wrong_inst_class_weight = chainer.Variable(
+            numpy.array([0, 0], dtype='f'))
+        with self.assertRaises(ValueError):
+            functions.softmax_cross_entropy(
+                self.x, self.t, class_weight=wrong_inst_class_weight)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -20,7 +20,6 @@ from chainer.testing import condition
     'ignore_index': [None, (slice(None),), (0,), (0, 1), (0, 1, 0)],
     'dtype': [numpy.float32],
     'weight_apply': [False, True],
-    'weight_var': [False, True],
 }) + testing.product({
     'shape': [None, (2, 3), (2, 3, 2), (2, 3, 2, 2)],
     'cache_score': [False],
@@ -28,7 +27,6 @@ from chainer.testing import condition
     'ignore_index': [(0, 1)],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'weight_apply': [False, True],
-    'weight_var': [False, True],
 })))
 class TestSoftmaxCrossEntropy(unittest.TestCase):
 
@@ -62,13 +60,9 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
     def check_forward(self, x_data, t_data, class_weight, use_cudnn=True):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
-        if self.weight_apply and self.weight_var:
-            class_weight = chainer.Variable(class_weight)
         loss = functions.softmax_cross_entropy(
             x, t, use_cudnn=use_cudnn, normalize=self.normalize,
             cache_score=self.cache_score, class_weight=class_weight)
-        if self.weight_apply and self.weight_var:
-            class_weight = class_weight.data
         self.assertEqual(loss.data.shape, ())
         self.assertEqual(loss.data.dtype, self.dtype)
         self.assertEqual(hasattr(loss.creator, 'y'), self.cache_score)
@@ -123,8 +117,6 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             False)
 
     def check_backward(self, x_data, t_data, class_weight, use_cudnn=True):
-        if self.weight_apply and self.weight_var:
-            class_weight = chainer.Variable(class_weight)
         func = functions.SoftmaxCrossEntropy(
             use_cudnn=use_cudnn, cache_score=self.cache_score,
             class_weight=class_weight)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -1,15 +1,16 @@
+import unittest
+
+import mock
+import numpy
+import six
+
+import chainer
 from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
-
-import chainer
-import mock
-import numpy
-import six
-import unittest
 
 
 @testing.parameterize(*(testing.product({
@@ -94,6 +95,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         testing.assert_allclose(
             loss_expect, loss_value, **self.check_forward_options)
 
+    # numpy.broadcast_to is available only from numpy>=1.10
     @testing.with_requires('numpy>=1.10')
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -122,6 +124,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             func, (x_data, t_data), None, eps=0.02,
             **self.check_backward_options)
 
+    # numpy.broadcast_to is available only from numpy>=1.10
     @testing.with_requires('numpy>=1.10')
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -94,6 +94,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         testing.assert_allclose(
             loss_expect, loss_value, **self.check_forward_options)
 
+    @testing.with_requires('numpy>=1.10')
     @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t, self.class_weight)
@@ -121,6 +122,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             func, (x_data, t_data), None, eps=0.02,
             **self.check_backward_options)
 
+    @testing.with_requires('numpy>=1.10')
     @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t, self.class_weight)
@@ -169,6 +171,7 @@ class TestSoftmaxCrossEntropyValueCheck(unittest.TestCase):
             with self.assertRaises(ValueError):
                 functions.softmax_cross_entropy(x, t, use_cudnn)
 
+    @testing.with_requires('numpy>=1.10')
     def test_value_check_cpu(self):
         self.check_value_check(self.x, self.t, False)
 
@@ -197,6 +200,7 @@ class TestSoftmaxCrossEntropyCudnnCall(unittest.TestCase):
         t = chainer.Variable(self.t)
         return functions.softmax_cross_entropy(x, t, self.use_cudnn)
 
+    @testing.with_requires('numpy>=1.10')
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports softmax-log')


### PR DESCRIPTION
This PR adds an option to softmax_cross_entropy function for weighting the softmax cross entropy loss with a constant vector.