### PR TITLE
Fix memory API

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -53,6 +53,7 @@ cdef class SingleDeviceMemoryPool:
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size)
     cpdef free(self, size_t ptr, Py_ssize_t size)
+    cpdef free_all_blocks(self)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
 
@@ -63,5 +64,6 @@ cdef class MemoryPool:
         object _pools
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size)
+    cpdef free_all_blocks(self)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -2,6 +2,7 @@
 
 import collections
 import ctypes
+import warnings
 import weakref
 
 import six
@@ -371,8 +372,14 @@ cdef class SingleDeviceMemoryPool:
         free = self._free[size]
         free.append(mem)
 
-    cpdef free_all_free(self):
+    cpdef free_all_blocks(self):
         self._free = collections.defaultdict(list)
+
+    cpdef free_all_free(self):
+        warnings.warn(
+            'free_all_free is deprecated. Use free_all_blocks instead.',
+            DeprecationWarning)
+        self.free_all_blocks()
 
     cpdef n_free_blocks(self):
         cdef Py_ssize_t n = 0
@@ -431,10 +438,17 @@ cdef class MemoryPool(object):
         dev = device.get_device_id()
         return self._pools[dev].malloc(size)
 
-    cpdef free_all_free(self):
+    cpdef free_all_blocks(self):
         """Release free blocks."""
         dev = device.get_device_id()
-        self._pools[dev].free_all_free()
+        self._pools[dev].free_all_blocks()
+
+    cpdef free_all_free(self):
+        """Release free blocks."""
+        warnings.warn(
+            'free_all_free is deprecated. Use free_all_blocks instead.',
+            DeprecationWarning)
+        self.free_all_blocks()
 
     cpdef n_free_blocks(self):
         """Count the total number of free blocks.


### PR DESCRIPTION
This PR provides appropriate function name (`free_all_blocks` instead of `free_all_free` ).

`PinnedMemoryPool` already use that name.
https://github.com/pfnet/chainer/blob/8fb2902a852bfa2755da71fe6e394bbc0dbfd613/cupy/cuda/pinned_memory.pxd#L46

