### PR TITLE
Make Dropout object immutable

### DIFF
--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -17,14 +17,15 @@ class Dropout(function.Function):
         type_check.expect(in_types[0].dtype.kind == 'f')
 
     def forward(self, x):
-        scale = x[0].dtype.type(1. / (1 - self.dropout_ratio))
-        xp = cuda.get_array_module(*x)
-        if xp == numpy:
-            flag = xp.random.rand(*x[0].shape) >= self.dropout_ratio
-        else:
-            flag = (xp.random.rand(*x[0].shape, dtype=numpy.float32) >=
-                    self.dropout_ratio)
-        self.mask = scale * flag
+        if not hasattr(self, 'mask'):
+            scale = x[0].dtype.type(1. / (1 - self.dropout_ratio))
+            xp = cuda.get_array_module(*x)
+            if xp == numpy:
+                flag = xp.random.rand(*x[0].shape) >= self.dropout_ratio
+            else:
+                flag = (xp.random.rand(*x[0].shape, dtype=numpy.float32) >=
+                        self.dropout_ratio)
+            self.mask = scale * flag
         return x[0] * self.mask,
 
     def backward(self, x, gy):

--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -83,5 +83,18 @@ class TestDropout(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x),
                             cuda.to_gpu(self.gy))
 
+    def check_immutable(self, x_data):
+        d = functions.Dropout(0.5)
+        y1 = d(chainer.Variable(x_data))
+        y2 = d(chainer.Variable(x_data))
+        testing.assert_allclose(y1.data, y2.data)
+
+    def test_immutable_cpu(self):
+        self.check_immutable(self.x)
+
+    @attr.gpu
+    def test_immutable_gpu(self):
+        self.check_immutable(cuda.to_gpu(self.x))
+
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Dropout object always makes new random mask when `__call__` method is called. For forget function, I fixed this behavior. I mean, with this patch, Dropout object checks if it has a random mask . If it has, it uses the old mask and doesn't make a new random mask.