### PR TITLE
Fix to transfer all variables in StandardUpdater to GPU

### DIFF
--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -128,7 +128,8 @@ class StandardUpdater(Updater):
         self._optimizers = optimizer
 
         if device is not None and device >= 0:
-            optimizer['main'].target.to_gpu(device)
+            for opt in optimizer.values():
+                opt.target.to_gpu(device)
 
         self.converter = converter
         self.loss_func = loss_func

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -128,7 +128,7 @@ class StandardUpdater(Updater):
         self._optimizers = optimizer
 
         if device is not None and device >= 0:
-            for opt in optimizer.values():
+            for opt in six.itervalues(optimizer):
                 opt.target.to_gpu(device)
 
         self.converter = converter


### PR DESCRIPTION
Current `StandardUpdater` implicitly assumes that the `optimizer` dictionary contains `main` only, i.e., `optimizer == {'main': opt}`. Although such an assumption holds true if we directly use `StandardUpdater`, it causes undesirable behavior when we inherit this class, add more optimizers, and change `update_core()` method. Moreover, it causes an error when we specify an dictionary that does not contain `main`. This PR aims to avoid such an error, and send all variables in  `optimizer` to GPU.