### PR TITLE
Support uninitialized variable and use it for uninitialized parameters

### DIFF
--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -9,6 +9,7 @@ from chainer.initializers import uniform  # NOQA
 # import class and function
 from chainer.initializers.constant import Constant
 from chainer.initializers.constant import Identity  # NOQA
+from chainer.initializers.constant import NaN  # NOQA
 from chainer.initializers.constant import One  # NOQA
 from chainer.initializers.constant import Zero  # NOQA
 from chainer.initializers.normal import GlorotNormal  # NOQA

--- a/chainer/initializers/constant.py
+++ b/chainer/initializers/constant.py
@@ -1,3 +1,5 @@
+import numpy
+
 from chainer import cuda
 from chainer import initializer
 
@@ -78,3 +80,16 @@ def One(dtype=None):
 
     """
     return Constant(1.0, dtype=dtype)
+
+
+def NaN(dtype=None):
+    """Returns initializer that initializes array with the all-NaN array.
+
+    Args:
+        dtype: Data type specifier.
+
+    Returns:
+        An initializer that initializes an array by NaN.
+
+    """
+    return Constant(numpy.nan, dtype=dtype)

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -7,7 +7,6 @@ import six
 
 from chainer import cuda
 from chainer import initializers
-import chainer.serializer
 from chainer import variable
 
 

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -124,7 +124,6 @@ class Link(object):
     def __init__(self, **params):
         self._params = []
         self._persistent = []
-        self._uninitialized_params = {}
         self._cpu = True
         self._device_id = None
         self.name = None
@@ -143,31 +142,37 @@ class Link(object):
         """
         return numpy if self._cpu else cuda.cupy
 
-    def add_param(self, name, shape, dtype=numpy.float32, initializer=None):
+    def add_param(self, name, shape=None, dtype=numpy.float32,
+                  initializer=None):
         """Registers a parameter to the link.
 
         The registered parameter is saved and loaded on serialization and
         deserialization, and involved in the optimization. The data and
         gradient of the variable are initialized by NaN arrays.
         If ``initializer`` is not ``None``, the data is initialized by
-        ``initializer``.
+        ``initializer``. The initializer can be an array, in which case the
+        parameter array is directly initialized by it.
 
-        If the supplied ``name`` argument corresponds to an uninitialized
-        parameter (that is, one that was added with the
-        :meth:`add_uninitialized_param` method), ``name`` will be removed
-        from the set of uninitialized parameters.
+        If ``shape`` is None and the initializer is not an array, this method
+        does not initialize the data and gradient arrays of the parameter
+        variable. They should be initialized by calling the
+        :meth:`chainer.Variable.initialize` method before using the parameter
+        in the forward computation. The shape can be specified at the
+        initialization.
 
         The parameter is set to an attribute of the link with the given name.
 
         Args:
             name (str): Name of the parameter. This name is also used as the
-                attribute name. Any uninitialized parameters with the same
-                name will be removed.
-            shape (int or tuple of ints): Shape of the parameter array.
+                attribute name.
+            shape (int or tuple of ints): Shape of the parameter array. If it
+                is omitted, the parameter variable is left uninitialized.
             dtype: Data type of the parameter array.
-            initializer(chainer.initializer.Initializer): If it is not
-                ``None``, the data is initialized with the given initializer.
-                Note that in this case ``dtype`` argument is ignored.
+            initializer: If it is not ``None``, the data is initialized with
+                the given initializer. If it is an array, the data is directly
+                initialized by it. If it is callable, it is used as a weight
+                initializer. Note that in these cases, ``dtype`` argument is
+                ignored.
 
         """
         d = self.__dict__
@@ -176,70 +181,24 @@ class Link(object):
                 'cannot register a new parameter %s: attribute exists'
                 % name)
         if initializer is None:
-            data = self.xp.full(shape, numpy.nan, dtype=dtype)
+            initializer = initializers.NaN(dtype)
+        if shape is None:
+            if callable(initializer):
+                # uninitialized parameter
+                var = variable.Variable(
+                    volatile='auto', name=name, initializer=initializer)
+            else:
+                # initialize parameter by the initial array
+                var = variable.Variable(
+                    initializer, volatile='auto', name=name)
         else:
             data = initializers.generate_array(initializer, shape, self.xp)
-        u = self._uninitialized_params.get(name)
-        if u is None:
             grad = self.xp.full_like(data, numpy.nan)
-        else:
-            if u._cleared:
-                grad = None
-            elif u._zeroed:
-                grad = self.xp.zeros_like(data)
-            else:
-                grad = self.xp.full_like(data, numpy.nan)
-        var = variable.Variable(data, volatile='auto', name=name)
-        var.grad = grad
+            var = variable.Variable(
+                data, volatile='auto', name=name, grad=grad)
+
         self._params.append(name)
         d[name] = var
-        if name in self._uninitialized_params:
-            del self._uninitialized_params[name]
-
-    def add_uninitialized_param(self, name):
-        """Registers an uninitialized parameter to the link.
-
-        An uninitialized parameter is defined as a parameter that has a name
-        but that does not yet have a shape. If the shape of a parameter
-        depends on the shape of the inputs to the ``__call__`` operator,
-        it can be useful to defer initialization (that is, setting the shape)
-        until the first forward call of the link. Such parameters are
-        intended to be defined as uninitialized parameters in the initializer
-        and then initialized during the first forward call.
-
-        An uninitialized parameter is intended to be registered to a link by
-        calling this method in the initializer method. Then, during the
-        first forward call, the shape of the parameter will be determined
-        from the size of the inputs and the parameter must be initialized by
-        calling the :meth:`add_param` method.
-
-        Args:
-            name: (str): Name of the uninitialized parameter.
-
-        """
-        class uninitialized_param(object):
-
-            def __init__(self):
-                self._cleared = False
-                self._zeroed = False
-
-        d = self.__dict__
-        if (name in self._uninitialized_params) or (name in d):
-            raise AttributeError(
-                'cannot register a new uninitialized parameter %s: exists'
-                % name)
-        self._uninitialized_params[name] = uninitialized_param()
-
-    @property
-    def has_uninitialized_params(self):
-        """Check if the link has uninitialized parameters.
-
-        Returns:
-            bool: ``True`` if the link has any uninitialized parameters.
-            Otherwise returns ``False``.
-
-        """
-        return len(self._uninitialized_params) > 0
 
     def add_persistent(self, name, value):
         """Registers a persistent value to the link.
@@ -415,12 +374,6 @@ class Link(object):
         dst = self.__dict__
         for name in self._params:
             dst[name].copydata(src[name])
-        # tuple() here is needed to avoid conflicts with add_param
-        for name in tuple(self._uninitialized_params):
-            if name in src:
-                src_param = src[name]
-                self.add_param(name, src_param.shape, src_param.dtype)
-                dst[name].copydata(src_param)
 
     def cleargrads(self):
         """Clears all gradient arrays.
