### PR TITLE
Fix installation failure on Windows.

### DIFF
--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -592,7 +592,7 @@ cudnnStatus_t cudnnRNNBackwardWeights(
 #endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 5000)
 
 
-#if not defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 5000)
+#if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 5000)
 // Some functions are renamed in cuDNN v5.
 // Following definitions are for compatibility with cuDNN v5 and higher.
 
@@ -602,7 +602,7 @@ cudnnStatus_t cudnnRNNBackwardWeights(
 #define cudnnSetConvolutionNdDescriptor_v3 cudnnSetConvolutionNdDescriptor
 #define cudnnGetFilterNdDescriptor_v5 cudnnGetFilterNdDescriptor
 
-#endif // #if not defined(CUPY_NO_CUDA) && CUDNN_VERSION >= 5000
+#endif // #if !defined(CUPY_NO_CUDA) && CUDNN_VERSION >= 5000
 
 
 #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION >= 5000)


### PR DESCRIPTION
I fixed installation failure on Windows.
Visual Studio doesn't support `#if not` directive.
I know Chainer doesn't support Windows, but I don't think `#if not` is C++ standard.
I fixed to use `#if !` instead of it.

Here is a part of error messages I got when installing Chainer 1.19.0 by `pip install chainer`.
`not` of `#if not defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 5000)` is not considered as a legal preprocessor directive and causes error.

My Environment:
* WIndows 10 (64-bit)
* Python 2.7.11 :: Anaconda 4.0.0 (64-bit)

```
  c:\users\daiki.sannou\appdata\local\temp\pip-build-slnu3t\chainer\cupy\cuda\cupy_cudnn.h(595) : warning C4067: プリプロセッサ ディレクティブの後に余分な文字がありました - 改行が必要です
  cupy\cuda\cudnn.cpp(3662) : error C3861: 'cudnnAddTensor_v3': 識別子が見つかりませんでした
  cupy\cuda\cudnn.cpp(4319) : error C3861: 'cudnnGetFilterNdDescriptor_v5': 識別子が見つかりませんでした
  cupy\cuda\cudnn.cpp(5068) : error C3861: 'cudnnSetConvolutionNdDescriptor_v3': 識別子が見つかりませんでした
  cupy\cuda\cudnn.cpp(6851) : error C3861: 'cudnnConvolutionBackwardFilter_v3': 識別子が見つかりませんでした
  cupy\cuda\cudnn.cpp(7741) : error C3861: 'cudnnConvolutionBackwardData_v3': 識別子が見つかりませんでした
  error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\BIN\\x86_amd64\\cl.exe' failed with exit status 2
```