### PR TITLE
Output size mismatch in InceptionBN

### DIFF
--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -118,7 +118,8 @@ class InceptionBN(link.Chain):
         outs.append(h33)
 
         if self.pooltype == 'max':
-            p = max_pooling_2d.max_pooling_2d(x, 3, stride=self.stride, pad=1)
+            p = max_pooling_2d.max_pooling_2d(x, 3, stride=self.stride, pad=1,
+                                              cover_all=False)
         else:
             p = average_pooling_2d.average_pooling_2d(x, 3, stride=self.stride,
                                                       pad=1)


### PR DESCRIPTION
I got an exception while ```stride=2``` and ```pooltype='max'``` was passed to ```chainer.links.InceptionBN```. The detail of the exception is as follows.

```shell
File "/path/to/python/lib/site-packages/chainer/links/connection/inceptionbn.py", line 129, in __call__
    y = concat.concat(outs, axis=1)
File "/path/to/python/lib/site-packages/chainer/functions/array/concat.py", line 64, in concat
    return Concat(axis=axis)(*xs)
File "/path/to/python/lib/site-packages/chainer/function.py", line 189, in __call__
    self._check_data_type_forward(in_data)
File "/path/to/python/lib/site-packages/chainer/function.py", line 280, in _check_data_type_forward
    type_check.InvalidType(e.expect, e.actual, msg=msg), None)
File "<string>", line 2, in raise_from
chainer.utils.type_check.InvalidType: 
Invalid operation is performed in: Concat (Forward)

Expect: in_types[0].shape[2] == in_types[2].shape[2]
```

Looking closely as the code of ```InceptionBN```, I found that the mismatch of the output size between ```convolution_2d``` and ```max_pooling_2d``` was a problem.

In these functions, the output sizes are determined in these lines.
https://github.com/pfnet/chainer/blob/master/chainer/functions/connection/convolution_2d.py#L84
https://github.com/pfnet/chainer/blob/master/chainer/functions/pooling/max_pooling_2d.py#L35

The problem is default value for the argument ```cover_all```. For ```convolution_2d```, it is ```False``` and, for ```max_pooling_2d```, it is ```True```. In InceptionBN, both of ```convolution_2d``` and ```max_pooling_2d``` is called without specifying ```cover_all```. Therefore, the size mismatch occurs because the method ```get_conv_outsize``` returns different sizes following the value of ```cover_all```.

I'm not sure but it can be fixed simply by calling ```max_pooling_2d``` at
https://github.com/pfnet/chainer/blob/master/chainer/links/connection/inceptionbn.py#L121
with the argument ```cover_all=False```. For ```average_pooling_2d```, this problem does not occur because its output size is computed with ```cover_all=False```.

My working environment is following.
OS: Ubuntu 16.04 LTS 64 bit
Python:  3.4 (with Anaconda2)
Chainer: 1.17.0
GPU: NVIDIA GeForce GTX 1080

Thank you in advance for your consideration.