### PR TITLE
Remove eps argument from fixed_batch_normalization method

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -319,8 +319,7 @@ def batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None,
                                       decay, use_cudnn)(x, gamma, beta)
 
 
-def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5,
-                              use_cudnn=True):
+def fixed_batch_normalization(x, gamma, beta, mean, var, use_cudnn=True):
     """Batch normalization function with fixed statistics.
 
     This is a variant of batch normalization, where the mean and variance
@@ -334,7 +333,6 @@ def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5,
         beta (Variable): Shifting parameter of scaled normalized data.
         mean (Variable): Shifting parameter of input.
         var (Variable): Square of scaling parameter of input.
-        eps (float): Epsilon value for numerical stability.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 
@@ -343,5 +341,5 @@ def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5,
        :class:`links.BatchNormalization`
 
     """
-    return BatchNormalizationFunction(eps, None, None, False, 0.0,
+    return BatchNormalizationFunction(2.0e-5, None, None, False, 0.0,
                                       use_cudnn)(x, gamma, beta, mean, var)

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -136,7 +136,7 @@ class BatchNormalization(link.Link):
             mean = variable.Variable(self.avg_mean, volatile='auto')
             var = variable.Variable(self.avg_var, volatile='auto')
             ret = batch_normalization.fixed_batch_normalization(
-                x, gamma, beta, mean, var, self.eps, self.use_cudnn)
+                x, gamma, beta, mean, var, self.use_cudnn)
         return ret
 
     def start_finetuning(self):

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -110,7 +110,6 @@ class TestFixedBatchNormalization(unittest.TestCase):
         shape = (5, 3) + (2,) * self.ndim
         self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        self.eps = 2e-5
         self.decay = 0.0
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
 
@@ -128,8 +127,7 @@ class TestFixedBatchNormalization(unittest.TestCase):
 
     def check_forward(self, args, use_cudnn=True):
         y = functions.fixed_batch_normalization(
-            *[chainer.Variable(i) for i in args],
-            eps=self.eps, use_cudnn=use_cudnn)
+            *[chainer.Variable(i) for i in args], use_cudnn=use_cudnn)
         self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_normalization(
@@ -156,7 +154,7 @@ class TestFixedBatchNormalization(unittest.TestCase):
         gradient_check.check_backward(
             batch_normalization.BatchNormalizationFunction(
                 mean=None, var=None, train=self.train,
-                decay=self.decay, eps=self.eps),
+                decay=self.decay),
             args, y_grad,  **self.check_backward_options)
 
     @condition.retry(3)


### PR DESCRIPTION
I removed eps argument of fixed_batch_normalization method.

fix #855 