### PR TITLE
Add cupy.scatter_add with interface identical to ndarray.__setitem__

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -402,6 +402,8 @@ from cupy.util import memoize  # NOQA
 from cupy.core import ElementwiseKernel  # NOQA
 from cupy.core import ReductionKernel  # NOQA
 
+from cupy.ext.scatter import scatter_add  # NOQA
+
 
 def asnumpy(a, stream=None):
     """Returns an array on the host memory from an arbitrary source array.

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2211,9 +2211,12 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v, int axis=0, op=''):
         _scatter_update_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
     elif op == 'add':
-        if not issubclass(v.dtype.type, (numpy.int32, numpy.float32)):
+        if not issubclass(v.dtype.type,
+                          (numpy.int32, numpy.float32,
+                           numpy.uint32, numpy.uint64, numpy.ulonglong)):
             raise TypeError(
-                'scatter_add only supports int32 and float32 as data type')
+                'scatter_add only supports int32, float32, uint32, uint64 as'
+                'data type')
         _scatter_add_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
     else:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2211,6 +2211,8 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v, int axis=0, op=''):
         _scatter_update_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
     elif op == 'add':
+        # There is constraints on types because atomicAdd() in CUDA 7.5
+        # only supports int32, uint32, uint64, and float32.
         if not issubclass(v.dtype.type,
                           (numpy.int32, numpy.float32,
                            numpy.uint32, numpy.uint64, numpy.ulonglong)):

--- a/cupy/ext/__init__.py
+++ b/cupy/ext/__init__.py
@@ -1,0 +1,2 @@
+# "NOQA" to suppress flake8 warning
+from cupy.ext import scatter  # NOQA

--- a/cupy/ext/scatter.py
+++ b/cupy/ext/scatter.py
@@ -1,16 +1,16 @@
 def scatter_add(a, slices, value):
     """Adds given values to specified elements of an array.
 
-    This function adds given ``value`` to specified elements of ``a``.
-    When all of the indices target different locations, :func:`scatter_add`
-    does operation equivalent to ``a[slices] = a[slices] + value``.
-    When there are indices targeting the same location, :func:`scatter_add`
-    uses all of the values for addition. On the other hand,
-    ``a[slices] = a[slices] + value`` only adds the contribution from one of
-    the indices targeting the same location.
+    It adds ``value`` to the specified elements of ``a``.
+    If all of the indices target different locations, the operation of
+    :func:`scatter_add` is equivalent to ``a[slices] = a[slices] + value``.
+    If there are multiple elements targeting the same location,
+    :func:`scatter_add` uses all of these values for addition. On the other
+    hand, ``a[slices] = a[slices] + value`` only adds the contribution from one
+    of the indices targeting the same location.
 
-    Similarly to array indexing, negative indices are interpreted as counting
-    from the end of an axis.
+    Note that just like an array indexing, negative indices are interpreted as
+    counting from the end of an array.
 
     Example
     -------

--- a/cupy/ext/scatter.py
+++ b/cupy/ext/scatter.py
@@ -1,0 +1,42 @@
+def scatter_add(a, slices, value):
+    """Adds given values to specified elements of an array.
+
+    This function adds given ``value`` to specified elements of ``a``.
+    When all of the indices target different locations, :func:`scatter_add`
+    does operation equivalent to ``a[slices] = a[slices] + value``.
+    When there are indices targeting the same location, :func:`scatter_add`
+    uses all of the values for addition. On the other hand,
+    ``a[slices] = a[slices] + value`` only adds the contribution from one of
+    the indices targeting the same location.
+
+    Similarly to array indexing, negative indices are interpreted as counting
+    from the end of an axis.
+
+    Example
+    -------
+    >>> import cupy
+    >>> a = cupy.zeros((6,))
+    >>> i = cupy.array([1, 0, 1])
+    >>> v = cupy.array([1., 1., 1.])
+    >>> cupy.scatter_add(a, i, v);
+    >>> a
+    array([ 1.,  2.,  0.,  0.,  0.,  0.])
+
+    Args:
+        a (ndarray): An array that gets added.
+        slices: It is integer, slices, ellipsis, numpy.newaxis,
+            integer array-like or tuple of them.
+            It works for slices used for
+            :func:`cupy.ndarray.__getitem__` and
+            :func:`cupy.ndarray.__setitem__`.
+        v (array-like): Values to increment ``a`` at referenced locations.
+
+    .. note::
+        Supports only arrays of type ``numpy.float32`` and ``numpy.int32``.
+
+    .. note::
+        :func:`scatter_add` does not raise an error when indices exceed size of
+        axes. Instead, it wraps indices.
+
+    """
+    a.scatter_add(slices, value)

