### PR TITLE
Make copied Variable instances to share its data and gradient arrays.

### DIFF
--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import unittest
 
@@ -594,6 +595,13 @@ class TestUninitializedVariable(unittest.TestCase):
         x.to_gpu()
         x.to_cpu()
         self.check_constant_initialization(x, self.a, np)
+
+    def test_copy_to_initialize(self):
+        # This test intends the use case of link.copy() method.
+        x = chainer.Variable()
+        y = copy.copy(x)
+        x.initialize((3, 2))
+        self.assertIs(x.data, y.data)
 
     def test_cleargrad(self):
         x = chainer.Variable()


### PR DESCRIPTION
Rel. #2072.

I've modified `Variable` class to share its actual data and gradient arrays across its copied instances including the initialized/uninitialized state. The code may not be complete yet, but would be enough to get the idea.

I guess this behavior from the docstring of `link.copy` method:

    The whole hierarchy rooted by this link is copied. The copy is
    basically shallow, except that the parameter variables are also
    shallowly copied. It means that the parameter variables of copied one
    are different from ones of original link, while they share the data and
    gradient arrays.

If I had some misunderstanding and the copied Variable instances should still have mutually independent data and gradient arrays, please point it out. If what I guess is right and the change is reasonable, I will complete the change.
