### PR TITLE
Make astype handle conversion b/w np.longlong and np.int64

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -276,7 +276,7 @@ cdef class ndarray:
         """
         # TODO(beam2d): Support ordering, casting, and subok option
         dtype = numpy.dtype(dtype)
-        if dtype == self.dtype:
+        if dtype.type == self.dtype.type:
             if copy:
                 return self.copy()
             else:

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import cupy
 from cupy import testing
 
 
@@ -55,6 +56,21 @@ class TestArrayCopyAndView(unittest.TestCase):
     def test_astype(self, xp, src_dtype, dst_dtype):
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return a.astype(dst_dtype)
+
+    @testing.for_all_dtypes(name='src_dtype')
+    @testing.for_all_dtypes(name='dst_dtype')
+    def test_astype_type(self, src_dtype, dst_dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, src_dtype)
+        b = a.astype(dst_dtype)
+        a_cpu = testing.shaped_arange((2, 3, 4), numpy, src_dtype)
+        b_cpu = a_cpu.astype(dst_dtype)
+        self.assertEqual(b.dtype.type, b_cpu.dtype.type)
+
+    @testing.for_all_dtypes()
+    def test_astype_type_no_copy(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        b = a.astype(dtype, copy=False)
+        self.assertTrue(b is a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
This PR fixes a bug in cupy.ndarray.astype that does not handle conversion between `np.dtype('q')` and `np.dtype('l')`. 

A simple failing case is as follows. The assertions pass for NumPy, but fails for CuPy.

```python 
import numpy as np
import cupy


def check_dtype_type(xp):
    x = xp.array([1,2,3], np.dtype('q'))
    assert x.dtype.type != np.dtype('l').type
    assert x.dtype.type == np.dtype('q').type

    xl = x.astype(np.dtype('l'))
    assert xl.dtype.type == np.dtype('l').type
    assert xl.dtype.type != np.dtype('q').type

check_dtype_type(np)
check_dtype_type(cupy)
```

This happens because equality operator is True for objects of type `numpy.dtype` (e.g. `x.dtype`, `np.dtype('q')`), but fails for type objects (`np.dtype('q').type`):

```python
>>> np.dtype('l') == np.dtype('q')
True
>>> np.dtype('l').type != np.dtype('q').type
False
```