--- a/cupy/ext/scatter.py
+++ b/cupy/ext/scatter.py
@@ -32,7 +32,9 @@ def scatter_add(a, slices, value):
         v (array-like): Values to increment ``a`` at referenced locations.
 
     .. note::
-        Supports only arrays of type ``numpy.float32`` and ``numpy.int32``.
+        It only supports types that are supported by CUDA's atomicAdd.
+        The supported types are ``numpy.float32``, ``numpy.int32``,
+        ``numpy.uint32``, ``numpy.uint64`` and ``numpy.ulonglong``.
 
     .. note::
         :func:`scatter_add` does not raise an error when indices exceed size of

--- a/docs/source/cupy-reference/ext.rst
+++ b/docs/source/cupy-reference/ext.rst
@@ -1,0 +1,4 @@
+External Functions
+==================
+
+.. autofunction:: cupy.scatter_add

--- a/docs/source/cupy-reference/overview.rst
+++ b/docs/source/cupy-reference/overview.rst
@@ -394,6 +394,11 @@ Padding
 
 :func:`pad`
 
+External Functions
+~~~~~~~~~~~~~~~~~~
+
+:func:`scatter_add`
+
 Other
 ~~~~~
 

--- a/docs/source/cupy-reference/routines.rst
+++ b/docs/source/cupy-reference/routines.rst
@@ -22,3 +22,4 @@ These functions cover a subset of
    random
    sorting
    statistics
+   ext

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -1,0 +1,95 @@
+import unittest
+
+import numpy
+
+import cupy
+from cupy import testing
+
+
+@testing.parameterize(
+    # array only
+    {'shape': (2, 3, 4), 'slices': numpy.array(-1), 'value': 1},
+    {'shape': (2, 3, 4), 'slices': numpy.array([1, 0]), 'value': 1},
+    {'shape': (2, 3, 4), 'slices': (slice(None), [1, 2]), 'value': 1},
+    {'shape': (3, 4, 5),
+     'slices': (slice(None), [[1, 2], [0, -1]],), 'value': 1},
+    {'shape': (3, 4, 5),
+     'slices': (slice(None), slice(None), [[1, 2], [0, 3]]), 'value': 1},
+    # slice and array
+    {'shape': (3, 4, 5),
+     'slices': (slice(None), slice(1, 2), [[1, 3], [0, 2]]), 'value': 1},
+    # None and array
+    {'shape': (3, 4, 5),
+     'slices': (None, [1, -1]), 'value': 1},
+    {'shape': (3, 4, 5),
+     'slices': (None, [1, -1], None), 'value': 1},
+    {'shape': (3, 4, 5),
+     'slices': (None, None, None, [1, -1]), 'value': 1},
+    # None, slice and array
+    {'shape': (3, 4, 5),
+     'slices': (slice(0, 1), None, [1, -1]), 'value': 1},
+    {'shape': (3, 4, 5),
+     'slices': (slice(0, 1), slice(1, 2), [1, -1]), 'value': 1},
+    {'shape': (3, 4, 5),
+     'slices': (slice(0, 1), None, slice(1, 2), [1, -1]), 'value': 1},
+    # broadcasting
+    {'shape': (3, 4, 5), 'slices': (slice(None), [[1, 2], [0, -1]],),
+     'value': numpy.arange(3 * 2 * 2 * 5).reshape(3, 2, 2, 5)},
+)
+@testing.gpu
+class TestScatterAddNoDuplicate(unittest.TestCase):
+
+    @testing.for_dtypes([numpy.float32, numpy.int32])
+    @testing.numpy_cupy_array_equal()
+    def test_scatter_add(self, xp, dtype):
+        a = xp.zeros(self.shape, dtype)
+        if xp is cupy:
+            a.scatter_add(self.slices, self.value)
+        else:
+            a[self.slices] = a[self.slices] + self.value
+        return a
+
+
+@testing.parameterize(
+    {'shape': (2, 3), 'slices': ([1, 1], slice(None)), 'value': 1,
+     'expected': numpy.array([[0, 0, 0], [2, 2, 2]])},
+    {'shape': (2, 3), 'slices': ([1, 0, 1], slice(None)), 'value': 1,
+     'expected': numpy.array([[1, 1, 1], [2, 2, 2]])},
+    {'shape': (2, 3), 'slices': (slice(1, 2), [1, 0, 1]), 'value': 1,
+     'expected': numpy.array([[0, 0, 0], [1, 2, 0]])},
+)
+@testing.gpu
+class TestScatterAddDuplicateVectorValue(unittest.TestCase):
+
+    @testing.for_dtypes([numpy.float32, numpy.int32])
+    def test_scatter_add(self, dtype):
+        a = cupy.zeros(self.shape, dtype)
+        a.scatter_add(self.slices, self.value)
+
+        numpy.testing.assert_almost_equal(a.get(), self.expected)
+
+
+@testing.gpu
+class TestScatterAddCupyArguments(unittest.TestCase):
+
+    @testing.for_dtypes([numpy.float32, numpy.int32])
+    def test_scatter_add_cupy_arguments(self, dtype):
+        shape = (2, 3)
+        a = cupy.zeros(shape, dtype)
+        slices = (cupy.array([1, 1]), slice(None))
+        a.scatter_add(slices, cupy.array(1.))
+        testing.assert_array_equal(
+            a, cupy.array([[0., 0., 0.], [2., 2., 2.]], dtype))
+
+    @testing.for_dtypes([numpy.float32, numpy.int32], name='src_dtype')
+    @testing.for_dtypes([numpy.float32, numpy.int32], name='dst_dtype')
+    def test_scatter_add_differnt_dtypes(self, src_dtype, dst_dtype):
+        shape = (2, 3)
+        a = cupy.zeros(shape, dtype=src_dtype)
+        value = cupy.array(1, dtype=dst_dtype)
+        slices = ([1, 1], slice(None))
+        a.scatter_add(slices, value)
+
+        numpy.testing.assert_almost_equal(
+            a.get(),
+            numpy.array([[0, 0, 0], [2, 2, 2]], dtype=src_dtype))

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -81,8 +81,12 @@ class TestScatterAddCupyArguments(unittest.TestCase):
         testing.assert_array_equal(
             a, cupy.array([[0., 0., 0.], [2., 2., 2.]], dtype))
 
