### PR TITLE
Support multiple integer arrays for cupy.ndarray.__setitem__

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1213,15 +1213,12 @@ cdef class ndarray:
     def __setitem__(self, slices, value):
         """x.__setitem__(slices, y) <==> x[slices] = y
 
-        Supported ``slices`` consists of
+        Supports both basic and advanced indexing.
 
-        * basic indexing
+        .. note::
 
-        * one integer array
-
-        * combination of basic indexing and integer arrays
-
-        * a boolean array
+            Currently, it does not support ``slices`` that consists of more
+            than one boolean arrays
 
         .. note::
 

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -169,6 +169,8 @@ class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': ([0, -1], slice(None), [1, -1]),
      'value': 1},
     {'shape': (2, 3, 4), 'indexes': ([0, -1], 1, 2), 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': ([1, 0], slice(None), [[2, 0], [3, 1]]),
+     'value': 1},
     # multiple arrays and basic indexing
     {'shape': (2, 3, 4), 'indexes': ([0, -1], None, [1, 0]), 'value': 1},
     {'shape': (2, 3, 4), 'indexes': ([0, -1], slice(0, 2), [1, 0]),

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -225,6 +225,16 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
     {'shape': (5,),
      'indexes': numpy.array([True, False, False, True, True]),
      'value': numpy.arange(3)},
+    # multiple arrays
+    {'shape': (2, 3, 4), 'indexes': ([1, 0], [2, 1]),
+     'value': numpy.arange(2 * 4).reshape(2, 4)},
+    {'shape': (2, 3, 4), 'indexes': ([1, 0], slice(None), [2, 1]),
+     'value': numpy.arange(2 * 3).reshape(2, 3)},
+    {'shape': (2, 3, 4), 'indexes': ([1, 0], slice(None), [[2, 0], [3, 1]]),
+     'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
+    {'shape': (2, 3, 4),
+     'indexes': ([[1, 0], [1, 0]], slice(None), [[2, 0], [3, 1]]),
+     'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):
@@ -288,5 +298,4 @@ class TestArrayAdvancedIndexingSetitemTranspose(unittest.TestCase):
         a = xp.zeros(shape).transpose(0, 2, 1)
         slices = (numpy.array([1, 0]), slice(None), numpy.array([2, 1]))
         a[slices] = 1
->>>>>>> add support for multiple integer arrays for cupy.ndarray.__setitem__
         return a

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -235,6 +235,9 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
     {'shape': (2, 3, 4),
      'indexes': ([[1, 0], [1, 0]], slice(None), [[2, 0], [3, 1]]),
      'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
+    {'shape': (2, 3, 4),
+     'indexes': (1, slice(None), [[2, 0], [3, 1]]),
+     'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -160,6 +160,28 @@ class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
      'value': 1},
     {'shape': (2, 3, 4),
      'indexes': (numpy.random.choice([False, True], (2, 3, 4)),), 'value': 1},
+    # multiple arrays
+    {'shape': (2, 3, 4), 'indexes': ([0, -1], [1, -1]), 'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': ([0, -1], [1, -1], [2, 1]), 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': ([0, -1], 1), 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': ([0, -1], slice(None), [1, -1]),
+     'value': 1},
+    {'shape': (2, 3, 4), 'indexes': ([0, -1], 1, 2), 'value': 1},
+    # multiple arrays and basic indexing
+    {'shape': (2, 3, 4), 'indexes': ([0, -1], None, [1, 0]), 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': ([0, -1], slice(0, 2), [1, 0]),
+     'value': 1},
+    {'shape': (2, 3, 4), 'indexes': ([0, -1], None, slice(0, 2), [1, 0]),
+     'value': 1},
+    {'shape': (1, 1, 2, 3, 4),
+     'indexes': (None, slice(None), slice(None), [1, 0], [2, -1], 1),
+     'value': 1},
+    {'shape': (1, 1, 2, 3, 4),
+     'indexes': (None, slice(None), 0, [1, 0], slice(0, 2, 2), [2, -1]),
+     'value': 1},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), [0, -1], [[1, 0], [0, 1], [-1, 1]]), 'value': 1},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
@@ -251,4 +273,17 @@ class TestArrayAdvancedIndexingSetitemDifferetnDtypes(unittest.TestCase):
         a = xp.zeros(shape, dtype=src_dtype)
         indexes = xp.array([True, False])
         a[indexes] = xp.array(1, dtype=dst_dtype)
+        return a
+
+
+@testing.gpu
+class TestArrayAdvancedIndexingSetitemTranspose(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal()
+    def test_adv_setitem_transp(self, xp):
+        shape = (2, 3, 4)
+        a = xp.zeros(shape).transpose(0, 2, 1)
+        slices = (numpy.array([1, 0]), slice(None), numpy.array([2, 1]))
+        a[slices] = 1
+>>>>>>> add support for multiple integer arrays for cupy.ndarray.__setitem__
         return a

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -50,6 +50,7 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': (None, [0, 1], None, [2, 1], slice(None))},
     {'shape': (2, 3, 4), 'indexes': numpy.array([1, 0])},
     {'shape': (2, 3, 4), 'indexes': [1, -1]},
+    {'shape': (2, 3, 4), 'indexes': ([0, 1], slice(None), [[2, 1], [3, 1]])},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):


### PR DESCRIPTION
This PR supports multiple integer arrays for `cupy.ndarray.__setitem__`. I rebased #1928.

I had to change interface of an internal function `_scatter_op_single` to support broader inputs.

After the change,  `_scatter_op_single` supports the input below. Also I left a comment in the code.
```
a.shape= (shape_0, ..., shape_{li-1}, shape_li, ..., shpe_ri, ..., shape_{a.ndim-1})
indices:  an integer array indexing axes from axis_li to axis_ri
li: id of the first axis that get indexed
ri: id of the last axis that get indexed
```
For example, when working on `a[[1,0], [0, 1]], a.shape=(2, 3, 4)`, you have `li=0, ri=1, indices=[3, 1]`.


Originally, `_scatter_op_single` only supported the special case of `li=ri`. In that case, I had to call `a._reshape` before passing to `_scatter_op_single` when working on multiple array indexing. `cupy.ndarray._reshape` may invoke copy, which is a problem because I need to store values to a view and not to a copy of the original array.

The new `_scatter_op_single` makes it possible to avoid calling `cupy.ndarray._reshape` thus never risking to call copy.

