### PR TITLE
Do not use isinstance to select array module

### DIFF
--- a/chainer/functions/pooling/unpooling_2d.py
+++ b/chainer/functions/pooling/unpooling_2d.py
@@ -1,3 +1,5 @@
+import numpy
+
 from chainer import cuda
 from chainer.functions.pooling import pooling_2d
 from chainer.utils import conv
@@ -43,11 +45,11 @@ class Unpooling2D(pooling_2d.Pooling2D):
         xp = cuda.get_array_module(*x)
         col = xp.tile(x[0][:, :, None, None],
                       (1, 1, self.kh, self.kw, 1, 1))
-        if xp is cuda.cupy:
-            y = conv.col2im_gpu(col, self.sy, self.sx, self.ph, self.pw,
+        if xp is numpy:
+            y = conv.col2im_cpu(col, self.sy, self.sx, self.ph, self.pw,
                                 self.outh, self.outw)
         else:
-            y = conv.col2im_cpu(col, self.sy, self.sx, self.ph, self.pw,
+            y = conv.col2im_gpu(col, self.sy, self.sx, self.ph, self.pw,
                                 self.outh, self.outw)
         return y,
 

--- a/chainer/functions/pooling/unpooling_2d.py
+++ b/chainer/functions/pooling/unpooling_2d.py
@@ -43,7 +43,7 @@ class Unpooling2D(pooling_2d.Pooling2D):
         xp = cuda.get_array_module(*x)
         col = xp.tile(x[0][:, :, None, None],
                       (1, 1, self.kh, self.kw, 1, 1))
-        if isinstance(x[0], cuda.ndarray):
+        if xp is cuda.cupy:
             y = conv.col2im_gpu(col, self.sy, self.sx, self.ph, self.pw,
                                 self.outh, self.outw)
         else:


### PR DESCRIPTION
Generally speaking, `isinstance` should not be used if possible because it is slow in some case. This PR avoid to use it to determine an array module used.