### PR TITLE
call model.to_gpu() in StandardUpdater

### DIFF
--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -127,6 +127,9 @@ class StandardUpdater(Updater):
             optimizer = {'main': optimizer}
         self._optimizers = optimizer
 
+        if device and device >= 0:
+            optimizer['main'].target.to_gpu(device)
+
         self.converter = converter
         self.loss_func = loss_func
         self.device = device

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -127,7 +127,7 @@ class StandardUpdater(Updater):
             optimizer = {'main': optimizer}
         self._optimizers = optimizer
 
-        if device and device >= 0:
+        if device is not None and device >= 0:
             optimizer['main'].target.to_gpu(device)
 
         self.converter = converter


### PR DESCRIPTION
Learning with GPU,  it is necessary to execute model.to_gpu() explicitly for StandardUpdater. (Otherwise we will get an array type error).
However, using ParallelUpdater, calling model.to_gpu() causes an CUDA error.

Since this behavior is difficult to understand, I think that StandardUpdater should also call model.to_gpu() automatically.