### PR TITLE
Lazy typecheck

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -250,17 +250,14 @@ class Function(object):
             return None
 
     def _check_data_type_forward(self, in_data):
-        if 1:
-            in_type = type_check.get_types2(in_data)
-            try:
-                with type_check.fetch:
-                    self.check_type_forward(in_type)
-                return
-            except Exception as e:
-                print(self)
-                print(e)
-                raise
-                pass
+        in_type = type_check.get_light_types(in_data)
+        try:
+            with type_check.light_mode:
+                self.check_type_forward(in_type)
+            return
+        except type_check.InvalidType:
+            # Ignore errors on first run
+            pass
 
         in_type = type_check.get_types(in_data, 'in_types', False)
         with type_check.get_function_check_context(self):

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -250,6 +250,18 @@ class Function(object):
             return None
 
     def _check_data_type_forward(self, in_data):
+        if 1:
+            in_type = type_check.get_types2(in_data)
+            try:
+                with type_check.fetch:
+                    self.check_type_forward(in_type)
+                return
+            except Exception as e:
+                print(self)
+                print(e)
+                raise
+                pass
+
         in_type = type_check.get_types(in_data, 'in_types', False)
         with type_check.get_function_check_context(self):
             self.check_type_forward(in_type)

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -64,7 +64,7 @@ class LSTM(function.Function):
             x_type.shape[0] <= c_type.shape[0],
             x_type.shape[1] == 4 * c_type.shape[1],
         )
-        for i in six.moves.range(2, c_type.ndim.eval()):
+        for i in six.moves.range(2, type_check.eval(c_type.ndim)):
             type_check.expect(x_type.shape[i] == c_type.shape[i])
 
     def forward(self, inputs):

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -23,7 +23,7 @@ class PReLUFunction(function.Function):
             x_type.dtype.kind == 'f',
             W_type.dtype == x_type.dtype,
             x_type.ndim >= W_type.ndim + 1,
-            x_type.shape[1:1 + W_type.ndim.eval()] == W_type.shape
+            x_type.shape[1:1 + type_check.eval(W_type.ndim)] == W_type.shape
         )
 
     def forward_cpu(self, inputs):

--- a/chainer/functions/activation/slstm.py
+++ b/chainer/functions/activation/slstm.py
@@ -77,7 +77,7 @@ class SLSTM(function.Function):
             x1_type.shape[1] == 4 * c1_type.shape[1],
             x2_type.shape[1] == 4 * c2_type.shape[1],
         )
-        for i in range(2, c1_type.ndim.eval()):
+        for i in range(2, type_check.eval(c1_type.ndim)):
             type_check.expect(x1_type.shape[i] == c1_type.shape[i])
             type_check.expect(x2_type.shape[i] == c2_type.shape[i])
             type_check.expect(x1_type.shape[i] == x2_type.shape[i])

