### PR TITLE
Add decorators to parameterize tests with order arg

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -31,6 +31,8 @@ for_all_dtypes_combination = helper.for_all_dtypes_combination
 for_signed_dtypes_combination = helper.for_signed_dtypes_combination
 for_unsigned_dtypes_combination = helper.for_unsigned_dtypes_combination
 for_int_dtypes_combination = helper.for_int_dtypes_combination
+for_orders = helper.for_orders
+for_CF_orders = helper.for_CF_orders
 
 with_requires = helper.with_requires
 

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -705,6 +705,45 @@ def for_int_dtypes_combination(names=('dtype',), no_bool=False, full=None):
     return for_dtypes_combination(types, names, full)
 
 
+def for_orders(orders, name='order'):
+    """Decorator to parameterize tests with order.
+
+    Args:
+         orders(list of orders): orders to be tested.
+         name(str): Argument name to which the specified order is passed.
+
+    This decorator adds a keyword argument specified by ``name``
+    to the test fixtures. Then, the fixtures run by passing each element of
+    ``orders`` to the named argument.
+
+    """
+    def decorator(impl):
+        @functools.wraps(impl)
+        def test_func(self, *args, **kw):
+            for order in orders:
+                try:
+                    kw[name] = order
+                    impl(self, *args, **kw)
+                except Exception:
+                    print(name, 'is', order)
+                    raise
+
+        return test_func
+    return decorator
+
+
+def for_CF_orders(name='order'):
+    """Decorator that checks the fixture with orders 'C' and 'F'.
+
+    Args:
+         name(str): Argument name to which the specified order is passed.
+
+    .. seealso:: :func:`cupy.testing.for_all_dtypes`
+
+    """
+    return for_orders(['C', 'F'], name)
+
+
 def with_requires(*requirements):
     """Run a test case only when given requirements are satisfied.
 

--- a/docs/source/cupy-reference/testing.rst
+++ b/docs/source/cupy-reference/testing.rst
@@ -58,3 +58,12 @@ combination of dtype(s).
 .. autofunction:: for_signed_dtypes_combination
 .. autofunction:: for_unsigned_dtypes_combination
 .. autofunction:: for_int_dtypes_combination
+
+
+Parameterized order Test
+------------------------
+The following decorators offer the standard way to parameterize tests with
+orders.
+
+.. autofunction:: for_orders
+.. autofunction:: for_CF_orders

--- a/docs/source/cupy-reference/testing.rst
+++ b/docs/source/cupy-reference/testing.rst
@@ -43,7 +43,7 @@ between CuPy's functions and corresponding NumPy's ones.
 Parameterized dtype Test
 ------------------------
 
-The following decorators offers the standard way for
+The following decorators offer the standard way for
 parameterized test with respect to single or the
 combination of dtype(s).
 

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -11,17 +11,11 @@ class TestBasic(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_empty(self, xp, dtype):
-        a = xp.empty((2, 3, 4), dtype=dtype)
-        a.fill(0)
-        return a
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_empty_f(self, xp, dtype):
-        a = xp.empty((2, 3, 4), dtype=dtype, order='F')
+    def test_empty(self, xp, dtype, order):
+        a = xp.empty((2, 3, 4), dtype=dtype, order=order)
         a.fill(0)
         return a
 
@@ -47,14 +41,10 @@ class TestBasic(unittest.TestCase):
         b.fill(0)
         return b
 
-    def test_empty_zero_sized_array_strides(self):
-        a = numpy.empty((1, 0, 2), dtype='d')
-        b = cupy.empty((1, 0, 2), dtype='d')
-        self.assertEqual(b.strides, a.strides)
-
-    def test_empty_zero_sized_array_strides_f(self):
-        a = numpy.empty((1, 0, 2), dtype='d', order='F')
-        b = cupy.empty((1, 0, 2), dtype='d', order='F')
+    @testing.for_CF_orders()
+    def test_empty_zero_sized_array_strides(self, order):
+        a = numpy.empty((1, 0, 2), dtype='d', order=order)
+        b = cupy.empty((1, 0, 2), dtype='d', order=order)
         self.assertEqual(b.strides, a.strides)
 
     @testing.for_all_dtypes()
@@ -82,14 +72,10 @@ class TestBasic(unittest.TestCase):
     def test_zeros_int(self, xp, dtype):
         return xp.zeros(3, dtype=dtype)
 
-    def test_zeros_strides(self):
-        a = numpy.zeros((2, 3), dtype='d', order='C')
-        b = cupy.zeros((2, 3), dtype='d', order='C')
-        self.assertEqual(b.strides, a.strides)
-
-    def test_zeros_strides_f(self):
-        a = numpy.zeros((2, 3), dtype='d', order='F')
-        b = cupy.zeros((2, 3), dtype='d', order='F')
+    @testing.for_CF_orders()
+    def test_zeros_strides(self, order):
+        a = numpy.zeros((2, 3), dtype='d', order=order)
+        b = cupy.zeros((2, 3), dtype='d', order=order)
         self.assertEqual(b.strides, a.strides)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -19,17 +19,19 @@ class TestBasic(unittest.TestCase):
         a.fill(0)
         return a
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_empty_scalar(self, xp, dtype):
-        a = xp.empty(None, dtype=dtype)
+    def test_empty_scalar(self, xp, dtype, order):
+        a = xp.empty(None, dtype=dtype, order=order)
         a.fill(0)
         return a
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_empty_int(self, xp, dtype):
-        a = xp.empty(3, dtype=dtype)
+    def test_empty_int(self, xp, dtype, order):
+        a = xp.empty(3, dtype=dtype, order=order)
         a.fill(0)
         return a
 
@@ -57,20 +59,23 @@ class TestBasic(unittest.TestCase):
     def test_identity(self, xp, dtype):
         return xp.identity(4, dtype)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_zeros(self, xp, dtype):
-        return xp.zeros((2, 3, 4), dtype=dtype)
+    def test_zeros(self, xp, dtype, order):
+        return xp.zeros((2, 3, 4), dtype=dtype, order=order)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_zeros_scalar(self, xp, dtype):
-        return xp.zeros(None, dtype=dtype)
+    def test_zeros_scalar(self, xp, dtype, order):
+        return xp.zeros(None, dtype=dtype, order=order)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_zeros_int(self, xp, dtype):
-        return xp.zeros(3, dtype=dtype)
+    def test_zeros_int(self, xp, dtype, order):
+        return xp.zeros(3, dtype=dtype, order=order)
 
     @testing.for_CF_orders()
     def test_zeros_strides(self, order):


### PR DESCRIPTION
Merge after #2103, #2104.

This PR adds a decorator that parameterizes tests with order options.
In addition to that, the new decorator is used to simplify tests written for `cupy.empty` and `cupy.zeros`.