### PR TITLE
Implement UpdateRule and use it in optimizers

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -41,6 +41,7 @@ from chainer.link import ChainList  # NOQA
 from chainer.link import Link  # NOQA
 from chainer.optimizer import GradientMethod  # NOQA
 from chainer.optimizer import Optimizer  # NOQA
+from chainer.optimizer import UpdateRule  # NOQA
 from chainer.reporter import DictSummary  # NOQA
 from chainer.reporter import get_current_reporter  # NOQA
 from chainer.reporter import report  # NOQA

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -423,6 +423,39 @@ class Link(object):
         for name in self._params:
             dst[name].addgrad(src[name])
 
+    def enable_update(self):
+        """Enables update rules of all parameters under the link hierarchy.
+
+        This method sets the :attr:`~chainer.UpdateRule.enabled` flag of the
+        update rule of each parameter variable to ``True``.
+
+        """
+        for param in self.params():
+            rule = param.update_rule
+            if rule is not None:
+                rule.enabled = True
+
+    def disable_update(self):
+        """Disables update rules of all parameters under the link hierarchy.
+
+        This method sets the :attr:~chainer.UpdateRule.enabled` flag of the
+        update rule of each parameter variable to ``False``.
+
+        """
+        for param in self.params():
+            rule = param.update_rule
+            if rule is not None:
+                rule.enabled = False
+
+    @property
+    def update_enabled(self):
+        """``True`` if at least one parameter has an update rule enabled."""
+        for param in self.params():
+            rule = param.update_rule
+            if rule is not None and rule.enabled:
+                return True
+        return False
+
     def serialize(self, serializer):
         """Serializes the link object.
 

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -51,6 +51,7 @@ class Hyperparameter(object):
         parent (Hyperparameter): Parent hyperparameter.
 
     """
+
     def __init__(self, parent=None):
         self._parent = parent
 
@@ -104,7 +105,7 @@ class UpdateRule(object):
     the first update. The values of the state dictionary are automatically
     copied to the appropriate device before the update based on the data and
     grad arrays.
-    
+
     Args:
         parent_hyperparam (Hyperparameter): Hyperparameter that provides the
             default values.
@@ -117,6 +118,7 @@ class UpdateRule(object):
         t (int): Number of updates made by this update rule.
 
     """
+
     def __init__(self, parent_hyperparam=None):
         self._hooks = collections.OrderedDict()
         self._state = None
@@ -305,6 +307,7 @@ class Optimizer(object):
             method.
 
     """
+
     def setup(self, link):
         """Sets a target link and initializes the optimizer states.
 
@@ -539,6 +542,7 @@ class GradientMethod(Optimizer):
        :class:`GradientMethod` object for efficiency.
 
     """
+
     def __init__(self):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -625,6 +625,30 @@ class GradientMethod(Optimizer):
         raise NotImplementedError
 
 
+class HyperparameterProxy(object):
+
+    """Property that acts as an alias to an attribute of the hyperparameter.
+
+    This class is used to define a property of an implementation of
+    :class:`GradientMethod` that acts as an alias to an attribute of the
+    hyperparameter.
+
+    Args:
+        attr_name (str): Name of the attribute of the hyperparameter.
+
+    """
+
+    def __init__(self, attr_name):
+        self._attr_name = attr_name
+        self.__doc__ = 'Alias to ``self.hyperparam.{}``'.format(attr_name)
+
+    def __get__(self, obj, type=None):
+        return getattr(obj.hyperparam, self._attr_name)
+
+    def __set__(self, obj, value):
+        setattr(obj.hyperparam, self._attr_name, value)
+
+
 class WeightDecay(object):
 
     """Optimizer/UpdateRule hook function for weight decay regularization.

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -539,9 +539,22 @@ class GradientMethod(Optimizer):
     :meth:`create_update_rule` to create the default update rule of each
     parameter.
 
+    This class also provides :attr:`hyperparam`, which is the hyperparameter
+    used as the default configuration of each update rule. All built-in
+    gradient method implementations also provide proxy properties that act
+    as aliases to the attributes of :attr:`hyperparam`. It is recommended to
+    provide such an alias to each attribute. It can be done by only adding one
+    line for each attribute using :class:`HyperparameterProxy`.
+
     .. note::
        It is recommended to call :meth:`use_cleargrads` after creating a
        :class:`GradientMethod` object for efficiency.
+
+    Attributes:
+        hyperparam (Hyperparameter): The hyperparameter of the gradient
+            method. It is used as the default configuration of each update
+            rule (i.e., the hyperparameter of each update rule refers this
+            hyperparameter as its parent).
 
     """
 

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -237,7 +237,9 @@ class UpdateRule(object):
         """Serializes the update rule state.
 
         Be careful that this method only saves/loads the state of the update
-        rule.
+        rule. The parameters of the target link is not saved/loaded by this
+        method, and so you need to serialize the target link separately if you
+        want to fully recover the training state including parameters.
 
         Args:
             serializer (~chainer.AbstractSerializer): Serializer object.
@@ -294,10 +296,10 @@ class Optimizer(object):
     Optimizer instance also supports *hook functions*. Hook function is
     registered by the :meth:`add_hook` method. Each hook function is called
     in registration order in advance of the actual parameter update. If the
-    hook function has an attribute ``call_for_each_param`` of a truth value,
-    the hook function is used as a hook function of all update rules (i.e., it
-    is invoked for every parameter by passing the corresponding update rule and
-    the parameter).
+    hook function has an attribute ``call_for_each_param`` and its value is
+    ``True``, the hook function is used as a hook function of all update rules
+    (i.e., it is invoked for every parameter by passing the corresponding
+    update rule and the parameter).
 
     Attributes:
         target: Target link object. It is set by the :meth:`setup` method.
@@ -534,7 +536,7 @@ class GradientMethod(Optimizer):
 
     This class uses :class:`~chainer.UpdateRule` to manage the update rule of
     each parameter. A child class of GradientMethod should override
-    :meth:`setup_update_rule` to set up the default update rule to each
+    :meth:`create_update_rule` to create the default update rule of each
     parameter.
 
     .. note::

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -4,37 +4,59 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class AdaDelta(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.rho = 0.95
+_default_hyperparam.eps = 1e-6
 
-    """Zeiler's ADADELTA.
 
-    See: http://www.matthewzeiler.com/pubs/googleTR2012/googleTR2012.pdf
+class AdaDeltaRule(optimizer.UpdateRule):
+
+    """Update rule of Zeiler's ADADELTA.
+
+    See :class:`~chainer.optimizers.AdaDelta` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        rho (float): Exponential decay rate of the first and second order
+            moments.
+        eps (float): Small value for the numerical stability.
 
     """