@@ -431,9 +384,6 @@ class Link(object):
         """
         for param in self.params():
             param.cleargrad()
-        for link in self.links():
-            for param in link._uninitialized_params.values():
-                param._cleared = True
 
     def zerograds(self):
         """Initializes all gradient arrays by zero.
@@ -450,9 +400,6 @@ class Link(object):
             DeprecationWarning)
         for param in self.params():
             param.zerograd()
-        for link in self.links():
-            for param in link._uninitialized_params.values():
-                param._zeroed = True
 
     def addgrads(self, link):
         """Accumulates gradient values from given link.
@@ -479,22 +426,17 @@ class Link(object):
         """
         d = self.__dict__
         for name in self._params:
-            serializer(name, d[name].data)
+            param = d[name]
+            data = serializer(name, param.data)
+            if param.data is None and data is not None:
+                # Initialize the variable here
+                param.initialize(data.shape)
+                if isinstance(param.data, numpy.ndarray):
+                    numpy.copyto(param.data, data)
+                else:
+                    param.data.set(numpy.asarray(data))
         for name in self._persistent:
             d[name] = serializer(name, d[name])
-        if (self.has_uninitialized_params and
-                isinstance(serializer, chainer.serializer.Serializer)):
-            raise ValueError("uninitialized parameters cannot be serialized")
-        for name in self._uninitialized_params.copy():
-            # Note: There should only be uninitialized parameters
-            # during deserialization.
-            initialized_value = serializer(name, None)
-            self.add_param(name, initialized_value.shape)
-            uninitialized_value = d[name].data
-            if isinstance(uninitialized_value, numpy.ndarray):
-                numpy.copyto(uninitialized_value, initialized_value)
-            elif isinstance(uninitialized_value, cuda.ndarray):
-                uninitialized_value.set(numpy.asarray(initialized_value))
 
 
 class Chain(Link):

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -1,4 +1,3 @@
-from chainer import cuda
 from chainer.functions.connection import convolution_2d
 from chainer import initializers
 from chainer import link

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -64,11 +64,9 @@ class Convolution2D(link.Link):
         # For backward compatibility
         self.initialW = initialW
 
-        self._W_initializer = initializers._get_initializer(initialW)
-
-        if in_channels is None:
-            self.add_uninitialized_param('W')
-        else:
+        self.add_param('W', initializer=initializers._get_initializer(
+            initialW))
+        if in_channels is not None:
             self._initialize_params(in_channels)
 
         if nobias:
@@ -82,7 +80,7 @@ class Convolution2D(link.Link):
     def _initialize_params(self, in_channels):
         kh, kw = _pair(self.ksize)
         W_shape = (self.out_channels, in_channels, kh, kw)
-        self.add_param('W', W_shape, initializer=self._W_initializer)
+        self.W.initialize(W_shape)
 
     def __call__(self, x):
         """Applies the convolution layer.
@@ -94,9 +92,8 @@ class Convolution2D(link.Link):
             ~chainer.Variable: Output of the convolution.
 
         """
-        if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
-                self._initialize_params(x.shape[1])
+        if self.W.data is None:
+            self._initialize_params(x.shape[1])
         return convolution_2d.convolution_2d(
             x, self.W, self.b, self.stride, self.pad, self.use_cudnn,
             deterministic=self.deterministic)

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -1,6 +1,3 @@
-import numpy
-
-from chainer import cuda
 from chainer.functions.connection import deconvolution_2d
 from chainer import initializers
 from chainer import link

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -79,10 +79,8 @@ class Deconvolution2D(link.Link):
         self.out_channels = out_channels
         self.deterministic = deterministic
 
-        # For backward compatibility, the scale of weights is proportional to
-        # the square root of wscale.
         self.add_param('W', initializer=initializers._get_initializer(
-            initialW, scale=math.sqrt(self.wscale)))
+            initialW))
         if in_channels is not None:
             self._initialize_params(in_channels)
 

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -79,31 +79,29 @@ class Deconvolution2D(link.Link):
         self.out_channels = out_channels
         self.deterministic = deterministic
 
-        if in_channels is None:
-            self.add_uninitialized_param('W')
-        else:
+        # For backward compatibility, the scale of weights is proportional to
+        # the square root of wscale.
+        self.add_param('W', initializer=initializers._get_initializer(
+            initialW, scale=math.sqrt(self.wscale)))
+        if in_channels is not None:
             self._initialize_params(in_channels)
 
         if nobias:
             self.b = None
         else:
-            self.add_param('b', out_channels)
-            if isinstance(initial_bias, (numpy.ndarray, cuda.ndarray)):
-                assert initial_bias.shape == (out_channels,)
             if initial_bias is None:
                 initial_bias = bias
-            initializers.init_weight(self.b.data, initial_bias)
+            bias_initializer = initializers._get_initializer(initial_bias)
+            self.add_param('b', out_channels, initializer=bias_initializer)
 
     def _initialize_params(self, in_channels):
         kh, kw = _pair(self.ksize)
         W_shape = (in_channels, self.out_channels, kh, kw)
-        self.add_param('W', W_shape)
-        initializers.init_weight(self.W.data, self.initialW)
+        self.W.initialize(W_shape)
 
     def __call__(self, x):
-        if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
-                self._initialize_params(x.shape[1])
+        if self.W.data is None:
+            self._initialize_params(x.shape[1])
         return deconvolution_2d.deconvolution_2d(
             x, self.W, self.b, self.stride, self.pad,
             self.outsize, self.use_cudnn,

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -61,7 +61,7 @@ class DilatedConvolution2D(link.Link):
         # For backward compatibility, the scale of weights is proportional to
         # the square root of wscale.
         self.add_param('W', initializer=initializers._get_initializer(
-            initialW, scale=math.sqrt(wscale)))
+            initialW))
         if in_channels is not None:
             self._initialize_params(in_channels)
 

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -58,9 +58,11 @@ class DilatedConvolution2D(link.Link):
         self.out_channels = out_channels
         self.initialW = initialW
 
