### PR TITLE
Add FindConvolution* wrappers to cupy

### DIFF
--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -10,7 +10,7 @@ cdef extern from *:
     ctypedef int ConvolutionBwdDataPreference \
         'cudnnConvolutionBwdDataPreference_t'
     ctypedef struct ConvolutionBwdDataAlgoPerf \
-        'cudnnConvolutionBwdDataAlgoPerf_t':
+        'cudnnConvolutionBwdDataAlgoPerf_t':  # NOQA: E125
         int algo
         int status
         float time
@@ -19,7 +19,7 @@ cdef extern from *:
     ctypedef int ConvolutionBwdFilterPreference \
         'cudnnConvolutionBwdFilterPreference_t'
     ctypedef struct ConvolutionBwdFilterAlgoPerf \
-        'cudnnConvolutionBwdFilterAlgoPerf_t':
+        'cudnnConvolutionBwdFilterAlgoPerf_t':  # NOQA: E125
         int algo
         int status
         float time

--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -9,11 +9,28 @@ cdef extern from *:
     ctypedef int ConvolutionBwdDataAlgo 'cudnnConvolutionBwdDataAlgo_t'
     ctypedef int ConvolutionBwdDataPreference \
         'cudnnConvolutionBwdDataPreference_t'
+    ctypedef struct ConvolutionBwdDataAlgoPerf \
+        'cudnnConvolutionBwdDataAlgoPerf_t':
+        int algo
+        int status
+        float time
+        size_t memory
     ctypedef int ConvolutionBwdFilterAlgo 'cudnnConvolutionBwdFilterAlgo_t'
     ctypedef int ConvolutionBwdFilterPreference \
         'cudnnConvolutionBwdFilterPreference_t'
+    ctypedef struct ConvolutionBwdFilterAlgoPerf \
+        'cudnnConvolutionBwdFilterAlgoPerf_t':
+        int algo
+        int status
+        float time
+        size_t memory
     ctypedef int ConvolutionFwdAlgo 'cudnnConvolutionFwdAlgo_t'
     ctypedef int ConvolutionFwdPreference 'cudnnConvolutionFwdPreference_t'
+    ctypedef struct ConvolutionFwdAlgoPerf 'cudnnConvolutionFwdAlgoPerf_t':
+        int algo
+        int status
+        float time
+        size_t memory
     ctypedef int ConvolutionMode 'cudnnConvolutionMode_t'
     ctypedef int DataType 'cudnnDataType_t'
     ctypedef int DirectionMode 'cudnnDirectionMode_t'
@@ -181,6 +198,13 @@ cpdef setConvolutionNdDescriptor_v3(
     size_t convDesc, int arrayLength, size_t padA, size_t filterStrideA,
     size_t upscaleA, int mode, int dataType)
 cpdef destroyConvolutionDescriptor(size_t convDesc)
