### PR TITLE
Implement array_split with cython and optimize it

### DIFF
--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -6,6 +6,7 @@ from cupy.core import internal  # NOQA
 from cupy.core.core import absolute  # NOQA
 from cupy.core.core import add  # NOQA
 from cupy.core.core import array  # NOQA
+from cupy.core.core import array_split  # NOQA
 from cupy.core.core import ascontiguousarray  # NOQA
 from cupy.core.core import asfortranarray  # NOQA
 from cupy.core.core import bitwise_and  # NOQA

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1825,7 +1825,7 @@ def array_split(ndarray ary, indices_or_sections, int axis):
     if numpy.isscalar(indices_or_sections):
         each_size = (size - 1) // indices_or_sections + 1
         indices = [i * each_size
-                   for i in six.moves.range(1, indices_or_sections)]
+                   for i in range(1, indices_or_sections)]
     else:
         indices = indices_or_sections
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1810,6 +1810,52 @@ cpdef ndarray rollaxis(ndarray a, Py_ssize_t axis, Py_ssize_t start=0):
     return a._transpose(axes)
 
 
+def array_split(ndarray ary, indices_or_sections, int axis):
+
+    cdef int i, ndim, size, each_size, index, prev, offset, stride
+    cdef vector.vector[Py_ssize_t] shape
+
+    ndim = ary.ndim
+    if -ndim > axis or ndim <= axis:
+        raise IndexError('Axis exceeds ndim')
+    if axis < 0:
+        axis += ndim
+    size = ary._shape[axis]
+
+    if numpy.isscalar(indices_or_sections):
+        each_size = (size - 1) // indices_or_sections + 1
+        indices = [i * each_size
+                   for i in six.moves.range(1, indices_or_sections)]
+    else:
+        indices = indices_or_sections
+
+    if len(indices) == 0:
+        return [ary]
+
+    # Make a copy of shape for each view
+    shape = ary._shape
+
+    prev = 0
+    ret = []
+    stride = ary._strides[axis]
+    for index in indices:
+        shape[axis] = index - prev
+        v = ary.view()
+        v.data = ary.data + prev * stride
+        v._set_shape_and_strides(shape, ary._strides)
+        ret.append(v)
+
+        prev = index
+
+    shape[axis] = size - prev
+    v = ary.view()
+    v.data = ary.data + prev * stride
+    v._set_shape_and_strides(shape, ary._strides)
+    ret.append(v)
+
+    return ret
+
+
 cdef class broadcast:
     """Object that performs broadcasting.
 

--- a/cupy/manipulation/split.py
+++ b/cupy/manipulation/split.py
@@ -1,5 +1,4 @@
 import numpy
-import six
 
 from cupy import core
 

--- a/cupy/manipulation/split.py
+++ b/cupy/manipulation/split.py
@@ -1,6 +1,8 @@
 import numpy
 import six
 
+from cupy import core
+
 
 def array_split(ary, indices_or_sections, axis=0):
     """Splits an array into multiple sub arrays along a given axis.
@@ -12,30 +14,7 @@ def array_split(ary, indices_or_sections, axis=0):
     .. seealso:: :func:`cupy.split` for more detail, :func:`numpy.array_split`
 
     """
-    ndim = ary.ndim
-    if -ndim > axis or ndim <= axis:
-        raise IndexError('Axis exceeds ndim')
-    axis %= ndim
-    size = ary.shape[axis]
-
-    if numpy.isscalar(indices_or_sections):
-        each_size = (size - 1) // indices_or_sections + 1
-        indices = [i * each_size
-                   for i in six.moves.range(1, indices_or_sections)]
-    else:
-        indices = indices_or_sections
-
-    if len(indices) == 0:
-        return [ary]
-
-    skip = (slice(None),) * axis
-    ret = []
-    i = 0
-    for index in indices:
-        ret.append(ary[skip + (slice(i, index),)])
-        i = index
-    ret.append(ary[skip + (slice(i, size),)])
-    return ret
+    return core.array_split(ary, indices_or_sections, axis)
 
 
 def dsplit(ary, indices_or_sections):


### PR DESCRIPTION
I optimized array_split method with Cython. The original implementation calls `__getitem__` method many times. I removed this call and made views manually, and it is simple enough.

related to #1492