-        if in_channels is None:
-            self.add_uninitialized_param('W')
-        else:
+        # For backward compatibility, the scale of weights is proportional to
+        # the square root of wscale.
+        self.add_param('W', initializer=initializers._get_initializer(
+            initialW, scale=math.sqrt(wscale)))
+        if in_channels is not None:
             self._initialize_params(in_channels)
 
         if nobias:
@@ -74,8 +76,7 @@ class DilatedConvolution2D(link.Link):
     def _initialize_params(self, in_channels):
         kh, kw = _pair(self.ksize)
         W_shape = (self.out_channels, in_channels, kh, kw)
-        self.add_param('W', W_shape)
-        initializers.init_weight(self.W.data, self.initialW)
+        self.W.initialize(W_shape)
 
     def __call__(self, x):
         """Applies the convolution layer.
@@ -87,9 +88,8 @@ class DilatedConvolution2D(link.Link):
             ~chainer.Variable: Output of the convolution.
 
         """
-        if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
-                self._initialize_params(x.shape[1])
+        if self.W.data is None:
+            self._initialize_params(x.shape[1])
         return dilated_convolution_2d.dilated_convolution_2d(
             x, self.W, self.b, self.stride,
             self.pad, self.dilate, self.use_cudnn)

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -1,4 +1,3 @@
-from chainer import cuda
 from chainer.functions.connection import dilated_convolution_2d
 from chainer import initializers
 from chainer import link

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -1,4 +1,3 @@
-from chainer import cuda
 from chainer.functions.connection import linear
 from chainer import initializers
 from chainer import link

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -82,7 +82,7 @@ class StatelessLSTM(LSTMBase):
                 output of LSTM units.
 
         """
-        if self.upward.has_uninitialized_params:
+        if self.upward.W.data is None:
             in_size = x.size // x.shape[0]
             with cuda.get_device(self._device_id):
                 self.upward._initialize_params(in_size)
@@ -218,7 +218,7 @@ class LSTM(LSTMBase):
             ~chainer.Variable: Outputs of updated LSTM units.
 
         """
-        if self.upward.has_uninitialized_params:
+        if self.upward.W.data is None:
             with cuda.get_device(self._device_id):
                 in_size = x.size // x.shape[0]
                 self.upward._initialize_params(in_size)

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,6 +1,3 @@
-import numpy
-
-from chainer import cuda
 from chainer import initializers
 from chainer import link
 from chainer import utils

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,3 +1,5 @@
+import numpy
+
 from chainer import cuda
 from chainer import initializers
 from chainer import link
@@ -48,14 +50,13 @@ class LayerNormalization(link.Chain):
     def __init__(self, size=None, eps=1e-6, initial_gamma=None,
                  initial_beta=None):
         super(LayerNormalization, self).__init__()
-        self.add_uninitialized_param('gamma')
-        self.add_uninitialized_param('beta')
         if initial_gamma is None:
             initial_gamma = initializers.One()
-        self._gamma_initializer = initial_gamma
         if initial_beta is None:
             initial_beta = initializers.Zero()
-        self._beta_initializer = initial_beta
+
+        self.add_param('gamma', initializer=initial_gamma)
+        self.add_param('beta', initializer=initial_beta)
         self.eps = eps
 
         if size is not None:
@@ -65,10 +66,8 @@ class LayerNormalization(link.Chain):
             'chainer.links.normalization.layer_normalization.py')
 
     def _initialize_params(self, size):
-        self.add_param('gamma', size)
-        initializers.init_weight(self.gamma.data, self._gamma_initializer)
-        self.add_param('beta', size)
-        initializers.init_weight(self.beta.data, self._beta_initializer)
+        self.gamma.initialize(size)
+        self.beta.initialize(size)
 
     def _normalize(self, x):
         size = x.shape[1]
@@ -92,9 +91,8 @@ class LayerNormalization(link.Chain):
             ~chainer.Variable: Output of the layer normalization.
 
         """
-        if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
-                self._initialize_params(x.size // x.shape[0])
+        if self.gamma.data is None:
+            self._initialize_params(x.size // x.shape[0])
 
         normalized = self._normalize(x)
         return bias.bias(scale.scale(normalized, self.gamma), self.beta)

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -290,7 +290,8 @@ class Optimizer(object):
         .. deprecated:: v1.5
 
         """
-        return numpy.sqrt(_sum_sqnorm([p.grad for p in self.target.params(False)]))
+        return numpy.sqrt(_sum_sqnorm(
+            [p.grad for p in self.target.params(False)]))
 
     def clip_grads(self, maxnorm):
         """Clips the norm of whole gradients up to the threshold.

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -91,7 +91,7 @@ class Optimizer(object):
 
         """
         states = self._states
-        for name, param in self.target.namedparams():
+        for name, param in self.target.namedparams(False):
             if name not in states:
                 state = {}
                 self.init_state(param, state)
@@ -290,7 +290,7 @@ class Optimizer(object):
         .. deprecated:: v1.5
 
         """
-        return numpy.sqrt(_sum_sqnorm([p.grad for p in self.target.params()]))
+        return numpy.sqrt(_sum_sqnorm([p.grad for p in self.target.params(False)]))
 
     def clip_grads(self, maxnorm):
         """Clips the norm of whole gradients up to the threshold.
