### PR TITLE
Support boolean array for cupy.ndarray.__setitem__

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2255,7 +2255,7 @@ cpdef _scatter_op_mask_single(ndarray a, ndarray mask, v, int axis, op):
 
     # broadcast v to shape determined by the mask
     mask_scanned = scan(mask.astype(numpy.int32).ravel())  # starts with 1
-    n_true = int(mask_scanned.max())
+    n_true = int(mask_scanned[-1])
     lshape = a.shape[:axis]
     rshape = a.shape[axis + mask.ndim:]
     v_shape = lshape + (n_true,) + rshape

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2253,6 +2253,7 @@ cpdef _scatter_op_mask_single(ndarray a, ndarray mask, v, int axis, op):
         v = array(v, dtype=a.dtype)
     v = v.astype(a.dtype)
 
+    # broadcast v to shape determined by the mask
     mask_scanned = scan(mask.astype(numpy.int32).ravel())  # starts with 1
     n_true = int(mask_scanned.max())
     lshape = a.shape[:axis]
@@ -2265,6 +2266,7 @@ cpdef _scatter_op_mask_single(ndarray a, ndarray mask, v, int axis, op):
     mask_br = broadcast_to(mask_br, a.shape)
     mask_br_scanned = scan(mask_br.astype(numpy.int32).ravel())
     mask_br_scanned = mask_br_scanned._reshape(mask_br._shape)
+
     if op == 'update':
         _scatter_update_mask_kernel(v, mask_br, mask_br_scanned, a)
     else:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1113,7 +1113,7 @@ cdef class ndarray:
                     advanced = True
                 elif issubclass(s.dtype.type, numpy.bool_):
                     if i == 0 and internal.vector_equal(self._shape, s._shape):
-                        return _boolean_array_indexing(self, s)
+                        return _getitem_mask(self, s)
                     else:
                         raise ValueError('Boolean array indexing is supported '
                                          'only for same sized array.')
@@ -2116,7 +2116,7 @@ cdef _boolean_array_indexing_nth = ElementwiseKernel(
     'cupy_boolean_array_indexing_nth')
 
 
-cpdef ndarray _boolean_array_indexing(ndarray a, ndarray boolean_array):
+cpdef ndarray _getitem_mask(ndarray a, ndarray boolean_array):
     a = a.flatten()
     boolean_array = boolean_array.flatten()
     nth_true_array = scan(boolean_array.astype(int)) - 1  # starts with 0

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2254,7 +2254,11 @@ cpdef _scatter_op_mask_single(ndarray a, ndarray mask, v, int axis, op):
     v = v.astype(a.dtype)
 
     # broadcast v to shape determined by the mask
-    mask_scanned = scan(mask.astype(numpy.int32).ravel())  # starts with 1
+    if mask.size <= 2 ** 31 - 1:
+        mask_type = numpy.int32
+    else:
+        mask_type = numpy.int64
+    mask_scanned = scan(mask.astype(mask_type).ravel())  # starts with 1
     n_true = int(mask_scanned[-1])
     lshape = a.shape[:axis]
     rshape = a.shape[axis + mask.ndim:]

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2245,6 +2245,10 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v, int axis=0, op=''):
 
 
 cpdef _scatter_op_mask_single(ndarray a, ndarray mask, v, int axis, op):
+    cdef ndarray mask_scanned, mask_br, mask_br_scanned
+    cdef int n_true
+    cdef tuple lshape, rshape, v_shape
+
     if not isinstance(v, ndarray):
         v = array(v, dtype=a.dtype)
     v = v.astype(a.dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -197,6 +197,9 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
      'indexes': (numpy.array(
          [[[True, False], [True, False]], [[True, True], [False, False]]]),),
      'value': numpy.arange(4)},
+    {'shape': (5,),
+     'indexes': numpy.array([True, False, False, True, True]),
+     'value': numpy.arange(3)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -184,6 +184,19 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
     # mask
     {'shape': (2, 3, 4), 'indexes': numpy.random.choice([False, True], (2, 3)),
      'value': numpy.arange(4)},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), numpy.array([True, False, True])),