+    def __init__(self, parent_hyperparam=None, rho=None, eps=None):
+        super(AdaDeltaRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if rho is not None:
+            self.hyperparam.rho = rho
+        if eps is not None:
+            self.hyperparam.eps = eps
 
-    def __init__(self, rho=0.95, eps=1e-6):
-        self.rho = rho
-        self.eps = eps
+    def init_state(self, param):
+        xp = cuda.get_array_module(param.data)
+        with cuda.get_device(param.data):
+            self.state['msg'] = xp.zeros_like(param.data)
+            self.state['msdx'] = xp.zeros_like(param.data)
 
-    def init_state(self, param, state):
-        data = param.data
-        xp = cuda.get_array_module(data)
-        with cuda.get_device(data):
-            state['msg'] = xp.zeros_like(data)
-            state['msdx'] = xp.zeros_like(data)
-
-    def update_one_cpu(self, param, state):
+    def update_core_cpu(self, param):
         grad = param.grad
-        msg, msdx = state['msg'], state['msdx']
+        if grad is None:
+            return
+        msg, msdx = self.state['msg'], self.state['msdx']
+        rho = self.hyperparam.rho
+        eps = self.hyperparam.eps
 
-        msg *= self.rho
-        msg += (1 - self.rho) * grad * grad
-        dx = numpy.sqrt((msdx + self.eps) / (msg + self.eps)) * grad
-        msdx *= self.rho
-        msdx += (1 - self.rho) * dx * dx
+        msg *= rho
+        msg += (1 - rho) * grad * grad
+        dx = numpy.sqrt((msdx + eps) / (msg + eps)) * grad
+        msdx *= rho
+        msdx += (1 - rho) * dx * dx
         param.data -= dx
 
-    def update_one_gpu(self, param, state):
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
         cuda.elementwise(
             'T grad, T one_minus_rho, T eps',
             'T param, T msg, T msdx',
@@ -42,5 +64,28 @@ class AdaDelta(optimizer.GradientMethod):
                T dx  = sqrt((msdx + eps) / (msg + eps)) * grad;
                msdx  += one_minus_rho * (dx * dx - msdx);
                param -= dx;''',
-            'adadelta')(param.grad, 1 - self.rho, self.eps,
-                        param.data, state['msg'], state['msdx'])
+            'adadelta')(grad, 1 - self.hyperparam.rho,
+                        self.hyperparam.eps, param.data,
+                        self.state['msg'], self.state['msdx'])
+
+
+class AdaDelta(optimizer.GradientMethod):
+
+    """Zeiler's ADADELTA.
+
+    See: http://www.matthewzeiler.com/pubs/googleTR2012/googleTR2012.pdf
+
+    Args:
+        rho (float): Exponential decay rate of the first and second order
+            moments.
+        eps (float): Small value for the numerical stability.
+
+    """
+    def __init__(self, rho=_default_hyperparam.rho,
+                 eps=_default_hyperparam.eps):
+        super(AdaDelta, self).__init__()
+        self.hyperparam.rho = rho
+        self.hyperparam.eps = eps
+
+    def create_update_rule(self):
+        return AdaDeltaRule(self.hyperparam)

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -17,13 +17,14 @@ class AdaDeltaRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         rho (float): Exponential decay rate of the first and second order
             moments.
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, parent_hyperparam=None, rho=None, eps=None):
         super(AdaDeltaRule, self).__init__(
             parent_hyperparam or _default_hyperparam)
@@ -81,6 +82,7 @@ class AdaDelta(optimizer.GradientMethod):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, rho=_default_hyperparam.rho,
                  eps=_default_hyperparam.eps):
         super(AdaDelta, self).__init__()

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -89,5 +89,8 @@ class AdaDelta(optimizer.GradientMethod):
         self.hyperparam.rho = rho
         self.hyperparam.eps = eps
 
+    rho = optimizer.HyperparameterProxy('rho')
+    eps = optimizer.HyperparameterProxy('eps')
+
     def create_update_rule(self):
         return AdaDeltaRule(self.hyperparam)

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -4,35 +4,78 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class AdaGrad(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.lr = 0.001
+_default_hyperparam.eps = 1e-8
 
-    """AdaGrad implementation.
 
-    See: http://jmlr.org/papers/v12/duchi11a.html
+class AdaGradRule(optimizer.UpdateRule):
+
+    """Update rule of AdaGrad.
+
+    See :class:`~chainer.optimizers.AdaGrad` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        lr (float): Learning rate.
+        eps (float): Small value for the numerical stability.
 
     """
+    def __init__(self, parent_hyperparam=None, lr=None, eps=None):
+        super(AdaGradRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+        if eps is not None:
+            self.hyperparam.eps = eps
 
-    def __init__(self, lr=0.001, eps=1e-8):
-        self.lr = lr
-        self.eps = eps
-
-    def init_state(self, param, state):
+    def init_state(self, param):
         xp = cuda.get_array_module(param.data)
         with cuda.get_device(param.data):
-            state['h'] = xp.zeros_like(param.data)
+            self.state['h'] = xp.zeros_like(param.data)
 
-    def update_one_cpu(self, param, state):
-        h = state['h']
+    def update_core_cpu(self, param):
         grad = param.grad
+        if grad is None:
+            return
+
+        lr = self.hyperparam.lr
+        eps = self.hyperparam.eps
+        h = self.state['h']
 
         h += grad * grad
-        param.data -= self.lr * grad / (numpy.sqrt(h) + self.eps)
+        param.data -= lr * grad / (numpy.sqrt(h) + eps)
 
-    def update_one_gpu(self, param, state):
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
         cuda.elementwise(
             'T grad, T lr, T eps',
             'T param, T h',
             '''h += grad * grad;
                param -= lr * grad / (sqrt(h) + eps);''',
-            'adagrad')(param.grad, self.lr, self.eps,
-                       param.data, state['h'])
+            'adagrad')(grad, self.hyperparam.lr, self.hyperparam.eps,
+                       param.data, self.state['h'])
+
+
+class AdaGrad(optimizer.GradientMethod):
+
+    """AdaGrad optimizer.
+
+    See: http://jmlr.org/papers/v12/duchi11a.html
+
+    Args:
+        lr (float): Learning rate.
+        eps (float): Small value for the numerical stability.
+
+    """
+    def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+        super(AdaGrad, self).__init__()
+        self.hyperparam.lr = lr
+        self.hyperparam.eps = eps
+
+    def create_update_rule(self):
+        return AdaGradRule(self.hyperparam)

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -79,5 +79,8 @@ class AdaGrad(optimizer.GradientMethod):
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 
+    lr = optimizer.HyperparameterProxy('lr')
+    eps = optimizer.HyperparameterProxy('eps')
+
     def create_update_rule(self):
         return AdaGradRule(self.hyperparam)

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -17,12 +17,13 @@ class AdaGradRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         lr (float): Learning rate.
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, parent_hyperparam=None, lr=None, eps=None):
         super(AdaGradRule, self).__init__(
             parent_hyperparam or _default_hyperparam)
@@ -72,6 +73,7 @@ class AdaGrad(optimizer.GradientMethod):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
         super(AdaGrad, self).__init__()
         self.hyperparam.lr = lr

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -6,46 +6,103 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class Adam(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.alpha = 0.001
+_default_hyperparam.beta1 = 0.9
+_default_hyperparam.beta2 = 0.999
+_default_hyperparam.eps = 1e-8
 
-    """Adam optimization algorithm.
 
-    See: https://arxiv.org/abs/1412.6980v8
+class AdamRule(optimizer.UpdateRule):
+
+    """Update rule of Adam optimization algorithm.
+
+    See :class:`~chainer.optimizers.Adam` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        alpha (float): Step size.
+        beta1 (float): Exponential decay rate of the first order moment.
+        beta2 (float): Exponential decay rate of the second order moment.
+        eps (float): Small value for the numerical stability.
 
     """
+    def __init__(self, parent_hyperparam=None,
+                 alpha=None, beta1=None, beta2=None, eps=None):
+        super(AdamRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if alpha is not None:
+            self.hyperparam.alpha = alpha
+        if beta1 is not None:
+            self.hyperparam.beta1 = beta1
+        if beta2 is not None:
+            self.hyperparam.beta2 = beta2
+        if eps is not None:
+            self.hyperparam.eps = eps
 
-    def __init__(self, alpha=0.001, beta1=0.9, beta2=0.999, eps=1e-8):
-        self.alpha = alpha
-        self.beta1 = beta1
-        self.beta2 = beta2
-        self.eps = eps
-
-    def init_state(self, param, state):
+    def init_state(self, param):
         xp = cuda.get_array_module(param.data)
         with cuda.get_device(param.data):
-            state['m'] = xp.zeros_like(param.data)
-            state['v'] = xp.zeros_like(param.data)
+            self.state['m'] = xp.zeros_like(param.data)
+            self.state['v'] = xp.zeros_like(param.data)
 
-    def update_one_cpu(self, param, state):
-        m, v = state['m'], state['v']
+    def update_core_cpu(self, param):
         grad = param.grad
+        if grad is None:
+            return
+        hp = self.hyperparam
+        m, v = self.state['m'], self.state['v']
 
-        m += (1 - self.beta1) * (grad - m)
-        v += (1 - self.beta2) * (grad * grad - v)
-        param.data -= self.lr * m / (numpy.sqrt(v) + self.eps)
+        m += (1 - hp.beta1) * (grad - m)
+        v += (1 - hp.beta2) * (grad * grad - v)
+        param.data -= self.lr * m / (numpy.sqrt(v) + hp.eps)
 
-    def update_one_gpu(self, param, state):
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
         cuda.elementwise(
             'T grad, T lr, T one_minus_beta1, T one_minus_beta2, T eps',
             'T param, T m, T v',
             '''m += one_minus_beta1 * (grad - m);
                v += one_minus_beta2 * (grad * grad - v);
                param -= lr * m / (sqrt(v) + eps);''',
-            'adam')(param.grad, self.lr, 1 - self.beta1, 1 - self.beta2,
-                    self.eps, param.data, state['m'], state['v'])
+            'adam')(grad, self.lr, 1 - self.hyperparam.beta1,
+                    1 - self.hyperparam.beta2, self.hyperparam.eps, param.data,
+                    self.state['m'], self.state['v'])
 
     @property
     def lr(self):
-        fix1 = 1. - self.beta1 ** self.t
-        fix2 = 1. - self.beta2 ** self.t
-        return self.alpha * math.sqrt(fix2) / fix1
+        fix1 = 1. - self.hyperparam.beta1 ** self.t
+        fix2 = 1. - self.hyperparam.beta2 ** self.t
+        return self.hyperparam.alpha * math.sqrt(fix2) / fix1
+
+
+class Adam(optimizer.GradientMethod):
+
+    """Adam optimizer.
+
+    See: http://arxiv.org/abs/1412.6980v8
+
+    Args:
+        alpha (float): Step size.
+        beta1 (float): Exponential decay rate of the first order moment.
+        beta2 (float): Exponential decay rate of the second order moment.
+        eps (float): Small value for the numerical stability.
+
+    """
+    def __init__(self,
+                 alpha=_default_hyperparam.alpha,
+                 beta1=_default_hyperparam.beta1,
+                 beta2=_default_hyperparam.beta2,
+                 eps=_default_hyperparam.eps):
+        super(Adam, self).__init__()
+        self.hyperparam.alpha = alpha
+        self.hyperparam.beta1 = beta1
+        self.hyperparam.beta2 = beta2
+        self.hyperparam.eps = eps
+
+    def create_update_rule(self):
+        return AdamRule(self.hyperparam)

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -106,5 +106,10 @@ class Adam(optimizer.GradientMethod):
         self.hyperparam.beta2 = beta2
         self.hyperparam.eps = eps
 
+    alpha = optimizer.HyperparameterProxy('alpha')
+    beta1 = optimizer.HyperparameterProxy('beta1')
+    beta2 = optimizer.HyperparameterProxy('beta2')
+    eps = optimizer.HyperparameterProxy('eps')
+
     def create_update_rule(self):
         return AdamRule(self.hyperparam)

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -113,3 +113,9 @@ class Adam(optimizer.GradientMethod):
 
     def create_update_rule(self):
         return AdamRule(self.hyperparam)
+
+    @property
+    def lr(self):
+        fix1 = 1. - self.hyperparam.beta1 ** self.t
+        fix2 = 1. - self.hyperparam.beta2 ** self.t
+        return self.hyperparam.alpha * math.sqrt(fix2) / fix1

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -21,7 +21,7 @@ class AdamRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         alpha (float): Step size.
         beta1 (float): Exponential decay rate of the first order moment.
@@ -29,6 +29,7 @@ class AdamRule(optimizer.UpdateRule):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, parent_hyperparam=None,
                  alpha=None, beta1=None, beta2=None, eps=None):
         super(AdamRule, self).__init__(
@@ -93,6 +94,7 @@ class Adam(optimizer.GradientMethod):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self,
                  alpha=_default_hyperparam.alpha,
                  beta1=_default_hyperparam.beta1,

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -2,30 +2,75 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class MomentumSGD(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.lr = 0.01
+_default_hyperparam.momentum = 0.9
 
-    """Classical momentum SGD."""
 
-    def __init__(self, lr=0.01, momentum=0.9):
-        self.lr = lr
-        self.momentum = momentum
+class MomentumSGDRule(optimizer.UpdateRule):
 
-    def init_state(self, param, state):
+    """Update rule for the classical momentum SGD.
+
+    See :class:`~chainer.optimizers.MomentumSGD` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        lr (float): Learning rate.
+        momentum (float): Exponential decay rate of the first order moment.
+
+    """
+    def __init__(self, parent_hyperparam=None, lr=None, momentum=None):
+        super(MomentumSGDRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+        if momentum is not None:
+            self.hyperparam.momentum = momentum
+
+    def init_state(self, param):
         xp = cuda.get_array_module(param.data)
         with cuda.get_device(param.data):
-            state['v'] = xp.zeros_like(param.data)
+            self.state['v'] = xp.zeros_like(param.data)
 
-    def update_one_cpu(self, param, state):
-        v = state['v']
-        v *= self.momentum
-        v -= self.lr * param.grad
+    def update_core_cpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
+        v = self.state['v']
+        v *= self.hyperparam.momentum
+        v -= self.hyperparam.lr * grad
         param.data += v
 
-    def update_one_gpu(self, param, state):
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
         cuda.elementwise(
             'T grad, T lr, T momentum',
             'T param, T v',
             '''v = momentum * v - lr * grad;
                param += v;''',
-            'momentum_sgd')(param.grad, self.lr, self.momentum,
-                            param.data, state['v'])
+            'momentum_sgd')(
+                grad, self.hyperparam.lr, self.hyperparam.momentum,
+                param.data, self.state['v'])
+
+
+class MomentumSGD(optimizer.GradientMethod):
+
+    """Momentum SGD optimizer.
+
+    Args:
+        lr (float): Learning rate.
+        momentum (float): Exponential decay rate of the first order moment.
+
+    """
+    def __init__(self, lr=_default_hyperparam.lr,
+                 momentum=_default_hyperparam.momentum):
+        super(MomentumSGD, self).__init__()
+        self.hyperparam.lr = lr
+        self.hyperparam.momentum = momentum
+
+    def create_update_rule(self):
+        return MomentumSGDRule(self.hyperparam)

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -15,12 +15,13 @@ class MomentumSGDRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         lr (float): Learning rate.
         momentum (float): Exponential decay rate of the first order moment.
 
     """
+
     def __init__(self, parent_hyperparam=None, lr=None, momentum=None):
         super(MomentumSGDRule, self).__init__(
             parent_hyperparam or _default_hyperparam)
@@ -66,6 +67,7 @@ class MomentumSGD(optimizer.GradientMethod):
         momentum (float): Exponential decay rate of the first order moment.
 
     """
+
     def __init__(self, lr=_default_hyperparam.lr,
                  momentum=_default_hyperparam.momentum):
         super(MomentumSGD, self).__init__()

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -74,5 +74,8 @@ class MomentumSGD(optimizer.GradientMethod):
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 
+    lr = optimizer.HyperparameterProxy('lr')
+    momentum = optimizer.HyperparameterProxy('momentum')
+
     def create_update_rule(self):
         return MomentumSGDRule(self.hyperparam)

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -2,39 +2,82 @@ from chainer import cuda
 from chainer import optimizer
 
 
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.lr = 0.01
+_default_hyperparam.momentum = 0.9
+
+
+class NesterovAGRule(optimizer.UpdateRule):
+
+    """Update rule for Nesterov's Accelerated Gradient.
+
+    See :class:`~chainer.optimizers.NesterovAG` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        lr (float): Learning rate.
+        momentum (float): Exponential decay rate of the first order moment.
+
+    """
+    def __init__(self, parent_hyperparam=None, lr=None, momentum=None):
+        super(NesterovAGRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+        if momentum is not None:
+            self.hyperparam.momentum = momentum
+
+    def init_state(self, param):
+        xp = cuda.get_array_module(param.data)
+        with cuda.get_device(param.data):
+            self.state['v'] = xp.zeros_like(param.data)
+
+    def update_core_cpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
+        v = self.state['v']
+        lr, momentum = self.hyperparam.lr, self.hyperparam.momentum
+
+        v *= momentum
+        v -= lr * grad
+        param.data += momentum * momentum * v
+        param.data -= (1 + momentum) * lr * grad
+
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
+        cuda.elementwise(
+            'T grad, T lr, T momentum',
+            'T param, T v',
+            '''
+               v = v * momentum - lr * grad;
+               param += momentum * momentum * v - (1 + momentum) * lr * grad;
+            ''',
+            'nesterov_ag')(
+                grad, self.hyperparam.lr, self.hyperparam.momentum,
+                param.data, self.state['v'])
+
+
 class NesterovAG(optimizer.GradientMethod):
 
     """Nesterov's Accelerated Gradient.
 
-    Formulated as the linear combination coefficients of the velocity and
-    gradient contributions at each iteration.
+    See: http://arxiv.org/abs/1212.0901
 
-    See: https://arxiv.org/abs/1212.0901
+    Args:
+        lr (float): Learning rate.
+        momentum (float): Exponential decay rate of the first order moment.
 
     """
+    def __init__(self, lr=_default_hyperparam.lr,
+                 momentum=_default_hyperparam.momentum):
+        super(NesterovAG, self).__init__()
+        self.hyperparam.lr = lr
+        self.hyperparam.momentum = momentum
 
-    def __init__(self, lr=0.01, momentum=0.9):
-        self.lr = lr
-        self.momentum = momentum
-
-    def init_state(self, param, state):
-        xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
-            state['v'] = xp.zeros_like(param.data)
-
-    def update_one_cpu(self, param, state):
-        v = state['v']
-        v *= self.momentum
-        v -= self.lr * param.grad
-        param.data += self.momentum * self.momentum * v
-        param.data -= (1 + self.momentum) * self.lr * param.grad
-
-    def update_one_gpu(self, param, state):
-        cuda.elementwise(
-            'T grad, T lr, T momentum',
-            'T param, T v',
-            '''v = v * momentum - lr * grad;
-               param += momentum * momentum * v - (1 + momentum) * lr * grad;
-               ''',
-            'nesterov_ag')(param.grad, self.lr, self.momentum,
-                           param.data, state['v'])
+    def create_update_rule(self):
+        return NesterovAGRule(self.hyperparam)

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -81,5 +81,8 @@ class NesterovAG(optimizer.GradientMethod):
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 
+    lr = optimizer.HyperparameterProxy('lr')
+    momentum = optimizer.HyperparameterProxy('momentum')
+
     def create_update_rule(self):
         return NesterovAGRule(self.hyperparam)

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -15,12 +15,13 @@ class NesterovAGRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         lr (float): Learning rate.
         momentum (float): Exponential decay rate of the first order moment.
 
     """
+
     def __init__(self, parent_hyperparam=None, lr=None, momentum=None):
         super(NesterovAGRule, self).__init__(
             parent_hyperparam or _default_hyperparam)
@@ -73,6 +74,7 @@ class NesterovAG(optimizer.GradientMethod):
         momentum (float): Exponential decay rate of the first order moment.
 
     """
+
     def __init__(self, lr=_default_hyperparam.lr,
                  momentum=_default_hyperparam.momentum):
         super(NesterovAG, self).__init__()

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -86,5 +86,9 @@ class RMSprop(optimizer.GradientMethod):
         self.hyperparam.alpha = alpha
         self.hyperparam.eps = eps
 
+    lr = optimizer.HyperparameterProxy('lr')
+    alpha = optimizer.HyperparameterProxy('alpha')
+    eps = optimizer.HyperparameterProxy('eps')
+
     def create_update_rule(self):
         return RMSpropRule(self.hyperparam)

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -18,13 +18,14 @@ class RMSpropRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         lr (float): Learning rate.
         alpha (float): Exponential decay rate of the second order moment.
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, parent_hyperparam=None, lr=None, alpha=None, eps=None):
         super(RMSpropRule, self).__init__(
             parent_hyperparam or _default_hyperparam)
@@ -77,6 +78,7 @@ class RMSprop(optimizer.GradientMethod):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, lr=_default_hyperparam.lr,
                  alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps):
         super(RMSprop, self).__init__()

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -4,33 +4,85 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class RMSprop(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.lr = 0.01
+_default_hyperparam.alpha = 0.99
+_default_hyperparam.eps = 1e-8
 
-    """Hinton's RMSprop."""
 
-    def __init__(self, lr=0.01, alpha=0.99, eps=1e-8):
-        self.lr = lr
-        self.alpha = alpha
-        self.eps = eps
+class RMSpropRule(optimizer.UpdateRule):
 
-    def init_state(self, param, state):
+    """Update rule for RMSprop.
+
+    See :class:`~chainer.optimizers.RMSprop` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        lr (float): Learning rate.
+        alpha (float): Exponential decay rate of the second order moment.
+        eps (float): Small value for the numerical stability.
+
+    """
+    def __init__(self, parent_hyperparam=None, lr=None, alpha=None, eps=None):
+        super(RMSpropRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+        if alpha is not None:
+            self.hyperparam.alpha = alpha
+        if eps is not None:
+            self.hyperparam.eps = eps
+
+    def init_state(self, param):
         xp = cuda.get_array_module(param.data)
         with cuda.get_device(param.data):
-            state['ms'] = xp.zeros_like(param.data)
+            self.state['ms'] = xp.zeros_like(param.data)
 
-    def update_one_cpu(self, param, state):
-        ms = state['ms']
+    def update_core_cpu(self, param):
         grad = param.grad
+        if grad is None:
+            return
+        hp = self.hyperparam
+        ms = self.state['ms']
 
-        ms *= self.alpha
-        ms += (1 - self.alpha) * grad * grad
-        param.data -= self.lr * grad / (numpy.sqrt(ms) + self.eps)
+        ms *= hp.alpha
+        ms += (1 - hp.alpha) * grad * grad
+        param.data -= hp.lr * grad / (numpy.sqrt(ms) + hp.eps)
 
-    def update_one_gpu(self, param, state):
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
         cuda.elementwise(
             'T grad, T lr, T alpha, T eps',
             'T param, T ms',
             '''ms = alpha * ms + (1 - alpha) * grad * grad;
                param -= lr * grad / (sqrt(ms) + eps);''',
-            'rmsprop')(param.grad, self.lr, self.alpha, self.eps,
-                       param.data, state['ms'])
+            'rmsprop')(grad, self.hyperparam.lr, self.hyperparam.alpha,
+                       self.hyperparam.eps, param.data, self.state['ms'])
+
+
+class RMSprop(optimizer.GradientMethod):
+
+    """RMSprop optimizer.
+
+    See: T. Tieleman and G. Hinton (2012). Lecture 6.5 - rmsprop, COURSERA:
+    Neural Networks for Machine Learning.
+
+    Args:
+        lr (float): Learning rate.
+        alpha (float): Exponential decay rate of the second order moment.
+        eps (float): Small value for the numerical stability.
+
+    """
+    def __init__(self, lr=_default_hyperparam.lr,
+                 alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps):
+        super(RMSprop, self).__init__()
+        self.hyperparam.lr = lr
+        self.hyperparam.alpha = alpha
+        self.hyperparam.eps = eps
+
+    def create_update_rule(self):
+        return RMSpropRule(self.hyperparam)

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -109,5 +109,10 @@ class RMSpropGraves(optimizer.GradientMethod):
         self.hyperparam.momentum = momentum
         self.hyperparam.eps = eps
 
+    lr = optimizer.HyperparameterProxy('lr')
+    alpha = optimizer.HyperparameterProxy('alpha')
+    momentum = optimizer.HyperparameterProxy('momentum')
+    eps = optimizer.HyperparameterProxy('eps')
+
     def create_update_rule(self):
         return RMSpropGravesRule(self.hyperparam)

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -19,7 +19,7 @@ class RMSpropGravesRule(optimizer.UpdateRule):
     the hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         lr (float): Learning rate.
         alpha (float): Exponential decay rate of the first and second order
@@ -29,6 +29,7 @@ class RMSpropGravesRule(optimizer.UpdateRule):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, parent_hyperparam=None,
                  lr=None, alpha=None, momentum=None, eps=None):
         super(RMSpropGravesRule, self).__init__(
@@ -97,6 +98,7 @@ class RMSpropGraves(optimizer.GradientMethod):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, lr=_default_hyperparam.lr,
                  alpha=_default_hyperparam.alpha,
                  momentum=_default_hyperparam.momentum,

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -4,41 +4,71 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class RMSpropGraves(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.lr = 1e-4
+_default_hyperparam.alpha = 0.95
+_default_hyperparam.momentum = 0.9
+_default_hyperparam.eps = 1e-4
 
-    """Alex Graves's RMSprop.
 
-    See https://arxiv.org/abs/1308.0850
+class RMSpropGravesRule(optimizer.UpdateRule):
+
+    """Update rule for Alex Graves's RMSprop.
+
+    See :class:`~chainer.optimizers.RMSpropGraves` for the default values of
+    the hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        lr (float): Learning rate.
+        alpha (float): Exponential decay rate of the first and second order
+            moments of the raw gradient.
+        momentum (float): Exponential decay rate of the first order moment of
+            the adjusted gradient.
+        eps (float): Small value for the numerical stability.
 
     """
+    def __init__(self, parent_hyperparam=None,
+                 lr=None, alpha=None, momentum=None, eps=None):
+        super(RMSpropGravesRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+        if alpha is not None:
+            self.hyperparam.alpha = alpha
+        if momentum is not None:
+            self.hyperparam.momentum = momentum
+        if eps is not None:
+            self.hyperparam.eps = eps
 
-    def __init__(self, lr=1e-4, alpha=0.95, momentum=0.9, eps=1e-4):
-        # Default parameter values are the ones in the original paper.
-        self.lr = lr
-        self.alpha = alpha
-        self.eps = eps
-        self.momentum = momentum
-
-    def init_state(self, param, state):
+    def init_state(self, param):
         xp = cuda.get_array_module(param.data)
         with cuda.get_device(param.data):
-            state['n'] = xp.zeros_like(param.data)
-            state['g'] = xp.zeros_like(param.data)
-            state['delta'] = xp.zeros_like(param.data)
+            self.state['n'] = xp.zeros_like(param.data)
+            self.state['g'] = xp.zeros_like(param.data)
+            self.state['delta'] = xp.zeros_like(param.data)
 
-    def update_one_cpu(self, param, state):
-        n, g, delta = state['n'], state['g'], state['delta']
+    def update_core_cpu(self, param):
         grad = param.grad
+        if grad is None:
+            return
+        n, g, delta = self.state['n'], self.state['g'], self.state['delta']
+        hp = self.hyperparam
 
-        n *= self.alpha
-        n += (1 - self.alpha) * grad * grad
-        g *= self.alpha
-        g += (1 - self.alpha) * grad
-        delta *= self.momentum
-        delta -= self.lr * grad / numpy.sqrt(n - g * g + self.eps)
+        n *= hp.alpha
+        n += (1 - hp.alpha) * grad * grad
+        g *= hp.alpha
+        g += (1 - hp.alpha) * grad
+        delta *= hp.momentum
+        delta -= hp.lr * grad / numpy.sqrt(n - g * g + hp.eps)
         param.data += delta
 
-    def update_one_gpu(self, param, state):
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
+        hp = self.hyperparam
         cuda.elementwise(
             'T grad, T lr, T alpha, T momentum, T eps',
             'T param, T avg_n, T avg_g, T delta',
@@ -48,5 +78,34 @@ class RMSpropGraves(optimizer.GradientMethod):
                    lr * grad * rsqrt(avg_n - avg_g * avg_g + eps);
                param += delta;''',
             'rmsprop_graves')(
-                param.grad, self.lr, self.alpha, self.momentum, self.eps,
-                param.data, state['n'], state['g'], state['delta'])
+                grad, hp.lr, hp.alpha, hp.momentum, hp.eps, param.data,
+                self.state['n'], self.state['g'], self.state['delta'])
+
+
+class RMSpropGraves(optimizer.GradientMethod):
+
+    """Alex Graves's RMSprop.
+
+    See: http://arxiv.org/abs/1308.0850
+
+    Args:
+        lr (float): Learning rate.
+        alpha (float): Exponential decay rate of the first and second order
+            moments of the raw gradient.
+        momentum (float): Exponential decay rate of the first order moment of
+            the adjusted gradient.
+        eps (float): Small value for the numerical stability.
+
+    """
+    def __init__(self, lr=_default_hyperparam.lr,
+                 alpha=_default_hyperparam.alpha,
+                 momentum=_default_hyperparam.momentum,
+                 eps=_default_hyperparam.eps):
+        super(RMSpropGraves, self).__init__()
+        self.hyperparam.lr = lr
+        self.hyperparam.alpha = alpha
+        self.hyperparam.momentum = momentum
+        self.hyperparam.eps = eps
+
+    def create_update_rule(self):
+        return RMSpropGravesRule(self.hyperparam)

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -54,5 +54,7 @@ class SGD(optimizer.GradientMethod):
         super(SGD, self).__init__()
         self.hyperparam.lr = lr
 
