### PR TITLE
use for_dtypes_combination decorator for array indexing tests

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -192,8 +192,7 @@ class TestArrayAdvancedIndexingSetitemCupyIndices(unittest.TestCase):
 @testing.gpu
 class TestArrayAdvancedIndexingSetitemDifferetnDtypes(unittest.TestCase):
 
-    @testing.for_all_dtypes(name='src_dtype')
-    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.for_all_dtypes_combination(names=['src_dtype', 'dst_dtype'])
     @testing.numpy_cupy_array_equal()
     def test_differnt_dtypes(self, xp, src_dtype, dst_dtype):
         shape = (2, 3)

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -81,12 +81,9 @@ class TestScatterAdd(unittest.TestCase):
         testing.assert_array_equal(
             a, cupy.array([[0., 0., 0.], [2., 2., 2.]], dtype))
 
-    @testing.for_dtypes(
+    @testing.for_dtypes_combination(
         [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
-         numpy.ulonglong], name='src_dtype')
-    @testing.for_dtypes(
-        [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
-         numpy.ulonglong], name='dst_dtype')
+         numpy.ulonglong], names=['src_dtype', 'dst_dtype'])
     def test_scatter_add_differnt_dtypes(self, src_dtype, dst_dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)


### PR DESCRIPTION
This PR changes a decorator that parameterized combination of dtypes to `for_dtypes_combination`.
This is better because you can speedup tests by reducing number of combinations to tests. Also, you can test all combinations with `for_dtypes_combination` by setting an environment variable properly.