@@ -335,7 +335,7 @@ class Optimizer(object):
            instead.
 
         """
-        for param, g_src in zip(self.target.params(), grads):
+        for param, g_src in zip(self.target.params(False), grads):
             g_dst = param.grad
             if isinstance(g_dst, numpy.ndarray):
                 g_dst += cuda.to_cpu(g_src)
@@ -397,7 +397,7 @@ class GradientMethod(Optimizer):
 
         # TODO(unno): Some optimizers can skip this process if they does not
         # affect to a parameter when its gradient is zero.
-        for name, param in self.target.namedparams():
+        for name, param in self.target.namedparams(False):
             if param.grad is None:
                 with cuda.get_device(param.data):
                     xp = cuda.get_array_module(param.data)
@@ -408,7 +408,7 @@ class GradientMethod(Optimizer):
 
         self.t += 1
         states = self._states
-        for name, param in self.target.namedparams():
+        for name, param in self.target.namedparams(False):
             with cuda.get_device(param.data):
                 self.update_one(param, states[name])
 
@@ -490,7 +490,7 @@ class WeightDecay(object):
 
     def __call__(self, opt):
         rate = self.rate
-        for param in opt.target.params():
+        for param in opt.target.params(False):
             p, g = param.data, param.grad
             with cuda.get_device(p) as dev:
                 if int(dev) == -1:
@@ -523,7 +523,7 @@ class Lasso(object):
 
     def __call__(self, opt):
         rate = self.rate
-        for param in opt.target.params():
+        for param in opt.target.params(False):
             p, g = param.data, param.grad
             xp = cuda.get_array_module(p)
             sign = xp.sign(p)
@@ -553,10 +553,11 @@ class GradientClipping(object):
         self.threshold = threshold
 
     def __call__(self, opt):
-        norm = numpy.sqrt(_sum_sqnorm([p.grad for p in opt.target.params()]))
+        norm = numpy.sqrt(_sum_sqnorm(
+            [p.grad for p in opt.target.params(False)]))
         rate = self.threshold / norm
         if rate < 1:
-            for param in opt.target.params():
+            for param in opt.target.params(False):
                 grad = param.grad
                 with cuda.get_device(grad):
                     grad *= rate
@@ -601,7 +602,7 @@ class GradientNoise(object):
             'T noise', 'T g', 'g += noise', 'gradient_noise')
 
     def __call__(self, opt):
-        for param in opt.target.params():
+        for param in opt.target.params(False):
             g = param.grad
             xp = cuda.get_array_module(g)
             with cuda.get_device(g) as dev:
@@ -635,7 +636,7 @@ class GradientHardClipping(object):
 
     def __call__(self, opt):
         xp = opt.target.xp
-        for param in opt.target.params():
+        for param in opt.target.params(False):
             grad = param.grad
             with cuda.get_device(grad):
                 xp.clip(grad, self.lower_bound, self.upper_bound, out=grad)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import heapq
 import traceback
 import warnings
@@ -123,6 +124,11 @@ Actual: {0}'''.format(type(data))
         self.creator = None
 
         self.name = name
+
+    def __copy__(self):
+        copied = Variable()
+        copied.__dict__ = copy.copy(self.__dict__)
+        return copied
 
     def __reduce__(self):
         return Variable, (self.data, self.volatile, self.name, self._grad)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -10,6 +10,7 @@ import chainer
 from chainer import cuda
 from chainer import flag
 from chainer import utils
+from chainer import initializers
 
 
 def _check_grad_type(func, x, gx):
@@ -76,24 +77,40 @@ class Variable(object):
             'auto') or boolean values can be used, too.
         name (str): Name of the variable.
         grad (array): Initial gradient array.
+        initializer (~chainer.Initializer): Initializer of the data array.
+            If `data` is None, this object is used for initializing the data
+            array in the :meth:`initialize` method.
 
     Attributes:
         data: Data array of type either :class:`numpy.ndarray` or
-            :class:`cupy.ndarray`.
+            :class:`cupy.ndarray`. If it is None, the variable is left in an
+            uninitialized state.
         grad: Gradient array.
         creator: The function who creates this variable. It is ``None`` if the
             variable is not created by any function.
         volatile: Ternary :class:`~chainer.Flag` object. If ``'ON'``, the
             variable does not keep track of any function applications. See
             :class:`~chainer.Flag` for the detail of ternary flags.
+        initializer: Initializer of the data array. It is used for initializing
+            the data array of an uninitialized variable.
 
     """
 
-    def __init__(self, data, volatile=flag.OFF, name=None, grad=None):
-        if not isinstance(data, (numpy.ndarray, cuda.ndarray)):
-            msg = '''numpy.ndarray or cuda.ndarray are expected.
+    initializer = None
+    _grad_initializer = None
+    _initial_device = -1
+
+    def __init__(self, data=None, volatile=flag.OFF, name=None, grad=None,
+                 initializer=None):
+        if data is None:
+            self.initializer = (
+                initializers.NaN() if initializer is None else initializer)
+            dtype = getattr(self.initializer, 'dtype', numpy.float32)
+            self._grad_initializer = initializers.NaN(dtype)
+        elif not isinstance(data, (numpy.ndarray, cuda.ndarray)):
+                msg = '''numpy.ndarray or cuda.ndarray are expected.
 Actual: {0}'''.format(type(data))
-            raise TypeError(msg)
+                raise TypeError(msg)
 
         self.data = data
         self.rank = 0
@@ -211,9 +228,12 @@ Actual: {0}'''.format(type(data))
 
     def to_cpu(self):
         """Copies the data and gradient arrays to CPU."""
-        self.data = cuda.to_cpu(self.data)
-        if self._grad is not None:
-            self._grad = cuda.to_cpu(self._grad)
+        if self.data is None:
+            self._initial_device = -1
+        else:
+            self.data = cuda.to_cpu(self.data)
+            if self._grad is not None:
+                self._grad = cuda.to_cpu(self._grad)
 
     def to_gpu(self, device=None):
         """Copies the data and gradient arrays to specified GPU.
@@ -223,14 +243,20 @@ Actual: {0}'''.format(type(data))
                 used.
 
         """
-        with cuda.get_device(device):
-            self.data = cuda.to_gpu(self.data)
-            if self._grad is not None:
-                self._grad = cuda.to_gpu(self._grad)
+        if self.data is None:
+            current = cuda.Device().id
+            self._initial_device = current if device is None else device
+        else:
+            with cuda.get_device(device):
+                self.data = cuda.to_gpu(self.data)
+                if self._grad is not None:
+                    self._grad = cuda.to_gpu(self._grad)
 
     def cleargrad(self):
         """Clears the gradient array."""
         self._grad = None
+        if self.data is None:
+            self._grad_initializer = None
 
     def zerograd(self):
         """Initializes the gradient array by zeros.
@@ -242,6 +268,12 @@ Actual: {0}'''.format(type(data))
         warnings.warn(
             'Variable.zerograd is deprecated. Use Variable.cleargard instead.',
             DeprecationWarning)
+
+        if self.data is None:
+            dtype = getattr(self.initializer, 'dtype', None)
+            self._grad_initializer = initializers.Zero(dtype)
+            return
+
         with cuda.get_device(self.data) as dev:
             if self._grad is None:
                 xp = numpy if int(dev) == -1 else cuda.cupy
@@ -252,9 +284,14 @@ Actual: {0}'''.format(type(data))
     def copydata(self, var):
         """Copies the data array from given source variable.
 
-        This method just copies the data attribute from given variable to this
-        variable, except that the copy is even done across the host and
-        different devices.
+        This method copies the data array from given variable to this variable.
+        The copy is done even if the arrays reside on different devices,
+        including across the host and a GPU device. If this variable has an
+        uninitialized data array, this method initializes it by the data array
+        of the given variable. Similarly, if the given variable has an
+        uninitialized data array, this method initializes it by the data array
+        of this variable (``self``). If both are uninitialized, this method
+        does nothing.
 
         Args:
             var (Variable): Source variable.
