### PR TITLE
Unified configuration

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -4,6 +4,7 @@ import pkg_resources
 import sys
 import threading
 
+from chainer import configuration  # NOQA
 from chainer import cuda  # NOQA
 from chainer import dataset  # NOQA
 from chainer import datasets  # NOQA
@@ -26,6 +27,9 @@ from chainer import variable  # NOQA
 
 
 # import class and function
+from chainer.configuration import config  # NOQA
+from chainer.configuration import global_config  # NOQA
+from chainer.configuration import using_config  # NOQA
 from chainer.flag import AUTO  # NOQA
 from chainer.flag import Flag  # NOQA
 from chainer.flag import OFF  # NOQA

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -84,6 +84,7 @@ def get_function_hooks():
 
 
 global_config.debug = bool(int(os.environ.get('CHAINER_DEBUG', '0')))
+global_config.enable_backprop = True
 global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
 
 

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -84,6 +84,7 @@ def get_function_hooks():
 
 
 global_config.debug = bool(int(os.environ.get('CHAINER_DEBUG', '0')))
+global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
 
 
 def is_debug():

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -3,6 +3,7 @@ import os
 import pkg_resources
 import sys
 import threading
+import warnings
 
 from chainer import configuration  # NOQA
 from chainer import cuda  # NOQA
@@ -119,11 +120,17 @@ class DebugMode(object):
     memorizing its original value. When exiting the context, it sets the debug
     mode back to the original value.
 
+    .. deprecated:: v2.0.0
+       DebugMode is deprecated. Use ``using_config('debug', debug)`` instead.
+
     Args:
         debug (bool): Debug mode used in the context.
     """
 
     def __init__(self, debug):
+        warnings.warn('chainer.DebugMode is deprecated. '
+                      'Use chainer.using_config("debug", ...) instead.',
+                      DeprecationWarning)
         self._using = using_config('debug', debug)
 
     def __enter__(self):

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -82,7 +82,8 @@ def get_function_hooks():
         thread_local.function_hooks = collections.OrderedDict()
     return thread_local.function_hooks
 
-_debug = False
+
+global_config.debug = bool(int(os.environ.get('CHAINER_DEBUG', '0')))
 
 
 def is_debug():
@@ -91,7 +92,7 @@ def is_debug():
     Returns:
         bool: Return ``True`` if Chainer is in debug mode.
     """
-    return _debug
+    return bool(config.debug)
 
 
 def set_debug(debug):
@@ -105,8 +106,7 @@ def set_debug(debug):
     Args:
         debug (bool): New debug mode.
     """
-    global _debug
-    _debug = debug
+    config.debug = debug
 
 
 class DebugMode(object):
@@ -122,14 +122,14 @@ class DebugMode(object):
     """
 
     def __init__(self, debug):
-        self._debug = debug
+        self._using = using_config('debug', debug)
 
     def __enter__(self):
-        self._old = is_debug()
-        set_debug(self._debug)
+        self._using.__enter__()
 
-    def __exit__(self, *_):
-        set_debug(self._old)
+    def __exit__(self, *args):
+        self._using.__exit__(*args)
+
 
 basic_math.install_variable_arithmetics()
 array.get_item.install_variable_get_item()

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -9,9 +9,10 @@ import six
 
 """Global and thread-local configuration of Chainer.
 
+TODO(beam2d): After adding more entries, move this document to sphinx rst and
+add references to the related features.
+
 Chainer provides some global settings that affect the behavior of some
-features. For example, the features with different behaviors on train/test
-phases can be configured by setting the ``phase`` configuration.
 
 There are two objects that users mainly deal with: :data:`chainer.config` and
 :data:`chainer.global_config`. The ``config`` object configures the thread-
@@ -23,14 +24,6 @@ which can be overridden by a value set to the corresponding environment
 variable. There is a naming rule of the environment variable: an entry of the
 name ``foo_var`` can be configured by the environment variable
 ``CHAINER_FOO_VAR``.
-
-The following entries are available by default.
-
-- ``debug``
-- ``deterministic``
-- ``test_mode``
-- ``type_check``
-- ``use_cudnn``
 
 """
 

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -83,7 +83,7 @@ class LocalConfig(object):
 
 def _print_attrs(obj, keys, file):
     for key in keys:
