### PR TITLE
Fix deadlock issue on multi-threaded application

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -147,13 +147,13 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
         if os.path.exists(path):
             with open(path, 'rb') as file:
                 cubin = file.read()
-            mod.load(cubin)
         else:
             lock.release()
             cubin = nvcc(source, options, arch)
-            mod.load(cubin)
             lock.acquire()
             with open(path, 'wb') as cubin_file:
                 cubin_file.write(cubin)
+
+    mod.load(cubin)
 
     return mod

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -329,9 +329,10 @@ cpdef streamAddCallback(size_t stream, callback, size_t arg,
                         unsigned int flags=0):
     func_arg = (callback, arg)
     cpython.Py_INCREF(func_arg)
-    status = cudaStreamAddCallback(
-        <driver.Stream>stream, <StreamCallback>_streamCallbackFunc,
-        <void*>func_arg, flags)
+    with nogil:
+        status = cudaStreamAddCallback(
+            <driver.Stream>stream, <StreamCallback>_streamCallbackFunc,
+            <void*>func_arg, flags)
     check_status(status)
 
 


### PR DESCRIPTION
This PR is a simple fix for deadlock issue on multi-threaded application.

I added "with nogil" to the cudaStreamAddCallback API call and I moved mod.load(cubin) outside the file lock. My application needs this fix to make it work.

Maybe we should add "with nogil" to all CUDA API call but I'm not sure what influence they have.