### PR TITLE
Make to_device method public

### DIFF
--- a/chainer/dataset/__init__.py
+++ b/chainer/dataset/__init__.py
@@ -6,6 +6,7 @@ from chainer.dataset import iterator  # NOQA
 
 # import class and function
 from chainer.dataset.convert import concat_examples  # NOQA
+from chainer.dataset.convert import to_device  # NOQA
 from chainer.dataset.dataset_mixin import DatasetMixin  # NOQA
 from chainer.dataset.download import cache_or_load_file  # NOQA
 from chainer.dataset.download import cached_download  # NOQA

--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -5,6 +5,28 @@ from chainer import cuda
 
 
 def to_device(device, x):
+    """Send an array to a given device.
+
+    This method send a given array to a given device. This method is used in
+    :func:`~chainer.dataset.concat_examples`.
+    You can also use this method in a custom converter method used in
+    :class:`~chainer.training.Updater` and :class:`~chainer.training.Extension`
+    such as :class:`~chainer.training.StandardUpdater` and
+    :class:`~chainer.training.extensions.Evaluator`.
+
+    .. see:: :func:`chainer.dataset.concat_examples`
+
+    Args:
+        device (int or None): Device ID to which an array is sent. If it is
+            negative value, an array is sent to CPU. If it is positive, an
+            array is sent to GPU with the given ID. If it is ``None``, an
+            array is left in the original device.
+        x (numpy.ndarray or cupy.ndarray): An array to send.
+
+    Returns:
+        Converted array.
+
+    """
     if device is None:
         return x
     elif device < 0:

--- a/docs/source/reference/core/dataset.rst
+++ b/docs/source/reference/core/dataset.rst
@@ -33,6 +33,7 @@ See :ref:`iterators` for dataset iterator implementations.
 Batch conversion function
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: concat_examples
+.. autofunction:: to_device
 
 Dataset management
 ~~~~~~~~~~~~~~~~~~

--- a/tests/chainer_tests/dataset_tests/test_convert.py
+++ b/tests/chainer_tests/dataset_tests/test_convert.py
@@ -210,52 +210,65 @@ class TestConcatExamplesWithPadding(unittest.TestCase):
         self.check_concat_dicts_padding(cuda.cupy)
 
 
+def get_xp(gpu):
+    if gpu:
+        return cuda.cupy
+    else:
+        return numpy
+
+
 @testing.parameterize(
-    {'device': None, 'src_xp': numpy, 'dst_xp': numpy},
-    {'device': -1, 'src_xp': numpy, 'dst_xp': numpy},
+    {'device': None, 'src_gpu': False, 'dst_gpu': False},
+    {'device': -1, 'src_gpu': False, 'dst_gpu': False},
 )
 class TestToDeviceCPU(unittest.TestCase):
 
     def test_to_device(self):
-        x = self.src_xp.array([1], 'i')
+        src_xp = get_xp(self.src_gpu)
+        dst_xp = get_xp(self.dst_gpu)
+        x = src_xp.array([1], 'i')
         y = dataset.to_device(self.device, x)
-        self.assertIsInstance(y, self.dst_xp.ndarray)
+        self.assertIsInstance(y, dst_xp.ndarray)
 
 
 @testing.parameterize(
-    {'device': None, 'src_xp': cuda.cupy, 'dst_xp': cuda.cupy},
+    {'device': None, 'src_gpu': True, 'dst_gpu': True},
 
-    {'device': -1, 'src_xp': cuda.cupy, 'dst_xp': numpy},
+    {'device': -1, 'src_gpu': True, 'dst_gpu': False},
 
-    {'device': 0, 'src_xp': numpy, 'dst_xp': cuda.cupy},
-    {'device': 0, 'src_xp': cuda.cupy, 'dst_xp': cuda.cupy},
+    {'device': 0, 'src_gpu': False, 'dst_gpu': True},
+    {'device': 0, 'src_gpu': True, 'dst_gpu': True},
 )
+@attr.gpu
 class TestToDeviceGPU(unittest.TestCase):
 
-    @attr.gpu
     def test_to_device(self):
-        x = self.src_xp.array([1], 'i')
+        src_xp = get_xp(self.src_gpu)
+        dst_xp = get_xp(self.dst_gpu)
+        x = src_xp.array([1], 'i')
         y = dataset.to_device(self.device, x)
-        self.assertIsInstance(y, self.dst_xp.ndarray)
+        self.assertIsInstance(y, dst_xp.ndarray)
 
         if self.device >= 0:
             self.assertEqual(int(y.device), self.device)
 
-        if self.device is None and self.src_xp is cuda.cupy:
+        if self.device is None and self.src_gpu:
             self.assertEqual(int(x.device), int(y.device))
 
 
 @testing.parameterize(
-    {'device': 1, 'src_xp': numpy, 'dst_xp': cuda.cupy},
-    {'device': 1, 'src_xp': cuda.cupy, 'dst_xp': cuda.cupy},
+    {'device': 1, 'src_gpu': False, 'dst_gpu': True},
+    {'device': 1, 'src_gpu': True, 'dst_gpu': True},
 )
+@attr.multi_gpu(2)
 class TestToDeviceMultiGPU(unittest.TestCase):
 
-    @attr.multi_gpu(2)
     def test_to_device(self):
-        x = self.src_xp.array([1], 'i')
+        src_xp = get_xp(self.src_gpu)
+        dst_xp = get_xp(self.dst_gpu)
+        x = src_xp.array([1], 'i')
         y = dataset.to_device(self.device, x)
-        self.assertIsInstance(y, self.dst_xp.ndarray)
+        self.assertIsInstance(y, dst_xp.ndarray)
 
         self.assertEqual(int(y.device), self.device)
 

--- a/tests/chainer_tests/dataset_tests/test_convert.py
+++ b/tests/chainer_tests/dataset_tests/test_convert.py
@@ -249,7 +249,7 @@ class TestToDeviceGPU(unittest.TestCase):
         y = dataset.to_device(self.device, x)
         self.assertIsInstance(y, dst_xp.ndarray)
 
-        if self.device >= 0:
+        if self.device is not None and self.device >= 0:
             self.assertEqual(int(y.device), self.device)
 
         if self.device is None and self.src_gpu:

--- a/tests/chainer_tests/dataset_tests/test_convert.py
+++ b/tests/chainer_tests/dataset_tests/test_convert.py
@@ -239,9 +239,9 @@ class TestToDeviceCPU(unittest.TestCase):
     {'device': 0, 'src_gpu': False, 'dst_gpu': True},
     {'device': 0, 'src_gpu': True, 'dst_gpu': True},
 )
-@attr.gpu
 class TestToDeviceGPU(unittest.TestCase):
 
+    @attr.gpu
     def test_to_device(self):
         src_xp = get_xp(self.src_gpu)
         dst_xp = get_xp(self.dst_gpu)
@@ -260,9 +260,9 @@ class TestToDeviceGPU(unittest.TestCase):
     {'device': 1, 'src_gpu': False, 'dst_gpu': True},
     {'device': 1, 'src_gpu': True, 'dst_gpu': True},
 )
-@attr.multi_gpu(2)
 class TestToDeviceMultiGPU(unittest.TestCase):
 
+    @attr.multi_gpu(2)
     def test_to_device(self):
         src_xp = get_xp(self.src_gpu)
         dst_xp = get_xp(self.dst_gpu)


### PR DESCRIPTION
I made `to_device` method public for users who want to make a custom converter method for `Updater`. I sometimes copy this method to my code by hand.