+     'value': numpy.arange(2 * 2 * 4).reshape(2, 2, 4)},
+    {'shape': (2, 3, 4),
+     'indexes': (numpy.array([[True, False, False], [False, True, True]]),),
+     'value': numpy.arange(3 * 4).reshape(3, 4)},
+    {'shape': (2, 2, 2),
+     'indexes': (slice(None), numpy.array([[True, False], [False, True]]),),
+     'value': numpy.arange(2 * 2).reshape(2, 2)},
+    {'shape': (2, 2, 2),
+     'indexes': (numpy.array(
+         [[[True, False], [True, False]], [[True, True], [False, False]]]),),
+     'value': numpy.arange(4)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -144,6 +144,22 @@ class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
      'indexes': (slice(0, 1), slice(1, 2), [1, -1]), 'value': 1},
     {'shape': (2, 3, 4),
      'indexes': (slice(0, 1), None, slice(1, 2), [1, -1]), 'value': 1},
+    # mask
+    {'shape': (2, 3, 4),
+     'indexes': numpy.array([True, False]), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), numpy.array([True, False, True])), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), slice(None),
+                 numpy.random.choice([False, True], (4,))),
+     'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (numpy.random.choice([False, True], (2, 3)),), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), numpy.random.choice([False, True], (3, 4)),),
+     'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (numpy.random.choice([False, True], (2, 3, 4)),), 'value': 1},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
@@ -165,6 +181,9 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
      'value': numpy.arange(2 * 2 * 4).reshape(2, 2, 4)},
     {'shape': (2, 3, 4), 'indexes': (slice(None), [[0, 1], [2, 0]]),
      'value': numpy.arange(2 * 2 * 2 * 4).reshape(2, 2, 2, 4)},
+    # mask
+    {'shape': (2, 3, 4), 'indexes': numpy.random.choice([False, True], (2, 3)),
+     'value': numpy.arange(4)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):
@@ -180,13 +199,21 @@ class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):
 @testing.gpu
 class TestArrayAdvancedIndexingSetitemCupyIndices(unittest.TestCase):
 
-    def test_cupy_array(self):
+    def test_cupy_indices_integer_array(self):
         shape = (2, 3)
         a = cupy.zeros(shape)
         indexes = cupy.array([0, 1])
         a[:, indexes] = cupy.array(1.)
         testing.assert_array_equal(
             a, cupy.array([[1., 1., 0.], [1., 1., 0.]]))
+
+    def test_cupy_indices_boolean_array(self):
+        shape = (2, 3)
+        a = cupy.zeros(shape)
+        indexes = cupy.array([True, False])
+        a[indexes] = cupy.array(1.)
+        testing.assert_array_equal(
+            a, cupy.array([[1., 1., 1.], [0., 0., 0.]]))
 
 
 @testing.gpu
@@ -199,4 +226,13 @@ class TestArrayAdvancedIndexingSetitemDifferetnDtypes(unittest.TestCase):
         a = xp.zeros(shape, dtype=src_dtype)
         indexes = xp.array([0, 1])
         a[:, indexes] = xp.array(1, dtype=dst_dtype)
+        return a
+
+    @testing.for_all_dtypes_combination(names=['src_dtype', 'dst_dtype'])
+    @testing.numpy_cupy_array_equal()
+    def test_differnt_dtypes_mask(self, xp, src_dtype, dst_dtype):
+        shape = (2, 3)
+        a = xp.zeros(shape, dtype=src_dtype)
+        indexes = xp.array([True, False])
+        a[indexes] = xp.array(1, dtype=dst_dtype)
         return a


### PR DESCRIPTION
This PR supports boolean array for `cupy.ndarray.__setitem__`.

+ It supports boolean array indexing on axes (e.g. `a[:, np.array([True, False])]`).
+ It does not support combination of boolean arrays (e.g. `a[np.array([True, False]), np.array([False, True])]`).

Also, I changed name of internal function `_boolean_array_indexing` which was used for boolean array indexing of `__getitem__` to `_getitem_mask`. I did so because the name was vague, and it needed to be distinguishable from functions for `__setitem__`.