+    lr = optimizer.HyperparameterProxy('lr')
+
     def create_update_rule(self):
         return SGDRule(self.hyperparam)

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -14,11 +14,12 @@ class SGDRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         lr (float): Learning rate.
 
     """
+
     def __init__(self, parent_hyperparam=None, lr=None):
         super(SGDRule, self).__init__(
             parent_hyperparam or _default_hyperparam)
@@ -48,6 +49,7 @@ class SGD(optimizer.GradientMethod):
         lr (float): Learning rate.
 
     """
+
     def __init__(self, lr=_default_hyperparam.lr):
         super(SGD, self).__init__()
         self.hyperparam.lr = lr

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -2,17 +2,55 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class SGD(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.lr = 0.01
 
-    """Vanilla Stochastic Gradient Descent."""
 
-    def __init__(self, lr=0.01):
-        self.lr = lr
+class SGDRule(optimizer.UpdateRule):
 
-    def update_one_cpu(self, param, state):
-        param.data -= self.lr * param.grad
+    """Update rule of vanilla stochastic gradient descent.
 
-    def update_one_gpu(self, param, state):
+    See :class:`~chainer.optimizers.SGD` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        lr (float): Learning rate.
+
+    """
+    def __init__(self, parent_hyperparam=None, lr=None):
+        super(SGDRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+
+    def update_core_cpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
+        param.data -= self.hyperparam.lr * grad
+
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
         cuda.elementwise('T grad, T lr', 'T param',
                          'param -= lr * grad',
-                         'sgd')(param.grad, self.lr, param.data)
+                         'sgd')(grad, self.hyperparam.lr, param.data)
+
+
+class SGD(optimizer.GradientMethod):
+
+    """Vanilla Stochastic Gradient Descent.
+
+    Args:
+        lr (float): Learning rate.
+
+    """
+    def __init__(self, lr=_default_hyperparam.lr):
+        super(SGD, self).__init__()
+        self.hyperparam.lr = lr
+
+    def create_update_rule(self):
+        return SGDRule(self.hyperparam)

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -17,12 +17,13 @@ class SMORMS3Rule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
             provides the default values.
         lr (float): Learning rate.
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, parent_hyperparam=None, lr=None, eps=None):
         super(SMORMS3Rule, self).__init__(
             parent_hyperparam or _default_hyperparam)
