### PR TITLE
Change name of kernels for scatter_* to be more consistent with other kernels

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2083,7 +2083,7 @@ cdef _scatter_update_kernel = ElementwiseKernel(
       int ri = i % rdim;
       a[(li * adim + wrap_indices) * rdim + ri] = v;
     ''',
-    'scatter_update')
+    'cupy_scatter_update')
 
 
 cdef _scatter_add_kernel = ElementwiseKernel(
@@ -2096,7 +2096,7 @@ cdef _scatter_add_kernel = ElementwiseKernel(
       int ri = i % rdim;
       atomicAdd(&a[(li * adim + wrap_indices) * rdim + ri], v[i]);
     ''',
-    'scatter_add')
+    'cupy_scatter_add')
 
 
 cdef _boolean_array_indexing_nth = ElementwiseKernel(


### PR DESCRIPTION
I changed name of kernels used for `scatter_*` to `cupy_scatter_*`.
These names are more consistent with other kernels called by CuPy (e.g. `cupy_take`).