### PR TITLE
Insert function label in initializer of InvalidType exception for readable stack-trace

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -269,15 +269,8 @@ class Function(object):
 
     def _check_data_type_forward(self, in_data):
         in_type = type_check.get_types(in_data, 'in_types', False)
-        try:
+        with type_check.check_function(self):
             self.check_type_forward(in_type)
-        except type_check.InvalidType as e:
-            msg = """
-Invalid operation is performed in: {0} (Forward)
-
-{1}""".format(self.label, str(e))
-            six.raise_from(
-                type_check.InvalidType(e.expect, e.actual, msg=msg), None)
 
     def check_type_forward(self, in_types):
         """Checks types of input data before forward propagation.

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -269,7 +269,7 @@ class Function(object):
 
     def _check_data_type_forward(self, in_data):
         in_type = type_check.get_types(in_data, 'in_types', False)
-        with type_check.check_function(self):
+        with type_check.get_function_check_context(self):
             self.check_type_forward(in_type)
 
     def check_type_forward(self, in_types):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -13,9 +13,10 @@ _thread_local = threading.local()
 
 @contextlib.contextmanager
 def get_function_check_context(f):
+    default = getattr(_thread_local, 'current_function', 'None')
     _thread_local.current_function = f
     yield
-    _thread_local.current_function = None
+    _thread_local.current_function = default
 
 
 class TypeInfo(object):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -12,7 +12,7 @@ _thread_local = threading.local()
 
 
 @contextlib.contextmanager
-def check_function(f):
+def get_function_check_context(f):
     _thread_local.current_function = f
     yield
     _thread_local.current_function = None

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -13,7 +13,7 @@ _thread_local = threading.local()
 
 @contextlib.contextmanager
 def get_function_check_context(f):
-    default = getattr(_thread_local, 'current_function', 'None')
+    default = getattr(_thread_local, 'current_function', None)
     _thread_local.current_function = f
     yield
     _thread_local.current_function = default

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -1,9 +1,21 @@
+import contextlib
 import operator
 import sys
+import threading
 
 import numpy
 
 from chainer import cuda
+
+
+_thread_local = threading.local()
+
+
+@contextlib.contextmanager
+def check_function(f):
+    _thread_local.current_function = f
+    yield
+    _thread_local.current_function = None
 
 
 class TypeInfo(object):
@@ -444,6 +456,13 @@ class InvalidType(Exception):
     def __init__(self, expect, actual, msg=None):
         if msg is None:
             msg = 'Expect: {0}\nActual: {1}'.format(expect, actual)
+            if (hasattr(_thread_local, 'current_function')
+                    and _thread_local.current_function is not None):
+                msg = '''
+Invalid operation is performed in: {0} (Forward)
+
+{1}'''.format(_thread_local.current_function.label, msg)
+
         super(InvalidType, self).__init__(msg)
 
         self.expect = expect


### PR DESCRIPTION
I used thread-local variable to check a label of a current function.
fix #2081 