### PR TITLE
Use callable_obj argument

### DIFF
--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -231,9 +231,8 @@ class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
             return xp.array(-2, dtype=numpy.float32)
 
     def test_correct_failure(self):
-        with numpy.testing.assert_raises_regex(AssertionError,
-                                               'mismatch 100.0%'):
-            self.correct_failure()
+        numpy.testing.assert_raises_regex(
+            AssertionError, 'mismatch 100.0%', self.correct_failure)
 
     @helper.for_unsigned_dtypes('dtype1')
     @helper.for_signed_dtypes('dtype2')


### PR DESCRIPTION
It looks that `assert_raises_regexp` doesn't support `with` statement?
https://docs.scipy.org/doc/numpy/reference/generated/numpy.testing.assert_raises_regex.html