### PR TITLE
Fix cupy.ndarray.get to work when device id and array id mismatch

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1333,7 +1333,8 @@ cdef class ndarray:
             numpy.ndarray: Copy of the array on host memory.
 
         """
-        a_gpu = ascontiguousarray(self)
+        with self.device:
+            a_gpu = ascontiguousarray(self)
         a_cpu = numpy.empty(self._shape, dtype=self.dtype)
         ptr = a_cpu.ctypes.data_as(ctypes.c_void_p)
         if stream is None:

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -46,3 +46,14 @@ class TestArrayGet(unittest.TestCase):
         def non_contiguous_array(xp):
             return testing.shaped_arange((3,), xp=xp, dtype=dtype)[0::2]
         self.check_get(non_contiguous_array, self.stream)
+
+    @testing.multi_gpu(2)
+    @testing.for_all_dtypes()
+    def test_get_multigpu(self, dtype):
+        with cuda.Device(1):
+            src = testing.shaped_arange((2, 3), xp=cupy, dtype=dtype)
+            src = cupy.asfortranarray(src)
+        with cuda.Device(0):
+            dst = src.get()
+        expected = testing.shaped_arange((2, 3), xp=numpy, dtype=dtype)
+        np_testing.assert_array_equal(dst, expected)


### PR DESCRIPTION
fix #2141.

It crashed when array was not c_contiguous. The test case reproduces that situation.