--- a/chainer/functions/array/broadcast.py
+++ b/chainer/functions/array/broadcast.py
@@ -89,7 +89,7 @@ class BroadcastTo(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
 
-        ndim = type_check.Variable(len(self._shape), 'len(shape)')
+        ndim = type_check.make_variable(len(self._shape), 'len(shape)')
         type_check.expect(in_types[0].ndim <= ndim)
 
         shape = type_check.eval(in_types[0].shape)

--- a/chainer/functions/array/broadcast.py
+++ b/chainer/functions/array/broadcast.py
@@ -32,7 +32,7 @@ class Broadcast(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
 
-        shapes = [t.eval().shape for t in in_types]
+        shapes = [type_check.eval(t).shape for t in in_types]
         r_shapes = [s[::-1] for s in shapes]
         r_filled = six.moves.zip_longest(*r_shapes, fillvalue=1)
         for ss in r_filled:
@@ -92,7 +92,7 @@ class BroadcastTo(function.Function):
         ndim = type_check.Variable(len(self._shape), 'len(shape)')
         type_check.expect(in_types[0].ndim <= ndim)
 
-        shape = in_types[0].shape.eval()
+        shape = type_check.eval(in_types[0].shape)
         # check the shape in inverse order
         for i in six.moves.range(-1, -len(shape) - 1, -1):
             if shape[i] == self._shape[i] or shape[i] == 1:

--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -26,9 +26,9 @@ class Concat(function.Function):
             -in_types[0].ndim <= self.axis,
             self.axis < in_types[0].ndim
         )
-        ndim = in_types[0].ndim.eval()
+        ndim = type_check.eval(in_types[0].ndim)
         axis = self.axis % ndim
-        for i in six.moves.range(1, in_types.size().eval()):
+        for i in six.moves.range(1, type_check.eval(in_types.size())):
             type_check.expect(
                 in_types[0].dtype == in_types[i].dtype,
                 in_types[0].ndim == in_types[i].ndim,

--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -20,7 +20,7 @@ class Concat(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
         type_check.expect(in_types[0].ndim >
-                          type_check.Variable(self.axis, 'axis'))
+                          type_check.make_variable(self.axis, 'axis'))
 
         type_check.expect(
             -in_types[0].ndim <= self.axis,

--- a/chainer/functions/array/dstack.py
+++ b/chainer/functions/array/dstack.py
@@ -13,8 +13,8 @@ class Dstack(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
 
-        ndim = in_types[0].ndim.eval()
-        for i in six.moves.range(1, in_types.size().eval()):
+        ndim = type_check.eval(in_types[0].ndim)
+        for i in six.moves.range(1, type_check.eval(in_types.size())):
             type_check.expect(
                 in_types[0].dtype == in_types[i].dtype,
                 in_types[0].ndim == in_types[i].ndim,

--- a/chainer/functions/array/hstack.py
+++ b/chainer/functions/array/hstack.py
@@ -13,8 +13,8 @@ class Hstack(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
 
-        ndim = in_types[0].ndim.eval()
-        for i in six.moves.range(1, in_types.size().eval()):
+        ndim = type_check.eval(in_types[0].ndim)
+        for i in six.moves.range(1, type_check.eval(in_types.size())):
             type_check.expect(
                 in_types[0].dtype == in_types[i].dtype,
                 in_types[0].ndim == in_types[i].ndim,

--- a/chainer/functions/array/reshape.py
+++ b/chainer/functions/array/reshape.py
@@ -35,8 +35,8 @@ class Reshape(function.Function):
             for s in self.shape:
                 if s > 0:
                     known_size *= s
-            size_var = type_check.Variable(known_size,
-                                           'known_size(=%d)' % known_size)
+            size_var = type_check.make_variable(
+                known_size, 'known_size(=%d)' % known_size)
             type_check.expect(
                 type_check.prod(x_type.shape) % size_var == 0)
 

--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -26,11 +26,11 @@ class SplitAxis(function.Function):
 
         if isinstance(self.indices_or_sections, collections.Iterable):
             if len(self.indices_or_sections) > 0:
-                max_index = type_check.Variable(
+                max_index = type_check.make_variable(
                     self.indices_or_sections[-1], 'max_index')
                 type_check.expect(in_types[0].shape[self.axis] > max_index)
         else:
-            sections = type_check.Variable(
+            sections = type_check.make_variable(
                 self.indices_or_sections, 'sections')
             type_check.expect(in_types[0].shape[self.axis] % sections == 0)
 

--- a/chainer/functions/array/vstack.py
+++ b/chainer/functions/array/vstack.py
@@ -13,8 +13,8 @@ class Vstack(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
 
-        ndim = in_types[0].ndim.eval()
-        for i in six.moves.range(1, in_types.size().eval()):
+        ndim = type_check.eval(in_types[0].ndim)
+        for i in six.moves.range(1, type_check.eval(in_types.size())):
             type_check.expect(
                 in_types[0].dtype == in_types[i].dtype,
                 in_types[0].ndim == in_types[i].ndim,

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -9,7 +9,7 @@ from chainer.utils import type_check
 class BilinearFunction(function.Function):
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size().eval()
+        n_in = type_check.eval(in_types.size())
         if n_in != 3 and n_in != 6:
             raise type_check.InvalidType(
                 '%s or %s' % (in_types.size() == 3, in_types.size() == 6),

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -16,7 +16,7 @@ class BilinearFunction(function.Function):
                 '%s == %s' % (in_types.size(), n_in))
 
         e1_type, e2_type, W_type = in_types[:3]
-        type_check_prod = type_check.Variable(numpy.prod, 'prod')
+        type_check_prod = type_check.make_variable(numpy.prod, 'prod')
         type_check.expect(
             e1_type.dtype == numpy.float32,
             e1_type.ndim >= 2,

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -51,7 +51,7 @@ class Convolution2DFunction(function.Function):
             x_type.shape[1] == w_type.shape[1],
         )
 
-        if n_in.eval() == 3:
+        if type_check.eval(n_in) == 3:
             b_type = in_types[2]
             type_check.expect(
                 b_type.dtype == x_type.dtype,

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -48,7 +48,7 @@ class ConvolutionND(function.Function):
             x_type.shape[1] == w_type.shape[1],
         )
 
-        if n_in.eval() == 3:
+        if type_check.eval(n_in) == 3:
             b_type = in_types[2]
             type_check.expect(
                 b_type.dtype == x_type.dtype,

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -62,7 +62,7 @@ class Deconvolution2DFunction(function.Function):
                                       self.sx, self.pw),
             )
 
-        if n_in.eval() == 3:
+        if type_check.eval(n_in) == 3:
             b_type = in_types[2]
             type_check.expect(
                 b_type.dtype == x_type.dtype,

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -56,7 +56,7 @@ class DeconvolutionND(function.Function):
                     conv.get_conv_outsize(out, w_type.shape[i + 2], s, p)
                 )
 
-        if n_in.eval() == 3:
+        if type_check.eval(n_in) == 3:
             b_type = in_types[2]
             type_check.expect(
                 b_type.dtype == x_type.dtype,

--- a/chainer/functions/connection/dilated_convolution_2d.py
+++ b/chainer/functions/connection/dilated_convolution_2d.py
@@ -52,7 +52,7 @@ class DilatedConvolution2DFunction(function.Function):
             x_type.shape[1] == w_type.shape[1],
         )
 
-        if n_in.eval() == 3:
+        if type_check.eval(n_in) == 3:
             b_type = in_types[2]
             type_check.expect(
                 b_type.dtype == x_type.dtype,

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -22,7 +22,7 @@ class LinearFunction(function.Function):
             w_type.ndim == 2,
             type_check.prod(x_type.shape[1:]) == w_type.shape[1],
         )
-        if n_in.eval() == 3:
+        if type_check.eval(n_in) == 3:
             b_type = in_types[2]
             type_check.expect(
                 b_type.dtype == x_type.dtype,

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -20,13 +20,13 @@ class Accuracy(function.Function):
             t_type.dtype == numpy.int32
         )
 
-        t_ndim = t_type.ndim.eval()
+        t_ndim = type_check.eval(t_type.ndim)
         type_check.expect(
             x_type.ndim >= t_type.ndim,
             x_type.shape[0] == t_type.shape[0],
             x_type.shape[2: t_ndim + 1] == t_type.shape[1:]
         )
-        for i in six.moves.range(t_ndim + 1, x_type.ndim.eval()):
+        for i in six.moves.range(t_ndim + 1, type_check.eval(x_type.ndim)):
             type_check.expect(x_type.shape[i] == 1)
 
     def forward(self, inputs):

--- a/chainer/functions/evaluation/classification_summary.py
+++ b/chainer/functions/evaluation/classification_summary.py
@@ -31,13 +31,13 @@ class ClassificationSummary(function.Function):
             t_type.dtype == numpy.int32
         )
 
-        t_ndim = t_type.ndim.eval()
+        t_ndim = type_check.eval(t_type.ndim)
         type_check.expect(
             x_type.ndim >= t_type.ndim,
             x_type.shape[0] == t_type.shape[0],
             x_type.shape[2: t_ndim + 1] == t_type.shape[1:]
         )
-        for i in six.moves.range(t_ndim + 1, x_type.ndim.eval()):
+        for i in six.moves.range(t_ndim + 1, type_check.eval(x_type.ndim)):
             type_check.expect(x_type.shape[i] == 1)
 
     def forward(self, inputs):

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -513,7 +513,6 @@ class MatMulVarConst(function.Function):
 
         _matmul._check_ndim(a_type)
 
-        a_type = _matmul._convert_type(a_type)
         a_idx = _matmul._get_check_index(False, False)
         b_idx = _matmul._get_check_index(False, True)
         type_check.expect(
@@ -548,7 +547,6 @@ class MatMulConstVar(function.Function):
 
         _matmul._check_ndim(b_type)
 
-        b_type = _matmul._convert_type(b_type)
         a_idx = _matmul._get_check_index(False, False)
         b_idx = _matmul._get_check_index(False, True)
         type_check.expect(

--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -46,7 +46,6 @@ class BatchDet(function.Function):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
         a_type, = in_types
-        a_type = matmul._convert_type(a_type)
         type_check.expect(a_type.dtype.kind == 'f')
         # Only a minibatch of 2D array shapes allowed.
         type_check.expect(a_type.ndim == 3)

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -82,16 +82,12 @@ def _check_ndim(in_type, lower=1, upper=2):
     )
 
 
-def _convert_type(in_type, vector_ndim=1):
-    if type_check.eval(in_type.ndim) == vector_ndim:
-        in_type = type_check.make_variable(
-            type_check.TypeInfo(
-                type_check.eval(in_type.shape) + (1,),
-                in_type.dtype),
-            '%s(1-D array)' % in_type.name)
+def _get_size(typ, index, vector_ndim):
+    if type_check.eval(typ.ndim) == vector_ndim and \
+       type_check.eval(index) == vector_ndim:
+        return 1
     else:
-        in_type.name = '%s(2-D array)' % in_type.name
-    return in_type
+        return typ.shape[index]
 
 
 def _get_check_index(trans, right, row_idx=0, col_idx=1):
@@ -119,12 +115,12 @@ class MatMul(function.Function):
         _check_ndim(a_type)
         _check_ndim(b_type)
 
-        a_type = _convert_type(a_type)
-        b_type = _convert_type(b_type)
         a_idx = _get_check_index(self.transa, False)
         b_idx = _get_check_index(self.transb, True)
+        a_size = _get_size(a_type, a_idx, 1)
+        b_size = _get_size(b_type, b_idx, 1)
         type_check.expect(
-            a_type.shape[a_idx] == b_type.shape[b_idx]
+            a_size == b_size
         )
 
     def forward(self, x):
@@ -187,12 +183,12 @@ class BatchMatMul(function.Function):
         _check_ndim(a_type, lower=2, upper=3)
         _check_ndim(b_type, lower=2, upper=3)
 
-        a_type = _convert_type(a_type, vector_ndim=2)
-        b_type = _convert_type(b_type, vector_ndim=2)
         a_idx = _get_check_index(self.transa, False, row_idx=1, col_idx=2)
         b_idx = _get_check_index(self.transb, True, row_idx=1, col_idx=2)
+        a_size = _get_size(a_type, a_idx, 2)
+        b_size = _get_size(b_type, b_idx, 2)
         type_check.expect(
-            a_type.shape[a_idx] == b_type.shape[b_idx]
+            a_size == b_size
         )
 
     def forward(self, x):

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -84,7 +84,7 @@ def _check_ndim(in_type, lower=1, upper=2):
 
 def _convert_type(in_type, vector_ndim=1):
     if type_check.eval(in_type.ndim) == vector_ndim:
-        in_type = type_check.Variable(
+        in_type = type_check.make_variable(
             type_check.TypeInfo(
                 type_check.eval(in_type.shape) + (1,),
                 in_type.dtype),

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -83,10 +83,11 @@ def _check_ndim(in_type, lower=1, upper=2):
 
 
 def _convert_type(in_type, vector_ndim=1):
-    if in_type.ndim.eval() == vector_ndim:
+    if type_check.eval(in_type.ndim) == vector_ndim:
         in_type = type_check.Variable(
-            type_check.TypeInfo(in_type.shape.eval() + (1,),
-                                in_type.dtype),
+            type_check.TypeInfo(
+                type_check.eval(in_type.shape) + (1,),
+                in_type.dtype),
             '%s(1-D array)' % in_type.name)
     else:
         in_type.name = '%s(2-D array)' % in_type.name

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -45,13 +45,13 @@ class BatchNormalizationFunction(function.Function):
         self.decay = decay
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size().eval()
+        n_in = type_check.eval(in_types.size())
         if n_in != 3 and n_in != 5:
             raise type_check.InvalidType(
                 '%s or %s' % (in_types.size() == 3, in_types.size() == 5),
                 '%s == %s' % (in_types.size(), n_in))
         x_type, gamma_type, beta_type = in_types[:3]
-        M = gamma_type.ndim.eval()
+        M = type_check.eval(gamma_type.ndim)
         type_check.expect(
             x_type.dtype.kind == 'f',
             x_type.ndim >= gamma_type.ndim + 1,

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -504,7 +504,7 @@ def expect(*bool_exprs):
         bool_exprs (tuple of Bool expressions): Bool expressions you want to
             evaluate.
     """
-    if _thread_local.light_mode:
+    if in_light_mode():
         if not all(bool_exprs):
             raise InvalidType('', '')
     else:
@@ -514,14 +514,14 @@ def expect(*bool_exprs):
 
 
 def eval(exp):
-    if _thread_local.light_mode:
+    if in_light_mode():
         return exp
     else:
         return exp.eval()
 
 
 def make_variable(value, name):
-    if _thread_local.light_mode:
+    if in_light_mode():
         return value
     else:
         return Variable(value, name)
@@ -541,8 +541,12 @@ _prod = Variable(numpy.prod, 'prod')
 light_mode = LightMode()
 
 
+def in_light_mode():
+    return getattr(_thread_local, 'light_mode', False)
+
+
 def prod(*args, **kwargs):
-    if _thread_local.light_mode:
+    if in_light_mode():
         return numpy.prod(*args, **kwargs)
     else:
         return _prod(*args, **kwargs)

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -520,6 +520,13 @@ def eval(exp):
         return exp.eval()
 
 
+def make_variable(value, name):
+    if _thread_local.light_mode:
+        return value
+    else:
+        return Variable(value, name)
+
+
 class LightMode(object):
 
     def __enter__(self):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -1,4 +1,3 @@
-import contextlib
 import operator
 import sys
 import threading

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -535,7 +535,7 @@ light_mode = LightMode()
 
 
 def prod(*args, **kwargs):
-    if _fetch:
+    if _thread_local.light_mode:
         return numpy.prod(*args, **kwargs)
     else:
         return _prod(*args, **kwargs)

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -1,3 +1,4 @@
+import contextlib
 import operator
 import sys
 import threading

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -546,8 +546,11 @@ def in_light_mode():
     return getattr(_thread_local, 'light_mode', False)
 
 
-def prod(*args, **kwargs):
+def prod(*args):
     if in_light_mode():
-        return numpy.prod(*args, **kwargs)
+        result = 1
+        for x in args:
+            result *= x
+        return result
     else:
-        return _prod(*args, **kwargs)
+        return _prod(*args)

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -537,8 +537,15 @@ class LightMode(object):
         _thread_local.light_mode = False
 
 
+def _prod_impl(xs):
+    result = 1
+    for x in xs:
+        result *= x
+    return result
+
+
 _thread_local = threading.local()
-_prod = Variable(numpy.prod, 'prod')
+_prod = Variable(_prod_impl, 'prod')
 light_mode = LightMode()
 
 
@@ -546,11 +553,8 @@ def in_light_mode():
     return getattr(_thread_local, 'light_mode', False)
 
 
-def prod(*args):
+def prod(xs):
     if in_light_mode():
-        result = 1
-        for x in args:
-            result *= x
-        return result
+        return _prod_impl(xs)
     else:
-        return _prod(*args)
+        return _prod(xs)

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -70,7 +70,7 @@ class LightTypeInfoTuple(tuple):
 
 
 def get_types(data, name, accept_none):
-    assert(isinstance(data, tuple))
+    assert isinstance(data, tuple)
 
     info = TypeInfoTuple(
         _get_type(name, i, x, accept_none) for i, x in enumerate(data))

--- a/tests/chainer_tests/test_function.py
+++ b/tests/chainer_tests/test_function.py
@@ -99,16 +99,14 @@ class TestFunction(unittest.TestCase):
     def check_check_type_forward(self):
         self.assertEqual(self.f.check_type_forward.call_count, 1)
         ts = self.f.check_type_forward.call_args[0][0]
-        self.assertIsInstance(ts, type_check.TypeInfoTuple)
+        self.assertIsInstance(ts, type_check.LightTypeInfoTuple)
         self.assertEqual(len(ts), 2)
 
-        self.assertEqual(ts[0].name, 'in_types[0]')
-        t1 = ts[0].eval()
+        t1 = ts[0]
         self.assertEqual(t1.shape, (3,))
         self.assertEqual(t1.dtype, numpy.float32)
 
-        self.assertEqual(ts[1].name, 'in_types[1]')
-        t2 = ts[1].eval()
+        t2 = ts[1]
         self.assertEqual(t2.shape, (3,))
         self.assertEqual(t2.dtype, numpy.int32)
 

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -347,10 +347,12 @@ class TestListItem(unittest.TestCase):
 class TestProd(unittest.TestCase):
 
     def test_name(self):
-        self.assertEqual(T.prod.name, 'prod')
+        p = T.prod([])
+        self.assertEqual(str(p), 'prod([])')
 
     def test_value(self):
-        self.assertIs(T.prod.value, numpy.prod)
+        value = T.prod([2, 3]).eval()
+        self.assertEqual(value, 6)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
It is a proto-type of lazy-type-check, that is faster type-check mechanism than the current implementation. It behaves like this:

- Run type check code with `ndarray` itself. It is very fast.
- If an error is found, make syntactic trees to show readable error message using the current type check mechanism.
- Error messages are not changed from the current one.
- #1692 can only shows stack trace.

It also fixes #1437 