### PR TITLE
Fix the simulated bug behaviour of packbits

### DIFF
--- a/cupy/binary/packing.py
+++ b/cupy/binary/packing.py
@@ -24,9 +24,6 @@ def packbits(myarray):
         raise TypeError(
             'Expected an input array of integer or boolean data type')
 
-    if myarray.size == 0:
-        return cupy.empty_like(myarray)
-
     myarray = myarray.ravel()
     packed_size = (myarray.size + 7) // 8
     packed = cupy.zeros((packed_size,), dtype=cupy.uint8)

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -24,13 +24,16 @@ class TestPacking(unittest.TestCase):
         return xp.unpackbits(a)
 
     def test_packbits(self):
-        self.check_packbits([])
         self.check_packbits([0])
         self.check_packbits([1])
         self.check_packbits([0, 1])
         self.check_packbits([1, 0, 1, 1, 0, 1, 1, 1])
         self.check_packbits([1, 0, 1, 1, 0, 1, 1, 1, 1])
         self.check_packbits(numpy.arange(24).reshape((2, 3, 4)) % 2)
+
+    @testing.with_requires('numpy>=1.12')
+    def test_packbits_empty(self):
+        self.check_packbits([])
 
     def test_unpackbits(self):
         self.check_unpackbits([])

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -33,6 +33,8 @@ class TestPacking(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.12')
     def test_packbits_empty(self):
+        # Note packbits of numpy <= 1.11 has a bug against empty arrays.
+        # See https://github.com/numpy/numpy/issues/8324
         self.check_packbits([])
 
     def test_unpackbits(self):


### PR DESCRIPTION
`packbits` and `unpackbits` of NumPy <= 1.11 have bugs against empty arrays (see https://github.com/numpy/numpy/issues/8324). I intentionally implemented this behaviour in CuPy's counterparts. These bugs are fixed at NumPy 1.12 (https://github.com/numpy/numpy/pull/8327), and thus this PR also fixes the 'bugs' in CuPy.
