### PR TITLE
Insert explicit cast for cython 0.25.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 
 install:
   - pip install -U pip wheel
-  - pip install 'cython!=0.25.2'
+  - pip install cython
   - python setup.py sdist
   - pip install dist/*.tar.gz
   - pip install h5py pillow

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -492,8 +492,8 @@ cdef class ndarray:
             newarray = ndarray(self.shape, self.dtype)
             elementwise_copy(self, newarray)
 
-        newarray._shape.assign(1, self.size)
-        newarray._strides.assign(1, self.itemsize)
+        newarray._shape.assign(1, <long>self.size)
+        newarray._strides.assign(1, <long>self.itemsize)
         newarray._c_contiguous = True
         newarray._f_contiguous = True
         return newarray
@@ -1370,7 +1370,7 @@ cpdef vector.vector[Py_ssize_t] _get_strides_for_nocopy_reshape(
 
     itemsize = a.itemsize
     if size == 1:
-        newstrides.assign(newshape.size(), itemsize)
+        newstrides.assign(newshape.size(), <size_t>itemsize)
         return newstrides
 
     cdef vector.vector[Py_ssize_t] shape, strides
@@ -1750,7 +1750,7 @@ cdef class broadcast:
                 broadcasted.append(a)
                 continue
 
-            r_strides.assign(self.nd, 0)
+            r_strides.assign(self.nd, <Py_ssize_t>0)
             a_ndim = a._shape.size()
             for i in range(a_ndim):
                 a_sh = a._shape[a_ndim - i - 1]

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -492,8 +492,8 @@ cdef class ndarray:
             newarray = ndarray(self.shape, self.dtype)
             elementwise_copy(self, newarray)
 
-        newarray._shape.assign(1, <long>self.size)
-        newarray._strides.assign(1, <long>self.itemsize)
+        newarray._shape.assign(<Py_ssize_t>1, self.size)
+        newarray._strides.assign(<Py_ssize_t>1, <Py_ssize_t>self.itemsize)
         newarray._c_contiguous = True
         newarray._f_contiguous = True
         return newarray
@@ -1370,7 +1370,7 @@ cpdef vector.vector[Py_ssize_t] _get_strides_for_nocopy_reshape(
 
     itemsize = a.itemsize
     if size == 1:
-        newstrides.assign(newshape.size(), <size_t>itemsize)
+        newstrides.assign(<Py_ssize_t>newshape.size(), itemsize)
         return newstrides
 
     cdef vector.vector[Py_ssize_t] shape, strides

--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -185,13 +185,13 @@ cpdef tuple _reduce_dims(list args, tuple params, tuple shape):
     if cnt == ndim:
         return args, shape
     if cnt == 1:
-        newshape.assign(1, <long>vecshape[axis])
+        newshape.assign(<Py_ssize_t>1, <Py_ssize_t>vecshape[axis])
         ret = []
         for i, a in enumerate(args):
             if is_array_flags[i]:
                 arr = a
                 arr = arr.view()
-                newstrides.assign(1, <long>arr._strides[axis])
+                newstrides.assign(<Py_ssize_t>1, <Py_ssize_t>arr._strides[axis])
                 arr._set_shape_and_strides(newshape, newstrides, False)
                 a = arr
             ret.append(a)

--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -191,7 +191,8 @@ cpdef tuple _reduce_dims(list args, tuple params, tuple shape):
             if is_array_flags[i]:
                 arr = a
                 arr = arr.view()
-                newstrides.assign(<Py_ssize_t>1, <Py_ssize_t>arr._strides[axis])
+                newstrides.assign(
+                    <Py_ssize_t>1, <Py_ssize_t>arr._strides[axis])
                 arr._set_shape_and_strides(newshape, newstrides, False)
                 a = arr
             ret.append(a)

--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -185,13 +185,13 @@ cpdef tuple _reduce_dims(list args, tuple params, tuple shape):
     if cnt == ndim:
         return args, shape
     if cnt == 1:
-        newshape.assign(1, vecshape[axis])
+        newshape.assign(1, <long>vecshape[axis])
         ret = []
         for i, a in enumerate(args):
             if is_array_flags[i]:
                 arr = a
                 arr = arr.view()
-                newstrides.assign(1, arr._strides[axis])
+                newstrides.assign(1, <long>arr._strides[axis])
                 arr._set_shape_and_strides(newshape, newstrides, False)
                 a = arr
             ret.append(a)


### PR DESCRIPTION
I inserted explicit casts to avoid cython 0.25.2 problem.
fix #1983 