### PR TITLE
make ndarray.__setitem__ to handle one integer array

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2266,6 +2266,7 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v, int axis=0, op=''):
 
     if not isinstance(v, ndarray):
         v = array(v, dtype=a.dtype)
+    v = v.astype(a.dtype)
 
     a_shape = a.shape
     axis %= ndim

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1257,7 +1257,7 @@ cdef class ndarray:
 
         # Expand ellipsis into empty slices
         ellipsis = -1
-        n_newaxes = n_ellipses = 0
+        n_newaxes, n_ellipses = 0, 0
         for i, s in enumerate(slices):
             if s is None:
                 n_newaxes += 1

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1223,7 +1223,7 @@ cdef class ndarray:
         .. note::
 
             The behavior differs from NumPy when integer arrays in ``slices``
-            index same location multiple times.
+            reference the same location multiple times.
             In that case, the value that is actually stored is undefined.
 
             >>> import cupy; import numpy
@@ -1235,7 +1235,7 @@ cdef class ndarray:
             array([9150., 9151.])
 
             On the other hand, NumPy stores the value corresponding to the
-            last index among the indices with duplicate target.
+            last index among the indices referencing duplicate locations.
 
             >>> import numpy
             >>> a_cpu = numpy.zeros((2,))

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1091,7 +1091,8 @@ cdef class ndarray:
         if len(slices) > self.ndim + n_newaxes:
             raise IndexError('too many indices for array')
 
-        # Check if advanced is true, and convert list/NumPy arrays to ndarray
+        # Check if advanced is true,
+        # and convert list/NumPy arrays to cupy.ndarray
         advanced = False
         for i, s in enumerate(slices):
             if isinstance(s, (list, numpy.ndarray)):

--- a/docs/source/cupy-reference/difference.rst
+++ b/docs/source/cupy-reference/difference.rst
@@ -52,3 +52,45 @@ We support the option in CuPy because cuRAND, which is used in CuPy, supports an
   TypeError: randn() got an unexpected keyword argument 'dtype'
   >>> cupy.random.randn(dtype='f')
   array(0.10689262300729752, dtype=float32)
+
+
+Out-of-bounds indices
+---------------------
+CuPy handles out-of-bounds indices differently by default from NumPy when
+using integer array indexing.
+NumPy handles them by raising an error, but CuPy wraps around them::
+
+  >>> x = numpy.array([0, 1, 2])
+  >>> x[[1, 3]] = 10
+  Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+  IndexError: index 3 is out of bounds for axis 1 with size 3
+  >>> x = cupy.array([0, 1, 2])
+  >>> x[[1, 3]] = 10
+  >>> x
+  array([10, 10, 2])
+
+
+Duplicate values in indices
+---------------------------
+CuPy's ``__setitem__`` behaves differently from NumPy when integer arrays
+reference the same location multiple times.
+In that case, the value that is actually stored is undefined.
+Here is an example of CuPy::
+
+  >>> a = cupy.zeros((2,))
+  >>> i = cupy.arange(10000) % 2
+  >>> v = cupy.arange(10000).astype(numpy.float)
+  >>> a[i] = v
+  >>> a
+  array([9150., 9151.])
+
+NumPy stores the value corresponding to the
+last element among elements referencing duplicate locations::
+
+  >>> a_cpu = numpy.zeros((2,))
+  >>> i_cpu = numpy.arange(10000) % 2
+  >>> v_cpu = numpy.arange(10000).astype(numpy.float)
+  >>> a_cpu[i_cpu] = v_cpu
+  >>> a_cpu
+  array([9998., 9999.])

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -187,3 +187,17 @@ class TestArrayAdvancedIndexingSetitemCupyIndices(unittest.TestCase):
         a[:, indexes] = cupy.array(1.)
         testing.assert_array_equal(
             a, cupy.array([[1., 1., 0.], [1., 1., 0.]]))
+
+
+@testing.gpu
+class TestArrayAdvancedIndexingSetitemDifferetnDtypes(unittest.TestCase):
+
+    @testing.for_all_dtypes(name='src_dtype')
+    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_differnt_dtypes(self, xp, src_dtype, dst_dtype):
+        shape = (2, 3)
+        a = xp.zeros(shape, dtype=src_dtype)
+        indexes = xp.array([0, 1])
+        a[:, indexes] = xp.array(1, dtype=dst_dtype)
+        return a

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -175,3 +175,15 @@ class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):
         a = xp.zeros(self.shape, dtype=dtype)
         a[self.indexes] = self.value.astype(a.dtype)
         return a
