### PR TITLE
Fix doctest of chainer.utils.experimental

### DIFF
--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -44,7 +44,7 @@ def experimental(api_name):
         f(1)
 
     .. testoutput::
-        :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+        :options: +IGNORE_EXCEPTION_DETAIL, +NORMALIZE_WHITESPACE
 
         ... FutureWarning: chainer.foo.bar.f is experimental. \
 The interface can change in the future.

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -64,7 +64,7 @@ The interface can change in the future.
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         ... FutureWarning: chainer.foo.C is experimental. \
-The interface can change in the future
+The interface can change in the future.
 
     If we want to mark ``__init__`` method only, rather than class itself,
     it is recommended that we explicitly feed its API name.
@@ -80,8 +80,8 @@ The interface can change in the future
     .. testoutput::
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-       ...  FutureWarning: D.__init__ is experimental. \
-The interface can change in the future
+        ...  FutureWarning: D.__init__ is experimental. \
+The interface can change in the future.
 
     Currently, we do not have any sophisticated way to mark some usage of
     non-experimental function as experimental.

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -44,9 +44,9 @@ def experimental(api_name):
         f(1)
 
     .. testoutput::
-        :options: +IGNORE_EXCEPTION_DETAIL, +NORMALIZE_WHITESPACE
+        :options: +NORMALIZE_WHITESPACE
 
-        ... FutureWarning: chainer.foo.bar.f is experimental. \
+        /home/user/.local/lib/python2.7/site-packages/chainer-1.18.0-py2.7-linux-x86_64.egg/chainer/utils/experimental.py:104: FutureWarning: chainer.foo.bar.f is experimental. \
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -44,10 +44,10 @@ def experimental(api_name):
         f(1)
 
     .. testoutput::
-        :options: +NORMALIZE_WHITESPACE
+        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-        /home/user/.local/lib/python2.7/site-packages/chainer-1.18.0-py2.7-linux-x86_64.egg/chainer/utils/experimental.py:104: FutureWarning: chainer.foo.bar.f is experimental. \
-The interface can change in the future.
+        ... FutureWarning: chainer.foo.bar.f is experimental. \
+The interface can change in the future. ...
 
     We can also make a whole class experimental. In that case,
     we should call this function in its ``__init__`` method.
@@ -64,7 +64,7 @@ The interface can change in the future.
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         ... FutureWarning: chainer.foo.C is experimental. \
-The interface can change in the future.
+The interface can change in the future. ...
 
     If we want to mark ``__init__`` method only, rather than class itself,
     it is recommended that we explicitly feed its API name.
@@ -81,7 +81,7 @@ The interface can change in the future.
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         ...  FutureWarning: D.__init__ is experimental. \
-The interface can change in the future.
+The interface can change in the future. ...
 
     Currently, we do not have any sophisticated way to mark some usage of
     non-experimental function as experimental.

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -34,7 +34,6 @@ def experimental(api_name):
         warnings.showwarning = showwarning_orig
 
     .. testcode::
-        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         from chainer.utils import experimental
 
@@ -45,15 +44,15 @@ def experimental(api_name):
         f(1)
 
     .. testoutput::
+        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-        ... FutureWarning: chainer.experimental.f is an experimental API. \
+        ... FutureWarning: chainer.foo.bar.f is an experimental API. \
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,
     we should call this function in its ``__init__`` method.
 
     .. testcode::
-        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         class C():
             def __init__(self):
@@ -62,6 +61,7 @@ The interface can change in the future.
         C()
 
     .. testoutput::
+        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         ... FutureWarning: chainer.foo.C is an experimental API. \
 The interface can change in the future
@@ -70,7 +70,6 @@ The interface can change in the future
     it is recommended that we explicitly feed its API name.
 
     .. testcode::
-        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
         class D():
             def __init__(self):
@@ -79,6 +78,7 @@ The interface can change in the future
         D()
 
     .. testoutput::
+        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
        ...  FutureWarning: D.__init__ is an experimental API. \
 The interface can change in the future

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -46,7 +46,7 @@ def experimental(api_name):
     .. testoutput::
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-        ... FutureWarning: chainer.foo.bar.f is an experimental API. \
+        ... FutureWarning: chainer.foo.bar.f is experimental. \
 The interface can change in the future.
 
     We can also make a whole class experimental. In that case,
@@ -63,7 +63,7 @@ The interface can change in the future.
     .. testoutput::
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-        ... FutureWarning: chainer.foo.C is an experimental API. \
+        ... FutureWarning: chainer.foo.C is experimental. \
 The interface can change in the future
 
     If we want to mark ``__init__`` method only, rather than class itself,
@@ -80,7 +80,7 @@ The interface can change in the future
     .. testoutput::
         :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
-       ...  FutureWarning: D.__init__ is an experimental API. \
+       ...  FutureWarning: D.__init__ is experimental. \
 The interface can change in the future
 
     Currently, we do not have any sophisticated way to mark some usage of

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -44,7 +44,7 @@ def experimental(api_name):
         f(1)
 
     .. testoutput::
-        :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
+        :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
         ... FutureWarning: chainer.foo.bar.f is experimental. \
 The interface can change in the future.


### PR DESCRIPTION
I found a doctest in the document of `chainer.utils.experimental` raised the following errors, but they were not detected by Jenkins because they were grasped. This PR fixed the doctest.