+cpdef findConvolutionForwardAlgorithm(
+    size_t handle, size_t xDesc, size_t wDesc, size_t convDesc, size_t yDesc,
+    int requestedAlgoCount)
+cpdef findConvolutionForwardAlgorithmEx(
+    size_t handle, size_t xDesc, size_t x, size_t wDesc, size_t w,
+    size_t convDesc, size_t yDesc, size_t y, int requestedAlgoCount,
+    size_t workSpace, size_t workSpaceSizeInBytes)
 cpdef int getConvolutionForwardAlgorithm(
     size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
     size_t destDesc, ConvolutionFwdPreference preference,
@@ -196,6 +220,13 @@ cpdef convolutionForward(
 cpdef convolutionBackwardBias(
     size_t handle, size_t alpha, size_t srcDesc, size_t srcData,
     size_t beta, size_t destDesc, size_t destData)
+cpdef findConvolutionBackwardFilterAlgorithm(
+    size_t handle, size_t xDesc, size_t dyDesc, size_t convDesc, size_t dwDesc,
+    int requestedAlgoCount)
+cpdef findConvolutionBackwardFilterAlgorithmEx(
+    size_t handle, size_t xDesc, size_t x, size_t dyDesc, size_t dy,
+    size_t convDesc, size_t dwDesc, size_t dw, int requestedAlgoCount,
+    size_t workSpace, size_t workSpaceSizeInBytes)
 cpdef int getConvolutionBackwardFilterAlgorithm(
     size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
     size_t filterDesc, ConvolutionBwdFilterPreference preference,
@@ -212,6 +243,13 @@ cpdef convolutionBackwardFilter_v3(
     size_t diffDesc, size_t diffData, size_t convDesc, int algo,
     size_t workSpace, size_t workSpaceSizeInBytes, size_t beta,
     size_t gradDesc, size_t gradData)
+cpdef findConvolutionBackwardDataAlgorithm(
+    size_t handle, size_t wDesc, size_t dyDesc, size_t convDesc, size_t dxDesc,
+    int requestedAlgoCount)
+cpdef findConvolutionBackwardDataAlgorithmEx(
+    size_t handle, size_t wDesc, size_t w, size_t dyDesc, size_t dy,
+    size_t convDesc, size_t dxDesc, size_t dx,
+    int requestedAlgoCount, size_t workSpace, size_t workSpaceSizeInBytes)
 cpdef int getConvolutionBackwardDataAlgorithm(
     size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
     size_t gradDesc, size_t preference,

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -73,6 +73,17 @@ cdef extern from "cupy_cudnn.h":
         int* filterStrideA, int* upscaleA, ConvolutionMode mode,
         DataType dataType) nogil
     int cudnnDestroyConvolutionDescriptor(ConvolutionDescriptor conDesc) nogil
+    int cudnnFindConvolutionForwardAlgorithm(
+        Handle handle, TensorDescriptor xDesc, FilterDescriptor wDesc,
+        ConvolutionDescriptor convDesc, TensorDescriptor yDesc,
+        int requestedAlgoCount, int* returnedAlgoCount,
+        ConvolutionFwdAlgoPerf* perfResults) nogil
+    int cudnnFindConvolutionForwardAlgorithmEx(
+        Handle handle, TensorDescriptor xDesc, void* x,
+        FilterDescriptor wDesc, void* w, ConvolutionDescriptor convDesc,
+        TensorDescriptor yDesc, void* y, int requestedAlgoCount,
+        int* returnedAlgoCount, ConvolutionFwdAlgoPerf* perfResults,
+        void* workSpace, size_t workSpaceSizeInBytes) nogil
     int cudnnGetConvolutionForwardAlgorithm(
         Handle handle, TensorDescriptor srcDesc,
         FilterDescriptor filterDesc, ConvolutionDescriptor convDesc,
@@ -93,6 +104,17 @@ cdef extern from "cupy_cudnn.h":
         Handle handle, void* alpha,
         TensorDescriptor srcDesc, void* srcData, void* beta,
         TensorDescriptor destDesc, void* destData) nogil
+    int cudnnFindConvolutionBackwardFilterAlgorithm(
+        Handle handle, TensorDescriptor xDesc, TensorDescriptor dyDesc,
+        ConvolutionDescriptor convDesc, FilterDescriptor dwDesc,
+        int requestedAlgoCount, int* returnedAlgoCount,
+        ConvolutionBwdFilterAlgoPerf* perfResults) nogil
+    int cudnnFindConvolutionBackwardFilterAlgorithmEx(
+        Handle handle, TensorDescriptor xDesc, void* x,
+        TensorDescriptor dyDesc, void* dy, ConvolutionDescriptor convDesc,
+        FilterDescriptor dwDesc, void* dw, int requestedAlgoCount,
+        int* returnedAlgoCount, ConvolutionBwdFilterAlgoPerf* perfResults,
+        void* workSpace, size_t workSpaceSizeInBytes) nogil
     int cudnnGetConvolutionBackwardFilterAlgorithm(
         Handle handle, TensorDescriptor srcDesc, TensorDescriptor diffDesc,
         ConvolutionDescriptor convDesc, FilterDescriptor filterDesc,
@@ -121,6 +143,17 @@ cdef extern from "cupy_cudnn.h":
         ConvolutionDescriptor convDesc, TensorDescriptor gradDesc,
         ConvolutionBwdDataPreference preference,
         size_t memoryLimitInbytes, ConvolutionBwdDataAlgo* algo) nogil
+    int cudnnFindConvolutionBackwardDataAlgorithm(
+        Handle handle, TensorDescriptor wDesc, TensorDescriptor dyDesc,
+        ConvolutionDescriptor convDesc, FilterDescriptor dxDesc,
+        int requestedAlgoCount, int* returnedAlgoCount,
+        ConvolutionBwdDataAlgoPerf* perfResults) nogil
+    int cudnnFindConvolutionBackwardDataAlgorithmEx(
+        Handle handle, FilterDescriptor wDesc, void* w,
+        TensorDescriptor dyDesc, void* dy, ConvolutionDescriptor convDesc,
+        TensorDescriptor dxDesc, void* dx, int requestedAlgoCount,
+        int* returnedAlgoCount, ConvolutionBwdDataAlgoPerf* perfResults,
+        void* workSpace, size_t workSpaceSizeInBytes) nogil
     int cudnnGetConvolutionBackwardDataWorkspaceSize(
         Handle handle, FilterDescriptor filterDesc,
         TensorDescriptor diffDesc,
@@ -511,6 +544,36 @@ cpdef destroyConvolutionDescriptor(size_t convDesc):
         <ConvolutionDescriptor>convDesc)
     check_status(status)
 
+cpdef findConvolutionForwardAlgorithm(
+        size_t handle, size_t xDesc, size_t wDesc, size_t convDesc,
+        size_t yDesc, int requestedAlgoCount):
+    cdef vector.vector[ConvolutionFwdAlgoPerf] perfResults
+    cdef vector.vector[int] returnedAlgoCount
+    perfResults.resize(requestedAlgoCount)
+    returnedAlgoCount.resize(1)
+    status = cudnnFindConvolutionForwardAlgorithm(
+        <Handle> handle, <TensorDescriptor>xDesc, <FilterDescriptor>wDesc,
+        <ConvolutionDescriptor>convDesc, <TensorDescriptor>yDesc,
+        requestedAlgoCount, &returnedAlgoCount[0], &perfResults[0])
+    check_status(status)
+    return returnedAlgoCount[0], perfResults
+
+cpdef findConvolutionForwardAlgorithmEx(
+        size_t handle, size_t xDesc, size_t x, size_t wDesc, size_t w,
+        size_t convDesc, size_t yDesc, size_t y, int requestedAlgoCount,
+        size_t workSpace, size_t workSpaceSizeInBytes):
+    cdef vector.vector[ConvolutionFwdAlgoPerf] perfResults
+    cdef vector.vector[int] returnedAlgoCount
+    perfResults.resize(requestedAlgoCount)
+    returnedAlgoCount.resize(1)
+    status = cudnnFindConvolutionForwardAlgorithmEx(
+        <Handle> handle, <TensorDescriptor>xDesc, <void*>x,
+        <FilterDescriptor>wDesc, <void*>w, <ConvolutionDescriptor>convDesc,
+        <TensorDescriptor>yDesc, <void*>y, requestedAlgoCount,
+        &returnedAlgoCount[0], &perfResults[0], <void*>workSpace,
+        workSpaceSizeInBytes)
+    check_status(status)
+    return returnedAlgoCount[0], perfResults
 
 cpdef int getConvolutionForwardAlgorithm(
         size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
@@ -563,6 +626,37 @@ cpdef convolutionBackwardBias(
             <TensorDescriptor>srcDesc, <void*>srcData, <void*>beta,
             <TensorDescriptor>destDesc, <void*>destData)
     check_status(status)
+
+cpdef findConvolutionBackwardFilterAlgorithm(
+        size_t handle, size_t xDesc, size_t dyDesc, size_t convDesc,
+        size_t dwDesc, int requestedAlgoCount):
+    cdef vector.vector[ConvolutionBwdFilterAlgoPerf] perfResults
+    cdef vector.vector[int] returnedAlgoCount
+    perfResults.resize(requestedAlgoCount)
+    returnedAlgoCount.resize(1)
+    status = cudnnFindConvolutionBackwardFilterAlgorithm(
+        <Handle> handle, <TensorDescriptor>xDesc, <TensorDescriptor>dyDesc,
+        <ConvolutionDescriptor>convDesc, <FilterDescriptor>dwDesc,
+        requestedAlgoCount, &returnedAlgoCount[0], &perfResults[0])
+    check_status(status)
+    return returnedAlgoCount[0], perfResults
+
+cpdef findConvolutionBackwardFilterAlgorithmEx(
+        size_t handle, size_t xDesc, size_t x, size_t dyDesc, size_t dy,
+        size_t convDesc, size_t dwDesc, size_t dw, int requestedAlgoCount,
+        size_t workSpace, size_t workSpaceSizeInBytes):
+    cdef vector.vector[ConvolutionBwdFilterAlgoPerf] perfResults
+    cdef vector.vector[int] returnedAlgoCount
+    perfResults.resize(requestedAlgoCount)
+    returnedAlgoCount.resize(1)
+    status = cudnnFindConvolutionBackwardFilterAlgorithmEx(
+        <Handle> handle, <TensorDescriptor>xDesc, <void*>x,
+        <TensorDescriptor>dyDesc, <void*>dy, <ConvolutionDescriptor>convDesc,
+        <FilterDescriptor>dwDesc, <void*>dw,
+        requestedAlgoCount, &returnedAlgoCount[0], &perfResults[0],
+        <void*>workSpace, workSpaceSizeInBytes)
+    check_status(status)
+    return returnedAlgoCount[0], perfResults
 
 cpdef int getConvolutionBackwardFilterAlgorithm(
         size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
@@ -617,6 +711,37 @@ cpdef convolutionBackwardFilter_v3(
             <void*>workSpace, workSpaceSizeInBytes, <void*>beta,
             <FilterDescriptor>gradDesc, <void*>gradData)
     check_status(status)
+
+cpdef findConvolutionBackwardDataAlgorithm(
+        size_t handle, size_t wDesc, size_t dyDesc, size_t convDesc,
+        size_t dxDesc, int requestedAlgoCount):
+    cdef vector.vector[ConvolutionBwdDataAlgoPerf] perfResults
+    cdef vector.vector[int] returnedAlgoCount
+    perfResults.resize(requestedAlgoCount)
+    returnedAlgoCount.resize(1)
+    status = cudnnFindConvolutionBackwardDataAlgorithm(
+        <Handle> handle, <FilterDescriptor>wDesc, <TensorDescriptor>dyDesc,
+        <ConvolutionDescriptor>convDesc, <TensorDescriptor>dxDesc,
+        requestedAlgoCount, &returnedAlgoCount[0], &perfResults[0])
+    check_status(status)
+    return returnedAlgoCount[0], perfResults
+
+cpdef findConvolutionBackwardDataAlgorithmEx(
+        size_t handle, size_t wDesc, size_t w, size_t dyDesc, size_t dy,
+        size_t convDesc, size_t dxDesc, size_t dx,
+        int requestedAlgoCount, size_t workSpace, size_t workSpaceSizeInBytes):
+    cdef vector.vector[ConvolutionBwdDataAlgoPerf] perfResults
+    cdef vector.vector[int] returnedAlgoCount
+    perfResults.resize(requestedAlgoCount)
+    returnedAlgoCount.resize(1)
+    status = cudnnFindConvolutionBackwardDataAlgorithmEx(
+        <Handle> handle, <FilterDescriptor>wDesc, <void*>w,
+        <TensorDescriptor>dyDesc, <void*>dy, <ConvolutionDescriptor>convDesc,
+        <TensorDescriptor>dxDesc, <void*>dx,
+        requestedAlgoCount, &returnedAlgoCount[0], &perfResults[0],
+        <void*>workSpace, workSpaceSizeInBytes)
+    check_status(status)
+    return returnedAlgoCount[0], perfResults
 
 cpdef int getConvolutionBackwardDataAlgorithm(
         size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -21,6 +21,7 @@ typedef enum {
 typedef enum {} cudnnActivationMode_t;
 typedef enum {} cudnnConvolutionFwdAlgo_t;
 typedef enum {} cudnnConvolutionFwdPreference_t;
+typedef struct {} cudnnConvolutionFwdAlgoPerf_t;
 typedef enum {} cudnnConvolutionMode_t;
 typedef enum {} cudnnDataType_t;
 typedef enum {} cudnnNanPropagation_t;
@@ -195,10 +196,16 @@ extern "C" {
 
 typedef enum {} cudnnConvolutionBwdDataAlgo_t;
 typedef enum {} cudnnConvolutionBwdDataPreference_t;
+typedef enum {} cudnnConvolutionBwdDataAlgoPerf_t;
 typedef enum {} cudnnConvolutionBwdFilterAlgo_t;
 typedef enum {} cudnnConvolutionBwdFilterPreference_t;
+typedef enum {} cudnnConvolutionBwdFilterAlgoPerf_t;
 
 cudnnStatus_t cudnnAddTensor_v3(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnFindConvolutionForwardAlgorithm(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
@@ -210,11 +217,19 @@ cudnnStatus_t cudnnGetConvolutionBackwardFilterWorkspaceSize(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
+cudnnStatus_t cudnnFindConvolutionBackwardFilterAlgorithm(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
 cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
 cudnnStatus_t cudnnConvolutionBackwardData_v3(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnFindConvolutionBackwardDataAlgorithm(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
@@ -363,6 +378,18 @@ cudnnStatus_t cudnnRNNBackwardData(...) {
 }
 
 cudnnStatus_t cudnnRNNBackwardWeights(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnFindConvolutionBackwardFilterAlgorithmEx(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnFindConvolutionForwardAlgorithmEx(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnFindConvolutionBackwardDataAlgorithmEx(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -21,7 +21,6 @@ typedef enum {
 typedef enum {} cudnnActivationMode_t;
 typedef enum {} cudnnConvolutionFwdAlgo_t;
 typedef enum {} cudnnConvolutionFwdPreference_t;
-typedef struct {} cudnnConvolutionFwdAlgoPerf_t;
 typedef enum {} cudnnConvolutionMode_t;
 typedef enum {} cudnnDataType_t;
 typedef enum {} cudnnNanPropagation_t;
@@ -196,10 +195,26 @@ extern "C" {
 
 typedef enum {} cudnnConvolutionBwdDataAlgo_t;
 typedef enum {} cudnnConvolutionBwdDataPreference_t;
-typedef enum {} cudnnConvolutionBwdDataAlgoPerf_t;
 typedef enum {} cudnnConvolutionBwdFilterAlgo_t;
 typedef enum {} cudnnConvolutionBwdFilterPreference_t;
-typedef enum {} cudnnConvolutionBwdFilterAlgoPerf_t;
+typedef struct {
+  cudnnConvolutionFwdAlgo_t algo;
+  cudnnStatus_t status;
+  float time;
+  size_t memory;
+} cudnnConvolutionFwdAlgoPerf_t;
+typedef struct {
+  cudnnConvolutionBwdFilterAlgo_t algo;
+  cudnnStatus_t status;
+  float time;
+  size_t memory;
+} cudnnConvolutionBwdFilterAlgoPerf_t;
+typedef struct {
+  cudnnConvolutionBwdDataAlgo_t algo;
+  cudnnStatus_t status;
+  float time;
+  size_t memory;
+} cudnnConvolutionBwdDataAlgoPerf_t;
 
 cudnnStatus_t cudnnAddTensor_v3(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;


### PR DESCRIPTION
This PR adds cudnn wrappers around FindConvolution* functions.

cuDNN v3 and above support `cudnnFindConvolution*Algorithm`, and cuDNN v5 and above support `cudnnFindConvolution*AlogrithmEx`.

On implementation, I could not find a Cython feature to avoid a flake8 error at https://github.com/yuyu2172/chainer/blob/28eca7525e663ee9f25a6655cfecf1cca6826043/cupy/cuda/cudnn.pxd#L13.

The error is 
```
./cupy/cuda/cudnn.pxd:13:9: E125 continuation line with same indent as next logical line  
```
Basically, the error says that I should not change lines in the middle of an expression. Usually, in Python, there is a workaround, but I could not find any for this cython code.
Also, I needed to change lines because the expression exceeds the 80 characters limit.

I would like to know if it is fine to use NOQA to avoid flake8 error in this case?
I would also like to know if it is possible to avoid the error.
