### PR TITLE
Add order option to cupy.zeros

### DIFF
--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -125,14 +125,14 @@ def ones_like(a, dtype=None):
     return ones(a.shape, dtype)
 
 
-def zeros(shape, dtype=float):
+def zeros(shape, dtype=float, order='C'):
     """Returns a new array of given shape and dtype, filled with zeros.
-
-    This function currently does not support ``order`` option.
 
     Args:
         shape (tuple of ints): Dimensionalities of the array.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: An array filled with ones.
@@ -140,8 +140,7 @@ def zeros(shape, dtype=float):
     .. seealso:: :func:`numpy.zeros`
 
     """
-    # TODO(beam2d): Support ordering option
-    a = empty(shape, dtype)
+    a = cupy.ndarray(shape, dtype, order=order)
     a.data.memset(0, a.nbytes)
     return a
 

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -70,6 +70,16 @@ class TestBasic(unittest.TestCase):
     def test_zeros_int(self, xp, dtype):
         return xp.zeros(3, dtype=dtype)
 
+    def test_zeros_strides(self):
+        a = numpy.zeros((2, 3), dtype='d', order='C')
+        b = cupy.zeros((2, 3), dtype='d', order='C')
+        self.assertEqual(b.strides, a.strides)
+
+    def test_zeros_strides_f(self):
+        a = numpy.zeros((2, 3), dtype='d', order='F')
+        b = cupy.zeros((2, 3), dtype='d', order='F')
+        self.assertEqual(b.strides, a.strides)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_zeros_like(self, xp, dtype):


### PR DESCRIPTION
This PR adds order option to `cupy.zeros`.
Also, I changed `cupy.zeros` to stop calling `cupy.empty`. This is more efficient and simpler.