### PR TITLE
Use cudnn.create_filter_descriptor

### DIFF
--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -329,7 +329,7 @@ class NStepLSTM(function.Function):
             self.reserve_space.data.ptr, self.reserve_space.size)
 
         dw = cuda.cupy.zeros_like(self.w)
-        dw_desc = cudnn.create_tensor_nd_descriptor(dw)
+        dw_desc = cudnn.create_filter_descriptor(dw))
         libcudnn.RNNBackwardWeights(
             handle, rnn_desc.value, length,
             self.c_x_descs.data, xs.data.ptr,

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -329,7 +329,7 @@ class NStepLSTM(function.Function):
             self.reserve_space.data.ptr, self.reserve_space.size)
 
         dw = cuda.cupy.zeros_like(self.w)
-        dw_desc = cudnn.create_filter_descriptor(dw))
+        dw_desc = cudnn.create_filter_descriptor(dw)
         libcudnn.RNNBackwardWeights(
             handle, rnn_desc.value, length,
             self.c_x_descs.data, xs.data.ptr,


### PR DESCRIPTION
In Cudnn v5 example code, use `cudnnSetFilterNdDescriptor`.

I fix NStepLSTM code because it uses `create_tensor_nd_descriptor`.
I think it should use `create_filter_descriptor` as CUDNN Example v5.