-        print(key, getattr(obj, key), sep=':\t', file=file)
+        print(u'{}:\t{}'.format(key, getattr(obj, key)), file=file)
 
 
 global_config = GlobalConfig()

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -95,7 +95,7 @@ def using_config(name, value, config=config):
             thread-local configuration is used by default.
 
     """
-    if hasattr(config, name):
+    if hasattr(config._local, name):
         old_value = getattr(config, name)
         setattr(config, name, value)
         yield

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -1,0 +1,106 @@
+from __future__ import print_function
+import contextlib
+import os
+import sys
+import threading
+
+import six
+
+
+"""Global and thread-local configuration of Chainer.
+
+Chainer provides some global settings that affect the behavior of some
+features. For example, the features with different behaviors on train/test
+phases can be configured by setting the ``phase`` configuration.
+
+There are two objects that users mainly deal with: :data:`chainer.config` and
+:data:`chainer.global_config`. The ``config`` object configures the thread-
+local configuration, while the ``global_config`` object configures the global
+configuration shared among all threads.
+
+Each entry of the global configuration is initialized by its default value,
+which can be overridden by a value set to the corresponding environment
+variable. There is a naming rule of the environment variable: an entry of the
+name ``foo_var`` can be configured by the environment variable
+``CHAINER_FOO_VAR``.
+
+The following entries are available by default.
+
+- ``debug``
+- ``deterministic``
+- ``test_mode``
+- ``type_check``
+- ``use_cudnn``
+
+"""
+
+
+class GlobalConfig(object):
+
+    """The plain object that represents the global configuration of Chainer."""
+    pass
+
+
+class LocalConfig(object):
+
+    """Thread-local configuration of Chainer.
+
+    This class implements the local configuration. When a value is set to this
+    object, the configuration is only updated in the current thread. When a
+    user tries to access an attribute and there is no local value, it
+    automatically retrieves a value from the global configuration.
+
+    """
+    def __init__(self, global_config):
+        super(LocalConfig, self).__setattr__('_global', global_config)
+        super(LocalConfig, self).__setattr__('_local', threading.local())
+
+    def __delattr__(self, name):
+        delattr(self._local, name)
+
+    def __getattr__(self, name):
+        if hasattr(self._local, name):
+            return getattr(self._local, name)
+        return getattr(self._global, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._local, name, value)
+
+    def show(self, file=sys.stdout):
+        """Prints the config entries.
+
+        The entries are sorted in the lexicographical order of the entry names.
+
+        Args:
+            file: Output file like object.
+
+        """
+        keys = sorted(set(self._global.__dict__) | set(self._local.__dict__))
+        for key in keys:
+            print(key, getattr(self, key), sep=':\t', file=file)
+
+
+global_config = GlobalConfig()
+config = LocalConfig(global_config)
+
+
+@contextlib.contextmanager
+def using_config(name, value, config=config):
+    """Context manager to temporarily change the thread-local configuration.
+
+    Args:
+        name (str): Name of the configuration to change.
+        value: Temporary value of the configuration entry.
+        config (~chainer.config.LocalConfig): Configuration object. Chainer's
+            thread-local configuration is used by default.
+
+    """
+    if hasattr(config, name):
+        old_value = getattr(config, name)
+        setattr(config, name, value)
+        yield
+        setattr(config, name, old_value)
+    else:
+        setattr(config, name, value)
+        yield
+        delattr(config, name)

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -1,10 +1,7 @@
 from __future__ import print_function
 import contextlib
-import os
 import sys
 import threading
-
-import six
 
 
 """Global and thread-local configuration of Chainer.

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -38,7 +38,18 @@ The following entries are available by default.
 class GlobalConfig(object):
 
     """The plain object that represents the global configuration of Chainer."""
-    pass
+
+    def show(self, file=sys.stdout):
+        """Prints the global config entries.
+
+        The entries are sorted in the lexicographical order of the entry name.
+
+        Args:
+            file: Output file-like object.
+
+        """
+        keys = sorted(self.__dict__)
+        _print_attrs(self, keys, file)
 
 
 class LocalConfig(object):
