### PR TITLE
Add tests for  how extensions are executed (issue #2006)

### DIFF
--- a/tests/chainer_tests/training_tests/test_extension.py
+++ b/tests/chainer_tests/training_tests/test_extension.py
@@ -1,10 +1,25 @@
 import unittest
+import mock
 
 from chainer import testing
 from chainer import training
 
+class DummyExtension(training.extension.Extension):
+
+    def __init__(self):
+        self.is_called = False
+        self.is_finalized = False
+
+    def __call__(self, trainer):
+        self.is_called = True
+
+    def finalize(self):
+        self.is_finalized = True
 
 class TestExtension(unittest.TestCase):
+
+    def setUp(self):
+        self.trainer = _get_mocked_trainer()
 
     def test_default_name(self):
         class MyExtension(training.Extension):
@@ -33,6 +48,67 @@ class TestExtension(unittest.TestCase):
         self.assertEqual(my_extension.default_name, 'my_extension')
         self.assertEqual(my_extension.priority, training.PRIORITY_READER)
         self.assertFalse(my_extension.invoke_before_training)
+
+    def test_add_class_extension(self):
+        dummy_extension = DummyExtension()
+        self.trainer.extend(dummy_extension)
+        self.trainer.run()
+        self.assertTrue(dummy_extension.is_called)
+        self.assertTrue(dummy_extension.is_finalized)
+
+    def test_add_make_extension(self):
+        self.is_called = False
+        @training.make_extension()
+        def dummy_extension(trainer):
+            self.is_called = True
+
+        self.trainer.extend(dummy_extension)
+        self.trainer.run()
+        self.assertTrue(self.is_called)
+
+    def test_add_two_extensions_default_priority(self):
+        self.called_order = []
+
+        @training.make_extension(trigger=(1, 'epoch'))
+        def dummy_extension_1(trainer):
+            self.called_order.append(1)
+
+        @training.make_extension(trigger=(1, 'epoch'))
+        def dummy_extension_2(trainer):
+            self.called_order.append(2)
+
+        self.trainer.extend(dummy_extension_1)
+        self.trainer.extend(dummy_extension_2)
+        self.trainer.run()
+        self.assertEqual(self.called_order, [1, 2])
+
+    def test_add_two_extensions_specific_priority(self):
+        self.called_order = []
+
+        @training.make_extension(trigger=(1, 'epoch'), priority=50)
+        def dummy_extension_1(trainer):
+            self.called_order.append(1)
+
+        @training.make_extension(trigger=(1, 'epoch'), priority=100)
+        def dummy_extension_2(trainer):
+            self.called_order.append(2)
+
+        self.trainer.extend(dummy_extension_1)
+        self.trainer.extend(dummy_extension_2)
+        self.trainer.run()
+        self.assertEqual(self.called_order, [2, 1])
+
+def _get_mocked_trainer(stop_trigger=(10, 'iteration')):
+    updater = mock.Mock()
+    updater.get_all_optimizers.return_value = {}
+    updater.iteration = 0
+    updater.epoch_detail = 1
+
+    def update():
+        updater.iteration += 1
+
+    updater.update = update
+    return training.Trainer(updater, stop_trigger)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/test_extension.py
+++ b/tests/chainer_tests/training_tests/test_extension.py
@@ -1,8 +1,9 @@
-import unittest
 import mock
+import unittest
 
 from chainer import testing
 from chainer import training
+
 
 class DummyExtension(training.extension.Extension):
 
@@ -15,6 +16,7 @@ class DummyExtension(training.extension.Extension):
 
     def finalize(self):
         self.is_finalized = True
+
 
 class TestExtension(unittest.TestCase):
 
@@ -58,6 +60,7 @@ class TestExtension(unittest.TestCase):
 
     def test_add_make_extension(self):
         self.is_called = False
+
         @training.make_extension()
         def dummy_extension(trainer):
             self.is_called = True
@@ -97,6 +100,7 @@ class TestExtension(unittest.TestCase):
         self.trainer.extend(dummy_extension_2)
         self.trainer.run()
         self.assertEqual(self.called_order, [2, 1])
+
 
 def _get_mocked_trainer(stop_trigger=(10, 'iteration')):
     updater = mock.Mock()

--- a/tests/chainer_tests/training_tests/test_extension.py
+++ b/tests/chainer_tests/training_tests/test_extension.py
@@ -1,27 +1,10 @@
-import mock
 import unittest
 
 from chainer import testing
 from chainer import training
 
 
-class DummyExtension(training.extension.Extension):
-
-    def __init__(self):
-        self.is_called = False
-        self.is_finalized = False
-
-    def __call__(self, trainer):
-        self.is_called = True
-
-    def finalize(self):
-        self.is_finalized = True
-
-
 class TestExtension(unittest.TestCase):
-
-    def setUp(self):
-        self.trainer = _get_mocked_trainer()
 
     def test_default_name(self):
         class MyExtension(training.Extension):
@@ -50,69 +33,6 @@ class TestExtension(unittest.TestCase):
         self.assertEqual(my_extension.default_name, 'my_extension')
         self.assertEqual(my_extension.priority, training.PRIORITY_READER)
         self.assertFalse(my_extension.invoke_before_training)
-
-    def test_add_class_extension(self):
-        dummy_extension = DummyExtension()
-        self.trainer.extend(dummy_extension)
-        self.trainer.run()
-        self.assertTrue(dummy_extension.is_called)
-        self.assertTrue(dummy_extension.is_finalized)
-
-    def test_add_make_extension(self):
-        self.is_called = False
-
-        @training.make_extension()
-        def dummy_extension(trainer):
-            self.is_called = True
-
-        self.trainer.extend(dummy_extension)
-        self.trainer.run()
-        self.assertTrue(self.is_called)
-
-    def test_add_two_extensions_default_priority(self):
-        self.called_order = []
-
-        @training.make_extension(trigger=(1, 'epoch'))
-        def dummy_extension_1(trainer):
-            self.called_order.append(1)
-
-        @training.make_extension(trigger=(1, 'epoch'))
-        def dummy_extension_2(trainer):
-            self.called_order.append(2)
-
-        self.trainer.extend(dummy_extension_1)
-        self.trainer.extend(dummy_extension_2)
-        self.trainer.run()
-        self.assertEqual(self.called_order, [1, 2])
-
-    def test_add_two_extensions_specific_priority(self):
-        self.called_order = []
-
-        @training.make_extension(trigger=(1, 'epoch'), priority=50)
-        def dummy_extension_1(trainer):
-            self.called_order.append(1)
-
-        @training.make_extension(trigger=(1, 'epoch'), priority=100)
-        def dummy_extension_2(trainer):
-            self.called_order.append(2)
-
-        self.trainer.extend(dummy_extension_1)
-        self.trainer.extend(dummy_extension_2)
-        self.trainer.run()
-        self.assertEqual(self.called_order, [2, 1])
-
-
-def _get_mocked_trainer(stop_trigger=(10, 'iteration')):
-    updater = mock.Mock()
-    updater.get_all_optimizers.return_value = {}
-    updater.iteration = 0
-    updater.epoch_detail = 1
-
-    def update():
-        updater.iteration += 1
-
-    updater.update = update
-    return training.Trainer(updater, stop_trigger)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -11,6 +11,19 @@ from chainer import testing
 from chainer import training
 
 
+class DummyExtension(training.extension.Extension):
+
+    def __init__(self):
+        self.is_called = False
+        self.is_finalized = False
+
+    def __call__(self, trainer):
+        self.is_called = True
+
+    def finalize(self):
+        self.is_finalized = True
+
+
 class TestTrainerElapsedTime(unittest.TestCase):
 
     def setUp(self):
@@ -43,11 +56,62 @@ class TestTrainerElapsedTime(unittest.TestCase):
         finally:
             shutil.rmtree(tempdir)
 
+    def test_add_class_extension(self):
+        dummy_extension = DummyExtension()
+        self.trainer.extend(dummy_extension)
+        self.trainer.run()
+        self.assertTrue(dummy_extension.is_called)
+        self.assertTrue(dummy_extension.is_finalized)
+
+    def test_add_make_extension(self):
+        self.is_called = False
+
+        @training.make_extension()
+        def dummy_extension(trainer):
+            self.is_called = True
+
+        self.trainer.extend(dummy_extension)
+        self.trainer.run()
+        self.assertTrue(self.is_called)
+
+    def test_add_two_extensions_default_priority(self):
+        self.called_order = []
+
+        @training.make_extension(trigger=(1, 'epoch'))
+        def dummy_extension_1(trainer):
+            self.called_order.append(1)
+
+        @training.make_extension(trigger=(1, 'epoch'))
+        def dummy_extension_2(trainer):
+            self.called_order.append(2)
+
+        self.trainer.extend(dummy_extension_1)
+        self.trainer.extend(dummy_extension_2)
+        self.trainer.run()
+        self.assertEqual(self.called_order, [1, 2])
+
+    def test_add_two_extensions_specific_priority(self):
+        self.called_order = []
+
+        @training.make_extension(trigger=(1, 'epoch'), priority=50)
+        def dummy_extension_1(trainer):
+            self.called_order.append(1)
+
+        @training.make_extension(trigger=(1, 'epoch'), priority=100)
+        def dummy_extension_2(trainer):
+            self.called_order.append(2)
+
+        self.trainer.extend(dummy_extension_1)
+        self.trainer.extend(dummy_extension_2)
+        self.trainer.run()
+        self.assertEqual(self.called_order, [2, 1])
+
 
 def _get_mocked_trainer(stop_trigger=(10, 'iteration')):
     updater = mock.Mock()
     updater.get_all_optimizers.return_value = {}
     updater.iteration = 0
+    updater.epoch_detail = 1
 
     def update():
         time.sleep(0.001)

--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -24,7 +24,7 @@ class DummyExtension(training.extension.Extension):
         self.is_finalized = True
 
 
-class TestTrainerElapsedTime(unittest.TestCase):
+class TestTrainer(unittest.TestCase):
 
     def setUp(self):
         self.trainer = _get_mocked_trainer()


### PR DESCRIPTION
This PR adds tests for how extensions are executed (in response to issue #2006)

What this test checks:
- An extension inheriting `extension.Extension` is properly called and finalized.
- An extension created by `make_extension` is properly called and finalized.
- Two extensions created by `make_extension` are executed in the correct order when the default priority is used.
- Two extensions created by `make_extension` are executed in the correct order when the priorities are specified in `make_extension`.

Because there are many ways to set configurations of an extension (specifying in `trainer.extend`, specifying in `make_extension`, and having configs as class members of an extension), testing all possible paths in a clean test code is difficult.  It might be a good idea to change the original code to provide a single way to specify configurations of an extension.

I can also add tests for extensions created with lambda functions and callables not inheriting `extension.Extension`, once PR #1930 is merged.