-    @testing.for_dtypes([numpy.float32, numpy.int32], name='src_dtype')
-    @testing.for_dtypes([numpy.float32, numpy.int32], name='dst_dtype')
+    @testing.for_dtypes(
+        [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
+         numpy.ulonglong], name='src_dtype')
+    @testing.for_dtypes(
+        [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
+         numpy.ulonglong], name='dst_dtype')
     def test_scatter_add_differnt_dtypes(self, src_dtype, dst_dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -70,7 +70,7 @@ class TestScatterAddDuplicateVectorValue(unittest.TestCase):
 
 
 @testing.gpu
-class TestScatterAddCupyArguments(unittest.TestCase):
+class TestScatterAdd(unittest.TestCase):
 
     @testing.for_dtypes([numpy.float32, numpy.int32])
     def test_scatter_add_cupy_arguments(self, dtype):

--- a/tests/cupy_tests/ext_tests/test_scatter.py
+++ b/tests/cupy_tests/ext_tests/test_scatter.py
@@ -1,0 +1,17 @@
+import unittest
+
+import numpy
+
+import cupy
+from cupy import testing
+
+
+@testing.gpu
+class TestScatter(unittest.TestCase):
+
+    def test_scatter_add(self):
+        a = cupy.zeros((3,), dtype=numpy.float32)
+        i = cupy.array([1, 1], numpy.int32)
+        v = cupy.array([2., 1.], dtype=numpy.float32)
+        cupy.scatter_add(a, i, v)
+        testing.assert_array_equal(a, cupy.array([0, 3, 0]))


### PR DESCRIPTION
Merge after #2040.

Related to #1920. I found the interface of `scatter_add` in #1920 to be insufficient for implementing backward pass of `chainer.Variable.__getitem__` (#2042).

This implements the function discussed in #2042.
This PR adds
+ `scatter_add` that handles one integer array
+ `scatter_add` that handles basic indexing
+ `scatter_add` that handles combination of basic indexing and an integer array.

This does not support slices with multiple integer arrays.