### PR TITLE
Fix test for cupy.pad by passing lists instead of passing ndarrays

### DIFF
--- a/tests/cupy_tests/padding_tests/test_pad.py
+++ b/tests/cupy_tests/padding_tests/test_pad.py
@@ -60,7 +60,7 @@ class TestPadNumpybug(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_pad_highdim_default(self, xp, dtype):
         array = xp.arange(6, dtype=dtype).reshape([2, 3])
-        pad_width = numpy.array([[1, 2], [3, 4]])
+        pad_width = [[1, 2], [3, 4]]
         constant_values = [[1, 2], [3, 4]]
         a = xp.pad(array, pad_width, mode='constant',
                    constant_values=constant_values)

--- a/tests/cupy_tests/padding_tests/test_pad.py
+++ b/tests/cupy_tests/padding_tests/test_pad.py
@@ -9,9 +9,9 @@ from cupy import testing
     {'array': numpy.arange(6).reshape([2, 3]), 'pad_width': 1,
      'mode': 'constant'},
     {'array': numpy.arange(6).reshape([2, 3]),
-     'pad_width': numpy.array([1, 2]), 'mode': 'constant'},
+     'pad_width': [1, 2], 'mode': 'constant'},
     {'array': numpy.arange(6).reshape([2, 3]),
-     'pad_width': numpy.array([[1, 2], [3, 4]]), 'mode': 'constant'},
+     'pad_width': [[1, 2], [3, 4]], 'mode': 'constant'},
 )
 @testing.gpu
 class TestPadDefault(unittest.TestCase):
@@ -30,11 +30,11 @@ class TestPadDefault(unittest.TestCase):
     {'array': numpy.arange(6).reshape([2, 3]), 'pad_width': 1,
      'mode': 'constant', 'constant_values': 3},
     {'array': numpy.arange(6).reshape([2, 3]),
-     'pad_width': numpy.array([1, 2]), 'mode': 'constant',
-     'constant_values': numpy.array([3, 4])},
+     'pad_width': [1, 2], 'mode': 'constant',
+     'constant_values': [3, 4]},
     {'array': numpy.arange(6).reshape([2, 3]),
-     'pad_width': numpy.array([[1, 2], [3, 4]]), 'mode': 'constant',
-     'constant_values': numpy.array([[3, 4], [5, 6]])},
+     'pad_width': [[1, 2], [3, 4]], 'mode': 'constant',
+     'constant_values': [[3, 4], [5, 6]]},
 )
 @testing.gpu
 class TestPad(unittest.TestCase):

--- a/tests/cupy_tests/padding_tests/test_pad.py
+++ b/tests/cupy_tests/padding_tests/test_pad.py
@@ -37,6 +37,8 @@ class TestPadDefault(unittest.TestCase):
      'constant_values': [[3, 4], [5, 6]]},
 )
 @testing.gpu
+# Old numpy does not work with multi-dimensional constant_values
+@testing.with_requires('numpy>=1.11.1')
 class TestPad(unittest.TestCase):
 
     _multiprocess_can_split_ = True
@@ -98,6 +100,7 @@ class TestPadSpecial(unittest.TestCase):
      'notallowedkeyword': 3},
 )
 @testing.gpu
+@testing.with_requires('numpy>=1.11.1')  # Old numpy fails differently
 class TestPadFailure(unittest.TestCase):
 
     _multiprocess_can_split_ = True


### PR DESCRIPTION
Old numpy does not accept array_like. [1.9](https://docs.scipy.org/doc/numpy-1.9.3/reference/generated/numpy.pad.html) [1.10](https://docs.scipy.org/doc/numpy-1.10.4/reference/generated/numpy.pad.html)