@@ -85,6 +86,7 @@ class SMORMS3(optimizer.GradientMethod):
         eps (float): Small value for the numerical stability.
 
     """
+
     def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
         super(SMORMS3, self).__init__()
         self.hyperparam.lr = lr

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -92,5 +92,8 @@ class SMORMS3(optimizer.GradientMethod):
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 
+    lr = optimizer.HyperparameterProxy('lr')
+    eps = optimizer.HyperparameterProxy('eps')
+
     def create_update_rule(self):
         return SMORMS3Rule(self.hyperparam)

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -4,40 +4,60 @@ from chainer import cuda
 from chainer import optimizer
 
 
-class SMORMS3(optimizer.GradientMethod):
+_default_hyperparam = optimizer.Hyperparameter()
+_default_hyperparam.lr = 0.001
+_default_hyperparam.eps = 1e-16
 
-    """Simon Funk's SMORMS3.
 
-    See http://sifter.org/~simon/journal/20150420.html.
+class SMORMS3Rule(optimizer.UpdateRule):
+
+    """Update rule for Simon Funk's SMORMS3.
+
+    See :class:`~chainer.optimizers.SMORMS3` for the default values of the
+    hyperparameters.
+
+    Args:
+        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that 
+            provides the default values.
+        lr (float): Learning rate.
+        eps (float): Small value for the numerical stability.
 
     """
