### PR TITLE
Add order option to cupy.empty

### DIFF
--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -1,14 +1,14 @@
 import cupy
 
 
-def empty(shape, dtype=float):
+def empty(shape, dtype=float, order='C'):
     """Returns an array without initializing the elements.
-
-    This function currently does not support ``order`` option.
 
     Args:
         shape (tuple of ints): Dimensionalities of the array.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: A new array with elements not initialized.
@@ -16,8 +16,7 @@ def empty(shape, dtype=float):
     .. seealso:: :func:`numpy.empty`
 
     """
-    # TODO(beam2d): Support ordering option
-    return cupy.ndarray(shape, dtype=dtype)
+    return cupy.ndarray(shape, dtype=dtype, order=order)
 
 
 def empty_like(a, dtype=None):

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -20,6 +20,13 @@ class TestBasic(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_empty_f(self, xp, dtype):
+        a = xp.empty((2, 3, 4), dtype=dtype, order='F')
+        a.fill(0)
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_empty_scalar(self, xp, dtype):
         a = xp.empty(None, dtype=dtype)
         a.fill(0)
@@ -43,6 +50,11 @@ class TestBasic(unittest.TestCase):
     def test_empty_zero_sized_array_strides(self):
         a = numpy.empty((1, 0, 2), dtype='d')
         b = cupy.empty((1, 0, 2), dtype='d')
+        self.assertEqual(b.strides, a.strides)
+
+    def test_empty_zero_sized_array_strides_f(self):
+        a = numpy.empty((1, 0, 2), dtype='d', order='F')
+        b = cupy.empty((1, 0, 2), dtype='d', order='F')
         self.assertEqual(b.strides, a.strides)
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
This PR supports order option for `cupy.empty`.