@@ -72,12 +83,16 @@ class LocalConfig(object):
         The entries are sorted in the lexicographical order of the entry names.
 
         Args:
-            file: Output file like object.
+            file: Output file-like object.
 
         """
         keys = sorted(set(self._global.__dict__) | set(self._local.__dict__))
-        for key in keys:
-            print(key, getattr(self, key), sep=':\t', file=file)
+        _print_attrs(self, keys, file)
+
+
+def _print_attrs(obj, keys, file):
+    for key in keys:
+        print(key, getattr(obj, key), sep=':\t', file=file)
 
 
 global_config = GlobalConfig()

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -52,6 +52,7 @@ class LocalConfig(object):
     automatically retrieves a value from the global configuration.
 
     """
+
     def __init__(self, global_config):
         super(LocalConfig, self).__setattr__('_global', global_config)
         super(LocalConfig, self).__setattr__('_local', threading.local())

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -15,10 +15,6 @@ from chainer.utils import type_check
 from chainer import variable
 
 
-_thread_local = threading.local()
-
-
-@contextlib.contextmanager
 def no_backprop_mode():
     """Disable back-propagation for Variable whose volatile is auto.
 
@@ -38,13 +34,9 @@ def no_backprop_mode():
     ...    y = x + 1
 
     """
-    default = getattr(_thread_local, 'default_backprop', True)
-    _thread_local.default_backprop = False
-    yield
-    _thread_local.default_backprop = default
+    return configuration.using_config('enable_backprop', False)
 
 
-@contextlib.contextmanager
 def force_backprop_mode():
     """Enable back-propagation for Variable whose volatile is auto.
 
@@ -73,10 +65,7 @@ def force_backprop_mode():
        See :func:`no_backprop_mode` for details of back-prop mode.
 
     """
-    default = getattr(_thread_local, 'default_backprop', True)
-    _thread_local.default_backprop = True
-    yield
-    _thread_local.default_backprop = default
+    return configuration.using_config('enable_backprop', True)
 
 
 class Function(object):
@@ -211,7 +200,7 @@ class Function(object):
         elif out_v == 'off':
             build_graph = True
         else:
-            build_graph = getattr(_thread_local, 'default_backprop', True)
+            build_graph = configuration.config.enable_backprop
 
         if build_graph:
             # Topological ordering

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -8,6 +8,7 @@ import weakref
 import six
 
 import chainer
+from chainer import configuration
 from chainer import cuda
 from chainer import flag
 from chainer.utils import type_check
@@ -143,14 +144,8 @@ class Function(object):
     Attributes:
         inputs: A tuple or list of input variables.
         outputs: A tuple or list of output variables.
-        type_check_enable: When it is ``True``, the function checks types of
-            input arguments. Set ``CHAINER_TYPE_CHECK`` environment variable
-            ``0`` to disable type check, or set the variable directly in
-            your own program.
 
     """
-    type_check_enable = int(os.environ.get('CHAINER_TYPE_CHECK', '1')) != 0
-
     def __call__(self, *inputs):
         """Applies forward propagation with chaining backward references.
 
@@ -185,7 +180,7 @@ class Function(object):
         if chainer.is_debug():
             self._stack = traceback.extract_stack()
 
-        if self.type_check_enable:
+        if configuration.config.type_check:
             self._check_data_type_forward(in_data)
 
         hooks = chainer.get_function_hooks()

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -1,7 +1,4 @@
 import collections
-import contextlib
-import os
-import threading
 import traceback
 import weakref
 

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -132,6 +132,7 @@ class Function(object):
         outputs: A tuple or list of output variables.
 
     """
+
     def __call__(self, *inputs):
         """Applies forward propagation with chaining backward references.
 

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -5,7 +5,6 @@ import six
 
 from chainer import configuration
 from chainer import cuda
-from chainer import function
 from chainer.functions.math import identity
 from chainer import testing
 from chainer import variable

