### PR TITLE
Support float array type loc and scale for cupy.random.normal

### DIFF
--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -72,8 +72,9 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
     """Returns an array of normally distributed samples.
 
     Args:
-        loc (float): Mean of the normal distribution.
-        scale (float): Standard deviation of the normal distribution.
+        loc (float or array_like of floats): Mean of the normal distribution.
+        scale (float or array_like of floats):
+            Standard deviation of the normal distribution.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
@@ -86,7 +87,9 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
 
     """
     rs = generator.get_random_state()
-    return rs.normal(loc, scale, size=size, dtype=dtype)
+    if loc.shape == () and scale.shape == ():
+        return rs.normal(loc, scale, size, dtype)
+    return (rs.normal(0, 1, size, dtype) * scale + loc).astype(dtype)
 
 
 def standard_normal(size=None, dtype=float):

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -87,8 +87,6 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
 
     """
     rs = generator.get_random_state()
-    if loc.shape == () and scale.shape == ():
-        return rs.normal(loc, scale, size, dtype)
     return (rs.normal(0, 1, size, dtype) * scale + loc).astype(dtype)
 
 

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -1,16 +1,14 @@
 import unittest
 
-import numpy
-
 import cupy
 from cupy.random import distributions
 from cupy import testing
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(3, 2)],
+    'shape': [(4, 3, 2), (3, 2)],
     'loc_shape': [(), (3, 2)],
-    'scale_shape': [(), (3, 2)]
+    'scale_shape': [(), (3, 2)],
 })
 )
 @testing.gpu
@@ -18,15 +16,16 @@ class TestDistributions(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    def check_distribution(self, dist_func, dtype):
-        loc = cupy.ones(self.loc_shape)
-        scale = cupy.ones(self.scale_shape)
+    def check_distribution(self, dist_func, loc_dtype, scale_dtype, dtype):
+        loc = cupy.ones(self.loc_shape, dtype=loc_dtype)
+        scale = cupy.ones(self.scale_shape, dtype=scale_dtype)
         out = dist_func(loc, scale, self.shape, dtype)
         self.assertEqual(self.shape, out.shape)
         self.assertEqual(out.dtype, dtype)
 
-    def test_normal_float32(self):
-        self.check_distribution(distributions.normal, numpy.float32)
-
-    def test_normal_float64(self):
-        self.check_distribution(distributions.normal, numpy.float64)
+    @cupy.testing.for_float_dtypes('dtype', no_float16=True)
+    @cupy.testing.for_float_dtypes('loc_dtype')
+    @cupy.testing.for_float_dtypes('scale_dtype')
+    def test_normal(self, loc_dtype, scale_dtype, dtype):
+        self.check_distribution(distributions.normal,
+                                loc_dtype, scale_dtype, dtype)

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -1,9 +1,32 @@
 import unittest
 
+import numpy
+
+import cupy
+from cupy.random import distributions
 from cupy import testing
 
 
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2)],
+    'loc_shape': [(), (3, 2)],
+    'scale_shape': [(), (3, 2)]
+})
+)
 @testing.gpu
 class TestDistributions(unittest.TestCase):
 
     _multiprocess_can_split_ = True
+
+    def check_distribution(self, dist_func, dtype):
+        loc = cupy.ones(self.loc_shape)
+        scale = cupy.ones(self.scale_shape)
+        out = dist_func(loc, scale, self.shape, dtype)
+        self.assertEqual(self.shape, out.shape)
+        self.assertEqual(out.dtype, dtype)
+
+    def test_normal_float32(self):
+        self.check_distribution(distributions.normal, numpy.float32)
+
+    def test_normal_float64(self):
+        self.check_distribution(distributions.normal, numpy.float64)


### PR DESCRIPTION
Like numpy.random.normal.

Please see https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.normal.html .