+
+
+@testing.gpu
+class TestArrayAdvancedIndexingSetitemCupyIndices(unittest.TestCase):
+
+    def test_cupy_array(self):
+        shape = (2, 3)
+        a = cupy.zeros(shape)
+        indexes = cupy.array([0, 1])
+        a[:, indexes] = cupy.array(1.)
+        testing.assert_array_equal(
+            a, cupy.array([[1., 1., 0.], [1., 1., 0.]]))

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -35,7 +35,7 @@ def perm(iterable):
     })
 )
 @testing.gpu
-class TestArrayAdvancedIndexingPerm(unittest.TestCase):
+class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -52,7 +52,7 @@ class TestArrayAdvancedIndexingPerm(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': [1, -1]},
 )
 @testing.gpu
-class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
+class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -68,7 +68,7 @@ class TestArrayAdvancedIndexingParametrized(unittest.TestCase):
      'indexes': (None, [1, 2], [0, -1])},
 )
 @testing.gpu
-class TestArrayAdvancedIndexingParametrizedTransp(unittest.TestCase):
+class TestArrayAdvancedIndexingGetitemParametrizedTransp(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -87,7 +87,7 @@ class TestArrayAdvancedIndexingParametrizedTransp(unittest.TestCase):
     {'shape': (10,), 'indexes': (numpy.random.choice([False, True], (10,)),)},
 )
 @testing.gpu
-class TestArrayAdvancedIndexingArrayClass(unittest.TestCase):
+class TestArrayAdvancedIndexingGetitemArrayClass(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -108,10 +108,70 @@ class TestArrayAdvancedIndexingArrayClass(unittest.TestCase):
     {'shape': (2, 3), 'indexes': (slice(None), [1, 2], slice(None))},
 )
 @testing.gpu
-class TestArrayInvalidIndexAdv(unittest.TestCase):
+class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_invalid_adv_getitem(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
         a[self.indexes]
+
+
+@testing.parameterize(
+    # array only
+    {'shape': (2, 3, 4), 'indexes': numpy.array(-1), 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([1, 0]), 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': [1, -1], 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': (slice(None), [1, 2]), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), [[1, 2], [0, -1]],), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), slice(None), [[1, 2], [0, 2]]), 'value': 1},
+    # slice and array
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), slice(1, 2), [[1, 2], [0, 2]]), 'value': 1},
+    # None and array
+    {'shape': (2, 3, 4),
+     'indexes': (None, [1, -1]), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (None, [1, -1], None), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (None, None, None, [1, -1]), 'value': 1},
+    # None, slice and array
+    {'shape': (2, 3, 4),
+     'indexes': (slice(0, 1), None, [1, -1]), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(0, 1), slice(1, 2), [1, -1]), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(0, 1), None, slice(1, 2), [1, -1]), 'value': 1},
+)
+@testing.gpu
+class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_adv_setitem(self, xp, dtype):
+        a = xp.zeros(self.shape, dtype=dtype)
+        a[self.indexes] = self.value
+        return a
+
+
+@testing.parameterize(
+    {'shape': (2, 3, 4), 'indexes': numpy.array(1),
+     'value': numpy.array([1])},
+    {'shape': (2, 3, 4), 'indexes': numpy.array(1),
+     'value': numpy.array([1, 2, 3, 4])},
+    {'shape': (2, 3, 4), 'indexes': (slice(None), [0, -1]),
+     'value': numpy.arange(2 * 2 * 4).reshape(2, 2, 4)},
+    {'shape': (2, 3, 4), 'indexes': (slice(None), [[0, 1], [2, 0]]),
+     'value': numpy.arange(2 * 2 * 2 * 4).reshape(2, 2, 2, 4)},
+)
+@testing.gpu
+class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_adv_setitem(self, xp, dtype):
+        a = xp.zeros(self.shape, dtype=dtype)
+        a[self.indexes] = self.value.astype(a.dtype)
+        return a


### PR DESCRIPTION
Related to #1919 which the reviewer and I concluded unnecessary addition to API.

In this PR, I modified `ndarray.__setitem__` to accept argument `slices` with following items.
+ one integer array
+ combination of basic and an integer array

I did not support multiple integer arrays in `slices` in this PR, but I am planning to send PR that supports them.

Mechanism to handle one dimensional array is same as #1919.
The part of the code that processes `slices` is mostly same as #1863.