@@ -262,6 +299,14 @@ Actual: {0}'''.format(type(data))
         """
         src = var.data
         dst = self.data
+        if src is None:
+            if dst is None:
+                return
+            var.initialize(self.shape)
+            src = var.data
+        elif dst is None:
+            self.initialize(src.shape)
+            dst = self.data
         src_xp = cuda.get_array_module(src)
         dst_xp = cuda.get_array_module(dst)
         if dst_xp is src_xp:
@@ -274,17 +319,23 @@ Actual: {0}'''.format(type(data))
     def addgrad(self, var):
         """Accumulates the gradient array from given source variable.
 
-        This method just runs ``self.grad += var.grad``, except that the
-        accumulation is even done across the host and different devices.
+        This method adds the gradient of a given variable to the gradient of
+        this variable. The accumulation is even done across the host and
+        different devices. If this variable has uninitialized data/grad arrays,
+        this method initializes it with the shape of the given varaible and
+        then accumulates the gradient.
 
         Args:
             var (Variable): Source variable.
 
         """
         src = var._grad
-        dst = self._grad
         if src is None:
             return
+
+        if self.data is None:
+            self.initialize(var.shape)
+        dst = self._grad
 
         src_dev = cuda.get_device(src)
         dst_dev = cuda.get_device(self.data)
@@ -477,6 +528,31 @@ Actual: {0}'''.format(type(data))
             for var in func.inputs:
                 add_cand(var.creator)
             func.unchain()
+
+    def initialize(self, shape):
+        """Initializes the uninitialized variable.
+
+        Uninitialized variable is a variable created with the data array set to
+        None. This method creates and initializes the data array. The shape of
+        the variable can be left unknown until this method is called.
+
+        Args:
+            shape (tuple of int): Shape of the data array.
+
+        """
+        data = initializers.generate_array(self.initializer, shape, numpy)
+
+        ginit = self._grad_initializer
+        grad = None if ginit is None else initializers.generate_array(
+            ginit, shape, numpy)
+
+        if self._initial_device >= 0:
+            data = cuda.to_gpu(data, device=self._initial_device)
+            if grad is not None:
+                grad = cuda.to_gpu(grad, device=self._initial_device)
+
+        self.data = data
+        self.grad = grad
 
     def __lt__(self, other):
         raise NotImplementedError()

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -111,7 +111,7 @@ class Variable(object):
         elif not isinstance(data, (numpy.ndarray, cuda.ndarray)):
             msg = '''numpy.ndarray or cuda.ndarray are expected.
 Actual: {0}'''.format(type(data))
-                raise TypeError(msg)
+            raise TypeError(msg)
 
         # Use a list as a data structure to hold the data array indirectly to
         # abstract its initialized/uninitialized state.

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -10,8 +10,8 @@ import six
 import chainer
 from chainer import cuda
 from chainer import flag
-from chainer import utils
 from chainer import initializers
+from chainer import utils
 
 
 def _check_grad_type(func, x, gx):
@@ -109,7 +109,7 @@ class Variable(object):
             dtype = getattr(self.initializer, 'dtype', numpy.float32)
             self._grad_initializer = initializers.NaN(dtype)
         elif not isinstance(data, (numpy.ndarray, cuda.ndarray)):
-                msg = '''numpy.ndarray or cuda.ndarray are expected.
+            msg = '''numpy.ndarray or cuda.ndarray are expected.
 Actual: {0}'''.format(type(data))
                 raise TypeError(msg)
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -112,7 +112,10 @@ class Variable(object):
 Actual: {0}'''.format(type(data))
                 raise TypeError(msg)
 
-        self.data = data
+        # Use a list as a data structure to hold the data array indirectly to
+        # abstract its initialized/uninitialized state.
+        self._data = [data]
+
         self.rank = 0
         self._volatile = flag.Flag(volatile)
 
@@ -201,6 +204,14 @@ Actual: {0}'''.format(type(data))
                              str(self.data.dtype))
 
     @property
+    def data(self):
+        return self._data[0]
+
+    @data.setter
+    def data(self, d):
+        self._data[0] = d
+
+    @property
     def grad(self):
         return self._grad
 
@@ -231,7 +242,7 @@ Actual: {0}'''.format(type(data))
         if self.data is None:
             self._initial_device = -1
         else:
-            self.data = cuda.to_cpu(self.data)
+            self._data = [cuda.to_cpu(self.data)]
             if self._grad is not None:
                 self._grad = cuda.to_cpu(self._grad)
 
@@ -248,7 +259,7 @@ Actual: {0}'''.format(type(data))
             self._initial_device = current if device is None else device
         else:
             with cuda.get_device(device):
-                self.data = cuda.to_gpu(self.data)
+                self._data = [cuda.to_gpu(self.data)]
                 if self._grad is not None:
                     self._grad = cuda.to_gpu(self._grad)
 
