### PR TITLE
Make cuda.get_array_module support Variable

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -29,6 +29,7 @@ import warnings
 import numpy
 import six
 
+import chainer
 
 available = False
 cudnn_enabled = False
@@ -543,8 +544,11 @@ def reduce(in_params, out_params, map_expr, reduce_expr, post_map_expr,
 def get_array_module(*args):
     """Gets an appropriate one from :mod:`numpy` or :mod:`cupy`.
 
-    This is almost equivalent to :func:`cupy.get_array_module`. The only
-    difference is that this function can be used even if CUDA is not available.
+    This is almost equivalent to :func:`cupy.get_array_module`. The differences
+    are that this function can be used even if CUDA is not available and that
+    it will return their data arrays' array module for
+    :class:`~chainer.Variable` arguments.
+.
 
     Args:
         args: Values to determine whether NumPy or CuPy should be used.
@@ -555,6 +559,8 @@ def get_array_module(*args):
 
     """
     if available:
+        args = (arg.data if isinstance(arg, chainer.Variable) else arg
+                for arg in args)
         return cupy.get_array_module(*args)
     else:
         return numpy

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -558,8 +558,8 @@ def get_array_module(*args):
 
     """
     if available:
-        args = (arg.data if isinstance(arg, chainer.Variable) else arg
-                for arg in args)
+        args = [arg.data if isinstance(arg, chainer.Variable) else arg
+                for arg in args]
         return cupy.get_array_module(*args)
     else:
         return numpy

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -548,7 +548,6 @@ def get_array_module(*args):
     are that this function can be used even if CUDA is not available and that
     it will return their data arrays' array module for
     :class:`~chainer.Variable` arguments.
-.
 
     Args:
         args: Values to determine whether NumPy or CuPy should be used.

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -65,6 +65,19 @@ class TestCuda(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 cuda.to_gpu(x)
 
+    def test_get_array_module_for_numpy(self):
+        self.assertIs(cuda.get_array_module(numpy.array([])), numpy)
+        self.assertIs(
+            cuda.get_array_module(chainer.Variable(numpy.array([]))),
+            numpy)
+
+    @attr.gpu
+    def test_get_array_module_for_cupy(self):
+        self.assertIs(cuda.get_array_module(cuda.cupy.array([])), cuda.cupy)
+        self.assertIs(
+            cuda.get_array_module(chainer.Variable(cuda.cupy.array([]))),
+            cuda.cupy)
+
     def test_empy_unavailable(self):
         if not cuda.available:
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
This PR will make `cuda.get_array_module` support `Variable` arguments so that it will return the array module of `Variable.data`. It will also add tests for `cuda.get_array_module`.