+    def __init__(self, parent_hyperparam=None, lr=None, eps=None):
+        super(SMORMS3Rule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+        if eps is not None:
+            self.hyperparam.eps = eps
 
-    def __init__(self, lr=0.001, eps=1e-16):
-        self.lr = lr
-        self.eps = eps
-
-    def init_state(self, param, state):
+    def init_state(self, param):
         xp = cuda.get_array_module(param.data)
         with cuda.get_device(param.data):
-            state['mem'] = xp.ones_like(param.data)
-            state['g'] = xp.zeros_like(param.data)
-            state['g2'] = xp.zeros_like(param.data)
+            self.state['mem'] = xp.ones_like(param.data)
+            self.state['g'] = xp.zeros_like(param.data)
+            self.state['g2'] = xp.zeros_like(param.data)
 
-    def update_one_cpu(self, param, state):
-        mem, g, g2 = state['mem'], state['g'], state['g2']
+    def update_core_cpu(self, param):
         grad = param.grad
+        if grad is None:
+            return
+        mem, g, g2 = self.state['mem'], self.state['g'], self.state['g2']
 
         r = 1 / (mem + 1)
         g = (1 - r) * g + r * grad
         g2 = (1 - r) * g2 + r * grad * grad
-        x = g * g / (g2 + self.eps)
-        param.data -= grad * numpy.minimum(x, self.lr) \
-            / (numpy.sqrt(g2) + self.eps)
+        x = g * g / (g2 + self.hyperparam.eps)
+        param.data -= grad * numpy.minimum(x, self.hyperparam.lr) \
+            / (numpy.sqrt(g2) + self.hyperparam.eps)
         mem = 1 + mem * (1 - x)
 
-        state['mem'], state['g'], state['g2'] = mem, g, g2
+        self.state['mem'], self.state['g'], self.state['g2'] = mem, g, g2
 
-    def update_one_gpu(self, param, state):
+    def update_core_gpu(self, param):
+        grad = param.grad
+        if grad is None:
+            return
         cuda.elementwise(
             'T grad, T lr, T eps',
             'T param, T mem, T g, T g2',
@@ -49,5 +69,26 @@ class SMORMS3(optimizer.GradientMethod):
                param -= grad * min(lr, x) / (sqrt(g2) + eps);
                mem = 1 + mem * (1 - x)
                ''',
-            'smorms3')(param.grad, self.lr, self.eps,
-                       param.data, state['mem'], state['g'], state['g2'])
+            'smorms3')(grad, self.hyperparam.lr, self.hyperparam.eps,
+                       param.data, self.state['mem'], self.state['g'],
+                       self.state['g2'])
+
+
+class SMORMS3(optimizer.GradientMethod):
+
+    """Simon Funk's SMORMS3.
+
+    See http://sifter.org/~simon/journal/20150420.html.
+
+    Args:
+        lr (float): Learning rate.
+        eps (float): Small value for the numerical stability.
+
+    """
+    def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+        super(SMORMS3, self).__init__()
+        self.hyperparam.lr = lr
+        self.hyperparam.eps = eps
+
+    def create_update_rule(self):
+        return SMORMS3Rule(self.hyperparam)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -216,6 +216,9 @@ class Variable(object):
         initializer (~chainer.Initializer): Initializer of the data array.
             If `data` is None, this object is used for initializing the data
             array in the :meth:`initialize` method.
+        update_rule: :class:`~chainer.optimizer.UpdateRule` instance that
+            updates this variable as a parameter. This argument is set to
+            :attr:`update_rule`.
 
     Attributes:
         data: Data array of type either :class:`numpy.ndarray` or
@@ -226,6 +229,9 @@ class Variable(object):
             variable is not created by any function.
         initializer: Initializer of the data array. It is used for initializing
             the data array of an uninitialized variable.
+        update_rule: :class:`~chainer.optimizer.UpdateRule` instance that
+            updates this variable as a parameter. This argument is set to
+            :attr:`update_rule`.
 
     """
 
@@ -233,7 +239,8 @@ class Variable(object):
     _grad_initializer = None
     _initial_device = -1
 
-    def __init__(self, data=None, name=None, grad=None, initializer=None):
+    def __init__(self, data=None, name=None, grad=None, initializer=None,
+                 update_rule=None):
         if data is None:
             self.initializer = (
                 initializers.NaN() if initializer is None else initializer)
@@ -248,6 +255,7 @@ Actual: {0}'''.format(type(data))
         # abstract its initialized/uninitialized state.
         self._data = [data]
         self.name = name
+        self.update_rule = update_rule
 
         self._node = VariableNode(self, grad)
 
@@ -259,7 +267,7 @@ Actual: {0}'''.format(type(data))
 
     def __reduce__(self):
         return Variable, (self.data, self.name, self._node._grad,
-                          self.initializer)
+                          self.initializer, self.update_rule)
 
     def __repr__(self):
         if self.name:
@@ -742,6 +750,16 @@ Actual: {0}'''.format(type(data))
     def retain_data(self):
         """Lets the corresponding variable node keep the underlying array."""
         self._node.data = self._data[0]
+
+    def update(self):
+        """Updates the data array using the gradient and the update rule.
+
+        This method updates the variable using the update rule attached to this
+        variable.
+
+        """
+        if self.update_rule is not None:
+            self.update_rule.update(self)
 
     def __lt__(self, other):
         raise NotImplementedError()

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -1,0 +1,47 @@
+import unittest
+
+import six
+
+import chainer
+from chainer import optimizers
+from chainer import testing
+
+
+@testing.parameterize(*testing.product({
+    'impl': [
+        optimizers.AdaDelta,
+        optimizers.AdaGrad,
+        optimizers.Adam,
+        optimizers.MomentumSGD,
+        optimizers.NesterovAG,
+        optimizers.RMSprop,
+        optimizers.RMSpropGraves,
+        optimizers.SGD,
+        optimizers.SMORMS3,
+    ]
+}))
+class TestOptimizerHyperparameter(unittest.TestCase):
+
+    def setUp(self):
+        self.target = chainer.Link(w=())
+
+    def create(self, *args, **kwargs):
+        self.optimizer = self.impl(*args, **kwargs)
+        self.optimizer.setup(self.target)
+
+    def get_hyperparam(self, name):
+        return getattr(self.target.w.update_rule.hyperparam, name)
+
+    def test_hyperparams(self):
+        self.create()
+        default = self.optimizer.hyperparam.get_dict()
+        for name, default_value in six.iteritems(default):
+            print('test param "{}"'.format(name))
+            self.create()
+            self.assertEqual(self.get_hyperparam(name), default_value)
+            new_value = default_value + 0.1
+            self.create(**{name: new_value})
+            self.assertEqual(self.get_hyperparam(name), new_value)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -111,8 +111,11 @@ class OptimizerTestBase(object):
             optimizer = self.model.optimizer
             model.to_gpu(1)
             optimizer.setup(model)
-        for name, param in optimizer.target.namedparams(False):
-            for v in six.itervalues(optimizer._states[name]):
+        # Initialize the optimizer state by running an update
+        for param in optimizer.target.params(False):
+            param.zerograd()
+            param.update()
+            for v in six.itervalues(param.update_rule.state):
                 self.assertEqual(int(param.data.device), int(v.device))
 
     def test_initialize(self):

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -244,6 +244,9 @@ class TestGroupHierachy(unittest.TestCase):
         self.optimizer = optimizers.AdaDelta()
         self.optimizer.setup(self.parent)
 
+        self.parent.zerograds()
+        self.optimizer.update()  # init states
+
     def _save(self, h5, obj, name):
         group = h5.create_group(name)
         serializer = hdf5.HDF5Serializer(group)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -229,6 +229,9 @@ class TestGroupHierachy(unittest.TestCase):
         self.optimizer = optimizers.AdaDelta()
         self.optimizer.setup(self.parent)
 
+        self.parent.zerograds()
+        self.optimizer.update()  # init all states
+
         self.savez = numpy.savez_compressed if self.compress else numpy.savez
 
     def _save(self, target, obj, name):
@@ -252,8 +255,8 @@ class TestGroupHierachy(unittest.TestCase):
                 'child/linear/b/msdx',
                 'child/Wc/msg',
                 'child/Wc/msdx') + state
-        self.assertSetEqual(set(file.keys()),
-                            {prefix + x for x in keys})
+        self.assertEqual(set(file.keys()),
+                         {prefix + x for x in keys})
 
     def test_save_chain(self):
         d = {}

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -20,6 +20,9 @@ class TestLink(unittest.TestCase):
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'
+        self.link.x.update_rule = chainer.UpdateRule()
+        self.link.x.update_rule.enabled = False
+        self.link.u.update_rule = chainer.UpdateRule()
 
     def check_param_init(self, name, shape, dtype, data_value=numpy.nan):
         self.assertTrue(hasattr(self.link, name))
@@ -291,6 +294,23 @@ class TestLink(unittest.TestCase):
         serializer.assert_any_call('x', None)
         self.assertIsInstance(l.x.data, numpy.ndarray)
         numpy.testing.assert_array_equal(l.x.data, ret)
+
+    def test_enable_update(self):
+        self.link.enable_update()
+        self.assertTrue(self.link.x.update_rule.enabled)
+        self.assertTrue(self.link.u.update_rule.enabled)
+
+    def test_disable_update(self):
+        self.link.disable_update()
+        self.assertFalse(self.link.x.update_rule.enabled)
+        self.assertFalse(self.link.u.update_rule.enabled)
+
+    def test_update_enabled(self):
+        self.assertTrue(self.link.update_enabled)
+        self.link.disable_update()
+        self.assertFalse(self.link.update_enabled)
+        self.link.enable_update()
+        self.assertTrue(self.link.update_enabled)
 
 
 class CountVariable(chainer.Variable):

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -11,6 +11,178 @@ from chainer import testing
 from chainer.testing import attr
 
 
+class TestHyperparameter(unittest.TestCase):
+
+    def setUp(self):
+        self.parent = optimizer.Hyperparameter()
+        self.parent.x = 1
+        self.parent.y = 2
+        self.child = optimizer.Hyperparameter(self.parent)
+        self.child.y = 3
+        self.child.z = 4
+
+    def test_getattr(self):
+        self.assertTrue(hasattr(self.parent, 'x'))
+        self.assertEqual(self.parent.x, 1)
+        self.assertTrue(hasattr(self.parent, 'y'))
+        self.assertEqual(self.parent.y, 2)
+        self.assertFalse(hasattr(self.parent, 'z'))
+
+        self.assertTrue(hasattr(self.child, 'x'))
+        self.assertEqual(self.child.x, 1)
+        self.assertTrue(hasattr(self.child, 'y'))
+        self.assertEqual(self.child.y, 3)
+        self.assertTrue(hasattr(self.child, 'z'))
+        self.assertEqual(self.child.z, 4)
+
+    def test_get_dict(self):
+        self.assertEqual(self.parent.get_dict(), {'x': 1, 'y': 2})
+        self.assertEqual(self.child.get_dict(), {'x': 1, 'y': 3, 'z': 4})
+
+    def test_repr(self):
+        self.assertEqual(repr(self.parent), 'Hyperparameter(x=1, y=2)')
+        self.assertEqual(repr(self.child), 'Hyperparameter(x=1, y=3, z=4)')
+
+
+class TestUpdateRule(unittest.TestCase):
+
+    def setUp(self):
+        self.data = np.ones((2, 3), np.float32)
+        self.grad = np.ones_like(self.data)
+        self.var = chainer.Variable(self.data, grad=self.grad)
+
+        self.update_rule = optimizer.UpdateRule()
+        self.update_rule.update_core_cpu = mock.MagicMock()
+        self.update_rule.update_core_gpu = mock.MagicMock()
+
+    def test_update_cpu(self):
+        self.update_rule.update(self.var)
+        self.assertEqual(self.update_rule.update_core_cpu.call_count, 1)
+        self.assertEqual(self.update_rule.update_core_gpu.call_count, 0)
+
+    @attr.gpu
+    def test_update_gpu(self):
+        self.var.to_gpu()
+        self.update_rule.update(self.var)
+        self.assertEqual(self.update_rule.update_core_cpu.call_count, 0)
+        self.assertEqual(self.update_rule.update_core_gpu.call_count, 1)
+
+    def check_add_hook(self, hook):
+        self.update_rule.update(self.var)
+        self.assertEqual(hook.call_count, 1)
+
+        args = hook.call_args_list[0][0]
+        self.assertEqual(len(args), 2)
+        self.assertIs(args[0], self.update_rule)
+        self.assertIs(args[1], self.var)
+
+    def test_add_hook(self):
+        hook = mock.MagicMock()
+        self.update_rule.add_hook(hook)
+        self.check_add_hook(hook)
+
+    def test_add_hook_with_name(self):
+        hook = mock.MagicMock()
+        self.update_rule.add_hook(hook, name='hook')
+        self.check_add_hook(hook)
+
+    def test_remove_hook(self):
+        hook = mock.MagicMock()
+        self.update_rule.add_hook(hook, name='hook')
+        self.update_rule.remove_hook('hook')
+        self.update_rule.update(self.var)
+        self.assertEqual(hook.call_count, 0)
+
+    def test_add_hook_with_function_name(self):
+        hook_body = mock.MagicMock()
+
+        def foo(update_rule, data, grad):
+            hook_body(update_rule, data, grad)
+
+        self.update_rule.add_hook(foo)
+        self.update_rule.remove_hook('foo')
+        self.update_rule.update(self.var)
+        self.assertEqual(hook_body.call_count, 0)
+
+    def test_add_hook_no_name(self):
+        class CallableWithoutName(object):
+            def __call__(self, update_rule, param):
+                pass
+
+        with self.assertRaises(ValueError):
+            self.update_rule.add_hook(CallableWithoutName())
+
+    def test_add_hook_duplicated_name(self):
+        self.update_rule.add_hook(mock.MagicMock(), name='foo')
+        with self.assertRaises(ValueError):
+            self.update_rule.add_hook(mock.MagicMock(), name='foo')
+
+    def test_remove_hook_not_exist(self):
+        with self.assertRaises(KeyError):
+            self.update_rule.remove_hook('foo')
+
+    def test_disabled_update_rule(self):
+        self.update_rule.update_core = mock.MagicMock()
+        self.update_rule.enabled = False
+        self.update_rule.update(self.var)
+        self.assertEqual(self.update_rule.update_core.call_count, 0)
+
+        self.update_rule.enabled = True
+        self.update_rule.update(self.var)
+        self.assertEqual(self.update_rule.update_core.call_count, 1)
+
+    def setup_state(self):
+        def init_state(data):
+            state = self.update_rule.state
+            state['a'] = 0
+            state['b'] = np.array([1, 2, 3], dtype=np.float32)
+        self.update_rule.init_state = init_state
+
+    @attr.gpu
+    def test_state_copy_to_gpu(self):
+        self.setup_state()
+
+        def update_core(param):
+            self.assertIsInstance(self.update_rule.state['a'], int)
+            self.assertIsInstance(self.update_rule.state['b'], cuda.ndarray)
+
+        self.update_rule.update_core = update_core
+        self.var.to_gpu()
+        self.update_rule.update(self.var)
+
+    @attr.multi_gpu(2)
+    def test_state_copy_to_another_gpu(self):
+        self.setup_state()
+
+        def update_core(param):
+            self.assertIsInstance(self.update_rule.state['b'], cuda.ndarray)
+            self.assertEqual(self.update_rule.state['b'].device.id, 1)
+
+        # call update with arrays on GPU 0 (tested by another method)
+        self.update_rule.update_core = lambda param: None
+        self.update_rule.update(chainer.Variable(
+            cuda.to_gpu(self.data, 0), grad=cuda.to_gpu(self.grad, 0)))
+        # check if it copies the states correctly when arrays on another GPU
+        # are passed
+        self.update_rule.update_core = update_core
+        self.update_rule.update(chainer.Variable(
+            cuda.to_gpu(self.data, 1), grad=cuda.to_gpu(self.grad, 1)))
+
+    @attr.gpu
+    def test_state_copy_to_cpu(self):
+        self.setup_state()
+
+        def update_core(param):
+            self.assertIsInstance(self.update_rule.state['a'], int)
+            self.assertIsInstance(self.update_rule.state['b'], np.ndarray)
+
+        self.var.to_gpu()
+        self.update_rule.update(self.var)
+        self.var.to_cpu()
+        self.update_rule.update_core = update_core
+        self.update_rule.update(self.var)
+
+
 class TestOptimizerUtility(unittest.TestCase):
 
     def setUp(self):
@@ -61,10 +233,19 @@ class TestOptimizerHook(unittest.TestCase):
 
     def test_add_hook(self):
         h1 = mock.MagicMock()
+        h1.call_for_each_param = False
         self.optimizer.setup(self.target)
         self.optimizer.add_hook(h1, 'h1')
         self.optimizer.call_hooks()
         h1.assert_called_with(self.optimizer)
+
+    def test_add_hook_call_for_each_param(self):
+        h1 = mock.MagicMock()
+        h1.call_for_each_param = True
+        self.optimizer.setup(self.target)
+        self.optimizer.add_hook(h1, 'h1')
+        self.optimizer.call_hooks()
+        h1.assert_called_with(self.target.param.update_rule, self.target.param)
 
     def test_remove_hook(self):
         h1 = mock.MagicMock()
@@ -186,7 +367,8 @@ class TestOptimizerGradientNoise(unittest.TestCase):
         opt.update()
 
         testing.assert_allclose(expect, w, rtol=0.4)
-        noise.assert_called_once_with(xp, (2, 3), np.float32, hook, opt)
+        rule = self.target.param.update_rule
+        noise.assert_called_once_with(xp, (2, 3), np.float32, hook, rule)
 
     def test_gradient_noise_cpu(self):
         self.check_gradient_noise()
@@ -230,85 +412,65 @@ class TestGradientHardClipping(unittest.TestCase):
 
 class TestGradientMethod(unittest.TestCase):
 
-    def _suffix(self, gpu):
-        if gpu:
-            return 'gpu'
-        else:
-            return 'cpu'
-
-    def _get_method(self, prefix, gpu):
-        return getattr(self.optimizer, prefix + '_' + self._suffix(gpu))
-
     def setUp(self):
-        opt = chainer.GradientMethod()
-        opt.init_state_cpu = mock.MagicMock()
-        opt.init_state_gpu = mock.MagicMock()
-        opt.update_one_cpu = mock.MagicMock()
-        opt.update_one_gpu = mock.MagicMock()
-        self.optimizer = opt
-
-        self.target = SimpleLink(
-            np.arange(3).astype(np.float32),
-            np.arange(3).astype(np.float32))
+        self.optimizer = chainer.GradientMethod()
+        self.target = chainer.ChainList(
+            SimpleLink(np.arange(3).astype(np.float32),
+                       np.arange(3).astype(np.float32)),
+            SimpleLink(np.arange(3).astype(np.float32),
+                       np.arange(3).astype(np.float32)))
+        self.optimizer.create_update_rule = mock.MagicMock
 
     def setup_cpu(self):
         self.optimizer.setup(self.target)
 
-    def setup_gpu(self, dst_id=None):
-        self.target.to_gpu(dst_id)
+    def setup_gpu(self, device=None):
+        self.target.to_gpu(device)
         self.optimizer.setup(self.target)
 
-    def check_init_state(self, gpu):
-        param = chainer.Variable(np.arange(3))
-        param.grad = np.arange(3)
-        if gpu:
-            param.to_gpu()
-        state = {}
-        self.optimizer.init_state(param, state)
+    def test_setup(self):
+        create_update_rule = mock.MagicMock()
+        self.optimizer.create_update_rule = create_update_rule
+        self.optimizer.setup(self.target)
 
-        self._get_method('init_state', gpu).assert_called_once_with(
-            param, state)
-        self.assertEqual(self._get_method('init_state', not gpu).call_count, 0)
+        self.assertEqual(create_update_rule.call_count, 2)
+        self.assertEqual(create_update_rule.call_args_list[0], [(), {}])
+        self.assertEqual(create_update_rule.call_args_list[1], [(), {}])
 
-    def test_init_state_cpu(self):
-        self.check_init_state(False)
-
-    @attr.gpu
-    def test_init_state_gpu(self):
-        self.check_init_state(True)
-
-    def check_update(self, gpu):
+    def check_update(self):
         self.assertEqual(self.optimizer.t, 0)
 
         self.optimizer.update()
         self.assertEqual(self.optimizer.t, 1)
 
-        self._get_method('update_one', gpu).assert_called_once_with(
-            self.target.param, {})
-        self.assertEqual(self._get_method('update_one', not gpu).call_count, 0)
+        self.target[0].param.update_rule.update.assert_called_once_with(
+            self.target[0].param)
+        self.target[1].param.update_rule.update.assert_called_once_with(
+            self.target[1].param)
 
         self.optimizer.zero_grads()
-        self.assertTrue((cuda.to_cpu(self.target.param.grad) == 0).all())
+        self.assertTrue((cuda.to_cpu(self.target[0].param.grad) == 0).all())
+        self.assertTrue((cuda.to_cpu(self.target[1].param.grad) == 0).all())
 
     def test_update_cpu(self):
         self.setup_cpu()
-        self.check_update(False)
+        self.check_update()
 
     @attr.gpu
     def test_update_gpu(self):
         self.setup_gpu()
-        self.check_update(True)
+        self.check_update()
 
     def check_accumulate_grads_from_cpu(self):
-        self.optimizer.accumulate_grads([np.arange(3)])
-        grad = self.target.param.grad
+        self.optimizer.accumulate_grads([np.arange(3)] * 2)
+        grad = self.target[0].param.grad
         self.assertTrue((cuda.to_cpu(grad) == np.arange(3) * 2).all())
 
     @attr.gpu
     def check_accumulate_grads_from_gpu(self, src_id):
         with cuda.Device(src_id):
-            self.optimizer.accumulate_grads([cuda.cupy.arange(3)])
-        grad = self.target.param.grad
+            self.optimizer.accumulate_grads([cuda.cupy.arange(3)] * 2)
+        grad = self.target[0].param.grad
         self.assertTrue((cuda.to_cpu(grad) == np.arange(3) * 2).all())
 
     def test_accumulate_grads_cpu_to_cpu(self):
@@ -338,7 +500,7 @@ class TestGradientMethod(unittest.TestCase):
 
     def check_compute_grads_norm(self):
         norm = self.optimizer.compute_grads_norm()
-        self.assertAlmostEqual(norm, np.sqrt(5))
+        self.assertAlmostEqual(norm, np.sqrt(10))
 
     def test_compute_grads_norm_cpu(self):
         self.setup_cpu()
@@ -351,7 +513,7 @@ class TestGradientMethod(unittest.TestCase):
 
     def check_weight_decay(self):
         self.optimizer.weight_decay(0.1)
-        g = cuda.to_cpu(self.target.param.grad)
+        g = cuda.to_cpu(self.target[0].param.grad)
         expect = np.array([0.0, 1.1, 2.2], dtype=np.float32)
         testing.assert_allclose(g, expect)
 
@@ -366,8 +528,9 @@ class TestGradientMethod(unittest.TestCase):
 
     def check_clip_grads(self):
         self.optimizer.clip_grads(1.0)
-        g = cuda.to_cpu(self.target.param.grad)
-        sqnorm = g.dot(g)
+        g0 = cuda.to_cpu(self.target[0].param.grad)
+        g1 = cuda.to_cpu(self.target[1].param.grad)
+        sqnorm = g0.dot(g0) + g1.dot(g1)
         self.assertAlmostEqual(sqnorm, 1.0, delta=1.0e-5)
 
     def test_clip_grads_cpu(self):
@@ -383,11 +546,11 @@ class TestGradientMethod(unittest.TestCase):
 class DummyOptimizer(chainer.GradientMethod):
 
     def __init__(self, test):
+        super(DummyOptimizer, self).__init__()
         self.test = test
 
-    def update_one(self, param, state):
-        # Confirm all grads are not None
-        self.test.assertIsNotNone(param.grad)
+    def create_update_rule(self):
+        return mock.MagicMock()
 
 
 class DummyHook(object):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1,17 +1,17 @@
 import copy
 import inspect
+import re
 import unittest
 
+import mock
 import numpy as np
+import six
 
 import chainer
 from chainer import cuda
 from chainer import initializers
 from chainer import testing
 from chainer.testing import attr
-
-import re
-import six
 
 
 class Constant(chainer.Function):
@@ -774,6 +774,22 @@ class TestUninitializedVariable(unittest.TestCase):
         self.assertEqual(int(x.data.device), 1)
         self.assertEqual(int(x.grad.device), 1)
         cp.testing.assert_array_equal(x.grad, self.b)
+
+    def test_update_rule(self):
+        update_rule = mock.MagicMock()
+        g = self.a.copy()
+        x = chainer.Variable(self.a, grad=g)
+        x.update_rule = update_rule
+        x.update()
+        self.assertEqual(update_rule.update.call_count, 1)
+        self.assertEqual(update_rule.update.call_args_list[0], [(x,), {}])
+
+    def test_update_rule_without_grad(self):
+        update_rule = mock.MagicMock()
+        x = chainer.Variable(self.a)
+        x.update_rule = update_rule
+        x.update()
+        self.assertEqual(update_rule.update.call_count, 1)
 
 
 class TestDebugPrint(unittest.TestCase):


### PR DESCRIPTION
Fix #2008. See the design docs for the original design. It enables us to configure the hyperparameters of optimization methods differently for each parameter (e.g. using different learning rates, different weight decay coefficients). This PR contains slight modifications to that design, including the following things.

- Hyperparameter object is introduced to let the optimizer provide the default values for hyperparameters of each update rule. It enables us to configure the hyperparameter at once for all parameters for which a hyperparameter is not overridden. **Note:** I actually don't satisfy with this design, since it introduces some complexity to the implementation of any optimizer and would require some care on handling hyperparameters. Any discussions are welcome.
- Most optimizer hook functions are now implemented as update rule hook functions. The `call_for_each_param` flag is introduced to these hook functions, with which the optimizer treats the hook functions as optimizer hook functions and invoke them for all parameters at their update.