### PR TITLE
Improve PlotReport

### DIFF
--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -1,13 +1,13 @@
 import json
-import warnings
 from os import path
+import warnings
 
 import numpy
 import six
 
 from chainer import reporter
-from chainer.training import extension
 import chainer.serializer as serializer_module
+from chainer.training import extension
 import chainer.training.trigger as trigger_module
 
 try:

--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -1,12 +1,12 @@
-from chainer import reporter
-from chainer.training import extension
+import json
 from os import path
 
-import chainer.serializer as serializer_module
-import chainer.training.trigger as trigger_module
-import json
 import numpy
 import six
+
+from chainer import reporter
+from chainer.training import extension
+import chainer.training.trigger as trigger_module
 
 try:
     import matplotlib

--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from os import path
 
 import numpy
@@ -6,6 +7,7 @@ import six
 
 from chainer import reporter
 from chainer.training import extension
+import chainer.serializer as serializer_module
 import chainer.training.trigger as trigger_module
 
 try:
@@ -22,11 +24,10 @@ except ImportError:
 
 def _check_available():
     if not _available:
-        msg = '''matplotlib is not installed on your environment.
-Please install matplotlib to plot figure.
-
-  $ pip install matplotlib'''
-        raise RuntimeError(msg)
+        warnings.warn('matplotlib is not installed on your environment, '
+                      'so that nothing will be plotted at this time. '
+                      'Please install matplotlib to plot figures.\n\n'
+                      '$ pip install matplotlib')
 
 
 class PlotReport(extension.Extension):
@@ -71,6 +72,9 @@ class PlotReport(extension.Extension):
 
         _check_available()
 
+        if not _available:
+            return
+
         self._x_key = x_key
         if isinstance(y_keys, str):
             y_keys = (y_keys,)
@@ -83,6 +87,9 @@ class PlotReport(extension.Extension):
         self._data = {k: [] for k in y_keys}
 
     def __call__(self, trainer):
+        if not _available:
+            return
+
         keys = self._y_keys
         observation = trainer.observation
         summary = self._summary

--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -25,9 +25,9 @@ except ImportError:
 def _check_available():
     if not _available:
         warnings.warn('matplotlib is not installed on your environment, '
-                      'so that nothing will be plotted at this time. '
+                      'so nothing will be plotted at this time. '
                       'Please install matplotlib to plot figures.\n\n'
-                      '$ pip install matplotlib')
+                      '  $ pip install matplotlib\n')
 
 
 class PlotReport(extension.Extension):

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import argparse
+from chainer import training
+from chainer.training import extensions
 
+import argparse
 import chainer
 import chainer.functions as F
 import chainer.links as L
-from chainer import training
-from chainer.training import extensions
 
 
 # Network definition
@@ -83,6 +83,14 @@ def main():
 
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())
+
+    # Save a plot image to the result dir
+    trainer.extend(
+        extensions.PlotReport(['main/loss', 'validation/main/loss'], 'epoch',
+                              file_name='loss.png'))
+    trainer.extend(
+        extensions.PlotReport(['main/accuracy', 'validation/main/accuracy'],
+                              'epoch', file_name='accuracy.png'))
 
     # Print selected entries of the log to stdout
     # Here "main" refers to the target link of the "main" optimizer again, and

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 from __future__ import print_function
-from chainer import training
-from chainer.training import extensions
-
 import argparse
+
 import chainer
 import chainer.functions as F
 import chainer.links as L
+from chainer import training
+from chainer.training import extensions
 
 
 # Network definition

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -84,7 +84,7 @@ def main():
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())
 
-    # Save a plot image to the result dir
+    # Save two plot images to the result dir
     trainer.extend(
         extensions.PlotReport(['main/loss', 'validation/main/loss'], 'epoch',
                               file_name='loss.png'))


### PR DESCRIPTION
This PR makes the plots created by PlotReport extension richer and adds this extension to the trainer in the MNIST example to show how to use this extension.

This PR actually adds legend to plots, and a label to x-axis, and grid to the figure.

After running `examples/mnist/train_mnist.py`, the below two plots will be saved in the result dir.

![loss](https://cloud.githubusercontent.com/assets/666535/21715212/88945896-d446-11e6-8be2-bb3d42fb60b5.png)
![accuracy](https://cloud.githubusercontent.com/assets/666535/21715216/8c04b354-d446-11e6-94bf-57898fe7847a.png)
