### PR TITLE
Fix max pooling backward cpu

### DIFF
--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -85,7 +85,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
         gcol = numpy.zeros(
             (n * c * out_h * out_w * kh * kw), dtype=x[0].dtype)
 
-        indexes = self.indexes.ravel()
+        indexes = self.indexes.flatten()
         indexes += numpy.arange(0, indexes.size * kh * kw, kh * kw)
 
         gcol[indexes] = gy[0].ravel()

--- a/chainer/functions/pooling/max_pooling_nd.py
+++ b/chainer/functions/pooling/max_pooling_nd.py
@@ -87,7 +87,7 @@ class MaxPoolingND(pooling_nd._PoolingND):
 
         gcol = numpy.zeros(n * c * prod_outs * prod_ksize, dtype=x[0].dtype)
 
-        indexes = self.indexes.ravel()
+        indexes = self.indexes.flatten()
         indexes += numpy.arange(0, indexes.size * prod_ksize, prod_ksize)
 
         gcol[indexes] = gy[0].ravel()

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -99,7 +99,7 @@ class TestMaxPooling2D(unittest.TestCase):
     def test_backward_cpu_more_than_once(self):
         func = functions.MaxPooling2D(
             3, stride=2, pad=1, cover_all=self.cover_all)
-        _ = func(self.x)
+        func(self.x)
         func.backward_cpu((self.x,), (self.gy,))
         func.backward_cpu((self.x,), (self.gy,))
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -96,6 +96,13 @@ class TestMaxPooling2D(unittest.TestCase):
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
 
+    def test_backward_cpu_more_than_once(self):
+        func = functions.MaxPooling2D(
+            3, stride=2, pad=1, cover_all=self.cover_all)
+        _ = func(self.x)
+        func.backward_cpu((self.x,), (self.gy,))
+        func.backward_cpu((self.x,), (self.gy,))
+
 
 @testing.parameterize(*testing.product({
     'use_cudnn': [True, False],

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -149,6 +149,14 @@ class TestMaxPoolingND(unittest.TestCase):
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
 
+    def test_backward_cpu_more_than_once(self):
+        func = functions.MaxPoolingND(
+            self.ndim, self.ksize, stride=self.stride, pad=self.pad,
+            cover_all=self.cover_all)
+        _ = func(self.x)
+        func.backward_cpu((self.x,), (self.gy,))
+        func.backward_cpu((self.x,), (self.gy,))
+
 
 @testing.parameterize(*testing.product({
     'dims': [(4, 3, 2), (3, 2), (2,)],

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -153,7 +153,7 @@ class TestMaxPoolingND(unittest.TestCase):
         func = functions.MaxPoolingND(
             self.ndim, self.ksize, stride=self.stride, pad=self.pad,
             cover_all=self.cover_all)
-        _ = func(self.x)
+        func(self.x)
         func.backward_cpu((self.x,), (self.gy,))
         func.backward_cpu((self.x,), (self.gy,))
 


### PR DESCRIPTION
`MaxPooling2D.backward_cpu()` causes an error when I call the method more than once.

You can reproduce the error by the following code:
```
import numpy as np
from chainer import functions as F

x = np.ones((1, 1, 4, 4), dtype=np.float32)
h = F.max_pooling_2d(x, 2)
h.grad = np.ones_like(h.data)

h.backward()

try:
    h.backward()
except IndexError as e:
    print e  # index 16 is out of bounds for axis 1 with size 16

try:
    h.backward()
except IndexError as e:
    print e  # index 24 is out of bounds for axis 1 with size 16
```

We expect the code will print nothing, but the message as the comment will be shown.

The actual error message is like this:
```
  File "C:\Users\sakurai\Anaconda2\lib\site-packages\chainer\functions\pooling\max_pooling_2d.py", line 91, in backward_cpu
    gcol[indexes] = gy[0].ravel()
    
IndexError: index 16 is out of bounds for axis 1 with size 16
```

The current implementation of `forward_cpu()` has a probably unintended side effect at [L88-89](https://github.com/pfnet/chainer/blob/d85f9e501a183a3c39fdb4c3ba6e1c4d2d492be5/chainer/functions/pooling/max_pooling_2d.py#L88-L89)

```
indexes = self.indexes.ravel()
indexes += numpy.arange(0, indexes.size * kh * kw, kh * kw)
```

`ndarray.ravel()` might return the view of `self.indexes` instead of the copy and it will be broken by `+=` .
To avoid this, I replaced `ravel()` with `flatten()` which always return the copy.

`MaxPoolingND.backward_cpu()` has the same problem so I fixed it as well.