--- a/tests/chainer_tests/test_configuration.py
+++ b/tests/chainer_tests/test_configuration.py
@@ -1,0 +1,71 @@
+import io
+import threading
+import unittest
+
+import chainer
+from chainer import configuration
+from chainer import testing
+
+
+class TestLocalConfig(unittest.TestCase):
+
+    def setUp(self):
+        self.global_config = configuration.GlobalConfig()
+        self.config = configuration.LocalConfig(self.global_config)
+
+        self.global_config.x = 'global x'
+        self.global_config.y = 'global y'
+        self.config.y = 'local y'
+        self.config.z = 'local z'
+
+    def test_attr(self):
+        self.assertTrue(hasattr(self.config, 'x'))
+        self.assertEqual(self.config.x, 'global x')
+        self.assertTrue(hasattr(self.config, 'y'))
+        self.assertEqual(self.config.y, 'local y')
+        self.assertTrue(hasattr(self.config, 'z'))
+        self.assertEqual(self.config.z, 'local z')
+        self.assertFalse(hasattr(self.config, 'w'))
+
+        del self.config.y
+        self.assertTrue(hasattr(self.config, 'y'))
+        self.assertEqual(self.config.y, 'global y')
+
+        with self.assertRaises(AttributeError):
+            del self.config.x
+
+    def test_multi_thread_attr(self):
+        def target():
+            self.config.y = 'local y2'
+            self.global_config.x = 'global x2'
+            self.global_config.z = 'global z2'
+
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join()
+
+        self.assertEqual(self.config.y, 'local y')
+        self.assertEqual(self.config.x, 'global x2')
+        self.assertEqual(self.config.z, 'local z')
+        self.assertEqual(self.global_config.z, 'global z2')
+
+    def test_using_config_local_did_not_exist(self):
+        with chainer.using_config('x', 'temporary x', self.config):
+            self.assertEqual(self.config.x, 'temporary x')
+            self.assertEqual(self.global_config.x, 'global x')
+        self.assertEqual(self.config.x, 'global x')
+
+    def test_using_config_local_existed(self):
+        with chainer.using_config('y', 'temporary y', self.config):
+            self.assertEqual(self.config.y, 'temporary y')
+            self.assertEqual(self.global_config.y, 'global y')
+        self.assertEqual(self.config.y, 'local y')
+
+    def test_print_config(self):
+        sio = io.StringIO()
+        self.config.show(sio)
+        contents = sio.getvalue()
+        self.assertEqual(contents, 'x:\tglobal x\ny:\tlocal y\nz:\tlocal z\n')
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_configuration.py
+++ b/tests/chainer_tests/test_configuration.py
@@ -54,6 +54,8 @@ class TestLocalConfig(unittest.TestCase):
             self.assertEqual(self.config.x, 'temporary x')
             self.assertEqual(self.global_config.x, 'global x')
         self.assertEqual(self.config.x, 'global x')
+        self.global_config.x = 'global x2'
+        self.assertEqual(self.config.x, 'global x2')
 
     def test_using_config_local_existed(self):
         with chainer.using_config('y', 'temporary y', self.config):

--- a/tests/chainer_tests/test_configuration.py
+++ b/tests/chainer_tests/test_configuration.py
@@ -69,5 +69,11 @@ class TestLocalConfig(unittest.TestCase):
         contents = sio.getvalue()
         self.assertEqual(contents, 'x:\tglobal x\ny:\tlocal y\nz:\tlocal z\n')
 
+    def test_print_global_config(self):
+        sio = io.StringIO()
+        self.global_config.show(sio)
+        contents = sio.getvalue()
+        self.assertEqual(contents, 'x:\tglobal x\ny:\tglobal y\n')
+
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR implements a unified way of managing the global/thread-local configuration of Chainer. As a first step, it implements the core part of configuration (GlobalConfig and LocalConfig), and moves some easy configurations (debug mode, type check, and backprop mode) to this configuration tool. The main features are:

- We can easily add a new entry just by setting an attribute to `chainer.global_config`.
- `with chainer.using_config('XXX', yyy):` lets us change the thread-local configuration temporarily.
- We can diagnose the current configuration with `chainer.config.show()`.

I did not finish #2048 by this PR; train/test mode and use_cudnn flag are not moved to this configuration yet, because both affect a wide range of codes in Chainer and its examples, and I want to separate PRs for them. I will work on them after this PR being merged.