@@ -551,7 +562,7 @@ Actual: {0}'''.format(type(data))
             if grad is not None:
                 grad = cuda.to_gpu(grad, device=self._initial_device)
 
-        self.data = data
+        self._data[0] = data
         self.grad = grad
 
     def __lt__(self, other):

--- a/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
@@ -177,7 +177,7 @@ class TestInvalidInput(unittest.TestCase):
 class TestInvalidInitialize(unittest.TestCase):
 
     def test_invalid_type(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.link = _create_ln(None, 1e-6, {})
             self.link(chainer.Variable(numpy.zeros((1, 5), dtype='f')))
 

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -111,7 +111,7 @@ class OptimizerTestBase(object):
             optimizer = self.model.optimizer
             model.to_gpu(1)
             optimizer.setup(model)
-        for name, param in optimizer.target.namedparams():
+        for name, param in optimizer.target.namedparams(False):
             for v in six.itervalues(optimizer._states[name]):
                 self.assertEqual(int(param.data.device), int(v.device))
 

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -5,7 +5,7 @@ import numpy
 
 import chainer
 from chainer import cuda
-import chainer.serializer
+from chainer import initializers
 from chainer import testing
 from chainer.testing import attr
 
@@ -15,26 +15,42 @@ class TestLink(unittest.TestCase):
     def setUp(self):
         x_shape_0 = 2
         x_shape_1 = numpy.int64(3)
-        self.link = chainer.Link(x=((x_shape_0, x_shape_1), 'd'), y=2)
+        self.link = chainer.Link(x=((x_shape_0, x_shape_1), 'd'), y=2,
+                                 u=(None, 'd'), v=None)
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'
 
-    def check_param_init(self, name, shape, dtype):
+    def check_param_init(self, name, shape, dtype, data_value=numpy.nan):
         self.assertTrue(hasattr(self.link, name))
         var = getattr(self.link, name)
         self.assertEqual(var.name, name)
         self.assertIsInstance(var, chainer.Variable)
         self.assertEqual(var.data.shape, shape)
         self.assertEqual(var.data.dtype, dtype)
-        self.assertTrue(numpy.all(numpy.isnan(var.data)))
+        numpy.testing.assert_array_equal(var.data, data_value)
         self.assertEqual(var.grad.shape, shape)
         self.assertEqual(var.grad.dtype, dtype)
-        self.assertTrue(numpy.all(numpy.isnan(var.grad)))
+        numpy.testing.assert_array_equal(var.grad, numpy.nan)
+
+    def check_param_uninit(self, name, initializer=None):
+        self.assertTrue(hasattr(self.link, name))
+        var = getattr(self.link, name)
+        self.assertIsInstance(var, chainer.Variable)
+        self.assertEqual(var.name, name)
+        self.assertIsNone(var.data)
+        if initializer is not None:
+            self.assertIs(var.initializer, initializer)
 
     def test_init(self):
         self.check_param_init('x', (2, 3), 'd')
         self.check_param_init('y', (2,), 'f')
+        self.check_param_uninit('u')
+        self.link.u.initialize((2, 3))
+        self.check_param_init('u', (2, 3), 'd')
+        self.check_param_uninit('v')
+        self.link.v.initialize((2, 3))
+        self.check_param_init('v', (2, 3), 'f')
 
     def test_add_param(self):
         self.link.add_param('z', (2, 3))
@@ -42,6 +58,28 @@ class TestLink(unittest.TestCase):
 
         self.link.add_param('w', (2, 3), dtype='d')
         self.check_param_init('w', (2, 3), 'd')
+
+        self.link.add_param('r')
+        self.check_param_uninit('r')
+        self.link.r.initialize((2, 3))
+        self.check_param_init('r', (2, 3), 'f')
+
+        self.link.add_param('s', dtype='d')
+        self.check_param_uninit('s')
+        self.link.s.initialize((2, 3))
+        self.check_param_init('s', (2, 3), 'd')
+
+        initializer = initializers.Zero('d')
+        self.link.add_param('t', initializer=initializer)
+        self.check_param_uninit('t', initializer)
+        self.link.t.initialize((2, 3))
+        self.check_param_init('t', (2, 3), 'd', 0)
+
+    def test_add_param_direct_initialization(self):
+        z = numpy.random.rand(2, 3).astype('f')
+        self.link.add_param('z', initializer=z)
+        self.assertIsInstance(self.link.z.data, numpy.ndarray)
+        numpy.testing.assert_array_equal(self.link.z.data, z)
 
     def test_add_persistent(self):
         self.assertTrue(hasattr(self.link, 'p'))
@@ -55,11 +93,13 @@ class TestLink(unittest.TestCase):
         link = self.link.copy()
         self.assertTrue(hasattr(link, 'x'))
         self.assertTrue(hasattr(link, 'y'))
+        self.assertTrue(hasattr(link, 'u'))
         self.assertTrue(hasattr(link, 'p'))
         self.assertIsNot(link.x, self.link.x)
         self.assertIs(link.x.data, self.link.x.data)
         self.assertIsNot(link.y, self.link.y)
         self.assertIs(link.y.data, self.link.y.data)
+        self.assertIsNone(link.u.data)
         self.assertIs(link.p, self.link.p)
         self.assertIs(link.name, None)
 
@@ -74,39 +114,53 @@ class TestLink(unittest.TestCase):
         self.assertIs(self.link.x.grad, gx)
         self.assertIs(self.link.y.data, y)
         self.assertIs(self.link.y.grad, gy)
+        self.assertIsNone(self.link.u.data)
+        self.assertIsNone(self.link.u.grad)
         self.assertIs(self.link.p, p)
 
     @attr.gpu
     def test_to_cpu(self):
         self.link.to_gpu()
         self.link.to_cpu()
+        self.link.v.initialize((2, 3))
         self.assertIs(self.link.xp, numpy)
         self.assertIsInstance(self.link.x.data, numpy.ndarray)
         self.assertIsInstance(self.link.x.grad, numpy.ndarray)
         self.assertIsInstance(self.link.y.data, numpy.ndarray)
         self.assertIsInstance(self.link.y.grad, numpy.ndarray)
+        self.assertIsNone(self.link.u.data)
+        self.assertIsNone(self.link.u.grad)
+        self.assertIsInstance(self.link.v.data, numpy.ndarray)
+        self.assertIsInstance(self.link.v.grad, numpy.ndarray)
         self.assertIsInstance(self.link.p, numpy.ndarray)
 
     @attr.gpu
     def test_to_gpu(self):
         cupy = cuda.cupy
         self.link.to_gpu()
+        self.link.v.initialize((2, 3))
         self.assertIs(self.link.xp, cupy)
         self.assertIsInstance(self.link.x.data, cupy.ndarray)
         self.assertIsInstance(self.link.x.grad, cupy.ndarray)
         self.assertIsInstance(self.link.y.data, cupy.ndarray)
         self.assertIsInstance(self.link.y.grad, cupy.ndarray)
+        self.assertIsNone(self.link.u.data)
+        self.assertIsNone(self.link.u.grad)
+        self.assertIsInstance(self.link.v.data, cupy.ndarray)
+        self.assertIsInstance(self.link.v.grad, cupy.ndarray)
         self.assertIsInstance(self.link.p, cupy.ndarray)
 
     def test_params(self):
         params = list(self.link.params())
         self.assertEqual({id(p) for p in params},
-                         {id(self.link.x), id(self.link.y)})
+                         {id(self.link.x), id(self.link.y),
+                          id(self.link.u), id(self.link.v)})
 
     def test_namedparams(self):
         namedparams = list(self.link.namedparams())
         self.assertEqual({(name, id(p)) for name, p in namedparams},
-                         {('/x', id(self.link.x)), ('/y', id(self.link.y))})
+                         {('/x', id(self.link.x)), ('/y', id(self.link.y)),
+                          ('/u', id(self.link.u)), ('/v', id(self.link.v))})
 
     def test_links(self):
         links = list(self.link.links())
@@ -125,34 +179,42 @@ class TestLink(unittest.TestCase):
     def test_copyparams(self):
         self.link.x.grad.fill(0)
         self.link.y.grad.fill(1)
+        self.link.u.initialize((2, 3))
+        self.link.u.data.fill(0)
+        self.link.u.grad.fill(1)
+        self.link.v.zerograd()
         gx = self.link.x.grad.copy()
         gy = self.link.y.grad.copy()
+        gu = self.link.u.grad.copy()
 
-        l = chainer.Link(x=(2, 3), y=2)
+        l = chainer.Link(x=(2, 3), y=2, u=(2, 3), v=(3, 2))
         l.x.data.fill(2)
         l.x.grad.fill(3)
         l.y.data.fill(4)
         l.y.grad.fill(5)
+        l.u.data.fill(6)
+        l.u.grad.fill(7)
+        l.v.data.fill(8)
+        l.v.grad.fill(9)
+
         self.link.copyparams(l)
         numpy.testing.assert_array_equal(self.link.x.data, l.x.data)
         numpy.testing.assert_array_equal(self.link.x.grad, gx)
         numpy.testing.assert_array_equal(self.link.y.data, l.y.data)
         numpy.testing.assert_array_equal(self.link.y.grad, gy)
-
-    def test_copyparams_uninitialized(self):
-        l = chainer.Link(x=(2, 3))
-        l.add_uninitialized_param('y')
-        self.link.x.data.fill(2)
-        self.link.y.data.fill(4)
-        l.copyparams(self.link)
-        numpy.testing.assert_array_equal(l.x.data, self.link.x.data)
-        self.assertTrue(hasattr(l, 'y'))
-        numpy.testing.assert_array_equal(l.y.data, self.link.y.data)
+        numpy.testing.assert_array_equal(self.link.u.data, l.u.data)
+        numpy.testing.assert_array_equal(self.link.u.grad, gu)
+        numpy.testing.assert_array_equal(self.link.v.data, l.v.data)
+        numpy.testing.assert_array_equal(self.link.v.grad, 0)
 
     def test_cleargrads(self):
         self.link.cleargrads()
         self.assertIsNone(self.link.x.grad)
         self.assertIsNone(self.link.y.grad)
+        self.link.u.initialize((2, 3))
+        self.link.v.initialize((2, 3))
+        self.assertIsNone(self.link.u.grad)
+        self.assertIsNone(self.link.v.grad)
 
     def test_zerograds(self):
         gx_expect = numpy.zeros_like(self.link.x.data)
@@ -160,21 +222,32 @@ class TestLink(unittest.TestCase):
         self.link.zerograds()
         numpy.testing.assert_array_equal(self.link.x.grad, gx_expect)
         numpy.testing.assert_array_equal(self.link.y.grad, gy_expect)
+        self.link.u.initialize((2, 3))
+        self.link.v.initialize((2, 3))
+        gu_expect = numpy.zeros_like(self.link.u.data)
+        gv_expect = numpy.zeros_like(self.link.v.data)
+        numpy.testing.assert_array_equal(self.link.u.grad, gu_expect)
+        numpy.testing.assert_array_equal(self.link.v.grad, gv_expect)
 
     def test_addgrads(self):
-        l = chainer.Link(x=(2, 3), y=2)
+        l = chainer.Link(x=(2, 3), y=2, u=(2, 3), v=None)
         l.x.grad.fill(1)
         l.y.grad.fill(2)
+        l.u.grad.fill(3)
 
         self.link.x.grad.fill(-1)
         self.link.y.grad.fill(-2)
+        self.link.u.cleargrad()
 
         self.link.addgrads(l)
 
         gx_expect = numpy.zeros_like(l.x.grad)
         gy_expect = numpy.zeros_like(l.y.grad)
+        gu_expect = l.u.grad
         numpy.testing.assert_array_equal(self.link.x.grad, gx_expect)
         numpy.testing.assert_array_equal(self.link.y.grad, gy_expect)
+        numpy.testing.assert_array_equal(self.link.u.grad, gu_expect)
+        self.assertIsNone(self.link.v.grad, None)
 
     def test_serialize(self):
         serializer = mock.MagicMock(return_value=3)
@@ -189,9 +262,8 @@ class TestLink(unittest.TestCase):
 
     def test_serialize_param_shape_placeholder(self):
         serializer = mock.MagicMock(return_value=3)
-        l = chainer.Link(y=2)
-        l.add_uninitialized_param('x')
-        l.add_param('x', (2, 3))
+        l = chainer.Link(y=2, x=None)
+        l.x.initialize((2, 3))
         l.add_persistent('z', 1)
         l.serialize(serializer)
         self.assertEqual(serializer.call_count, 3)
@@ -200,40 +272,15 @@ class TestLink(unittest.TestCase):
         serializer.assert_any_call('z', 1)
         self.assertEqual(l.z, 3)
 
-    def test_serialize_uninitialized_param(self):
-        class SerializerMock(chainer.serializer.Serializer):
-
-            def __getitem__(self, key):
-                pass
-
-            def __call__(self, key, value):
-                pass
-
-        serializer = SerializerMock()
-        l = chainer.Link()
-        l.add_uninitialized_param('x')
-        with self.assertRaises(ValueError):
-            l.serialize(serializer)
-
-    def test_duplicate_uninitialized_param(self):
-        l = chainer.Link(y=2)
-        l.add_uninitialized_param('x')
-        with self.assertRaises(AttributeError):
-            l.add_uninitialized_param('x')
-
-    def test_uninitialized_param_already_param(self):
-        l = chainer.Link(y=2)
-        l.add_param('x', (2, 3))
-        with self.assertRaises(AttributeError):
-            l.add_uninitialized_param('x')
-
-    def test_has_uninitialized_params(self):
-        l = chainer.Link(y=2)
-        self.assertFalse(l.has_uninitialized_params)
-        l.add_uninitialized_param('x')
-        self.assertTrue(l.has_uninitialized_params)
-        l.add_param('x', (2, 3))
-        self.assertFalse(l.has_uninitialized_params)
+    def test_serialize_deserialize_to_uninitialized_param(self):
+        ret = numpy.random.rand(2, 3).astype('f')
+        serializer = mock.MagicMock(return_value=ret)
+        l = chainer.Link(x=None)
+        l.serialize(serializer)
+        self.assertEqual(serializer.call_count, 1)
+        serializer.assert_any_call('x', None)
+        self.assertIsInstance(l.x.data, numpy.ndarray)
+        numpy.testing.assert_array_equal(l.x.data, ret)
 
 
 class CountVariable(chainer.Variable):
@@ -484,8 +531,7 @@ class TestChain(unittest.TestCase):
 class TestChainList(unittest.TestCase):
 
     def setUp(self):
-        self.l1 = chainer.Link(x=(2, 3))
-        self.l1.add_uninitialized_param('y')
+        self.l1 = chainer.Link(x=(2, 3), y=None)
         self.l2 = chainer.Link(x=2)
         self.l3 = chainer.Link(x=3)
         self.c1 = chainer.ChainList(self.l1)
@@ -618,12 +664,14 @@ class TestChainList(unittest.TestCase):
     def test_params(self):
         params = list(self.c2.params())
         self.assertEqual({id(p) for p in params},
-                         {id(self.l1.x), id(self.l2.x), id(self.l3.x)})
+                         {id(self.l1.x), id(self.l1.y),
+                          id(self.l2.x), id(self.l3.x)})
 
     def test_namedparams(self):
         namedparams = list(self.c2.namedparams())
         self.assertEqual({(name, id(p)) for name, p in namedparams},
                          {('/0/0/x', id(self.l1.x)),
+                          ('/0/0/y', id(self.l1.y)),
                           ('/0/1/x', id(self.l2.x)),
                           ('/1/x', id(self.l3.x))})
 
@@ -663,7 +711,7 @@ class TestChainList(unittest.TestCase):
                          (id(self.l1), id(self.l2)))
 
     def test_copyparams(self):
-        l1 = chainer.Link(x=(2, 3))
+        l1 = chainer.Link(x=(2, 3), y=None)
         l2 = chainer.Link(x=2)
         l3 = chainer.Link(x=3)
         c1 = chainer.ChainList(l1, l2)
@@ -683,19 +731,19 @@ class TestChainList(unittest.TestCase):
         numpy.testing.assert_array_equal(self.l1.x.grad, numpy.zeros((2, 3)))
         numpy.testing.assert_array_equal(self.l2.x.grad, numpy.zeros(2))
         numpy.testing.assert_array_equal(self.l3.x.grad, numpy.zeros(3))
-
-        self.assertTrue(self.l1._uninitialized_params['y']._zeroed)
+        self.l1.y.initialize((2, 3))
+        numpy.testing.assert_array_equal(self.l1.y.grad, numpy.zeros((2, 3)))
 
     def test_cleargrads(self):
         self.c2.cleargrads()
         self.assertIsNone(self.l1.x.grad)
         self.assertIsNone(self.l2.x.grad)
         self.assertIsNone(self.l3.x.grad)
-
-        self.assertTrue(self.l1._uninitialized_params['y']._cleared)
+        self.l1.y.initialize((2, 3))
+        self.assertIsNone(self.l1.y.grad)
 
     def test_addgrads(self):
-        l1 = chainer.Link(x=(2, 3))
+        l1 = chainer.Link(x=(2, 3), y=(2, 3))
         l2 = chainer.Link(x=2)
         l3 = chainer.Link(x=3)
         c1 = chainer.ChainList(l1, l2)
@@ -703,30 +751,37 @@ class TestChainList(unittest.TestCase):
         l1.x.grad.fill(1)
         l2.x.grad.fill(2)
         l3.x.grad.fill(3)
+        l1.y.grad.fill(4)
 
         self.l1.x.grad.fill(-1)
+        self.l1.y.cleargrad()
         self.l2.x.grad.fill(-2)
         self.l3.x.grad.fill(-3)
 
         self.c2.addgrads(c2)
         numpy.testing.assert_array_equal(self.l1.x.grad, numpy.zeros((2, 3)))
+        numpy.testing.assert_array_equal(self.l1.y.grad, l1.y.grad)
         numpy.testing.assert_array_equal(self.l2.x.grad, numpy.zeros(2))
         numpy.testing.assert_array_equal(self.l3.x.grad, numpy.zeros(3))
 
     def test_serialize(self):
-        self.l1.add_param('y', (1, 1))
+        l1 = chainer.Link(x=(2, 3))
+        l1.add_param('y', (1, 1))
+        l2 = chainer.Link(x=2)
+        c1 = chainer.ChainList(l1, l2)
         mocks = {'0': mock.MagicMock(), '1': mock.MagicMock()}
         serializer = mock.MagicMock()
         serializer.__getitem__.side_effect = lambda k: mocks[k]
-        self.c1.serialize(serializer)
+        serializer.return_value = None
+        c1.serialize(serializer)
 
         self.assertEqual(serializer.call_count, 0)
         self.assertEqual(serializer.__getitem__.call_count, 2)
         serializer.__getitem__.assert_any_call('0')
         serializer.__getitem__.assert_any_call('1')
 
-        mocks['0'].assert_called_with('y', self.l1.y.data)
-        mocks['1'].assert_called_with('x', self.l2.x.data)
+        mocks['0'].assert_called_with('y', l1.y.data)
+        mocks['1'].assert_called_with('x', l2.x.data)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import unittest
 
@@ -622,6 +623,13 @@ class TestUninitializedVariable(unittest.TestCase):
         x.to_gpu()
         x.to_cpu()
         self.check_constant_initialization(x, self.a, np)
+
+    def test_copy_to_initialize(self):
+        # This test intends the use case of link.copy() method.
+        x = chainer.Variable()
+        y = copy.copy(x)
+        x.initialize((3, 2))
+        self.assertIs(x.data, y.data)
 
     def test_cleargrad(self):
         x = chainer.Variable()


### PR DESCRIPTION
Fix #1967. It includes the following changes:

- Variable supports uninitialized state, in which the data array is None.
- Link supports uninitialized variable as a parameter. Link.add_uninitialized_param and Link.has_uninitialied_params are **removed**.
- The implementations of links that use parameter shape placeholder (Convolution2D, Deconvolution2D, DilatedConvolution2D, LayerNormalization, Linear, and LSTM) are updated to use the new uninitialized parameters. The interface of them is not changed.

The two methods of Link are removed. I was first thinking about leaving them with deprecation warning, but I found that the existing code is broken even if I leave them (because the way of initializing the uninitialized parameter is changed: we had to call `link.add_param('param', shape)` in the previous design, while we have to call `link.param.initialize(shape)` in the new design). In this case, it is better to raise an error on using these methods (because the related code cannot run as expected), and so I decided to remove them.

Some methods of Variable are also updated to support the uninitialized parameter. Some of them are not explained in the original design document. I also updated the document of them, so I hope the changes are obvious.