### PR TITLE
Kindly warn when numpy and cupy are used together

### DIFF
--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -41,6 +41,10 @@ class EmbedIDFunction(function.Function):
             return xp.where(
                 mask[..., None], 0, W.take(xp.where(mask, 0, x), axis=0)),
 
+        if type(x) != type(W):
+            raise ValueError('Type of W and x must be the same\n'
+                             '%s != %s' % (type(x), type(W)))
+
         return W.take(x, axis=0),
 
     def backward(self, inputs, grad_outputs):


### PR DESCRIPTION
This PR adds a warning message when numpy and cupy are used together by mistake.

When `W` is `numpy.ndarray` and `x` is `cupy.core.core.ndarray`
(which can happen when the user forgets sending the model to the GPU(s)),
the current version yields a very unfriendly error:
```
File "/path/to/chainer/functions/connection/embed_id.py", line 44, in forward
return W.take(x, axis=0)
ValueError: object __array__ method not producing an array
``` 
This PR fixes this issue by raising an exception with a more friendly message.

A small code that points out the underlying problem:
```
W = numpy.array([1,2,3])
x = cupy.array([0])
W.take(x)
# The same exception as the above sample occurs.
# take() tries to do numpy.array(x), but it does not work as 
# cupy.core.core.ndarray does not satisfy the condition to be array_like 
```

The fundamental solution might be implementing \_\_array_interface\_\_ to `cupy.core.core.ndarray`
as commented in `cupy/core/core.pyx` (so that any mixture of `numpy.ndarray` and `cupy.core.core.ndarray` runs), but this is involved with a design decision whether
people want a system that "runs slowly" or "just requires a fix" when numpy and cupy are mixed.