### PR TITLE
Optimize __getitem__ for boolean array indices

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2119,7 +2119,12 @@ cdef _boolean_array_indexing_nth = ElementwiseKernel(
 cpdef ndarray _getitem_mask(ndarray a, ndarray boolean_array):
     a = a.ravel()
     boolean_array = boolean_array.ravel()
-    nth_true_array = scan(boolean_array.astype(int))  # starts with 1
+    if boolean_array.size <= 2 ** 31 - 1:
+        boolean_array_type = numpy.int32
+    else:
+        boolean_array_type = numpy.int64
+    nth_true_array = scan(
+        boolean_array.astype(boolean_array_type))  # starts with 1
 
     n_true = int(nth_true_array[-1])
     out_shape = (n_true,)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2121,7 +2121,7 @@ cpdef ndarray _getitem_mask(ndarray a, ndarray boolean_array):
     boolean_array = boolean_array.ravel()
     nth_true_array = scan(boolean_array.astype(int))  # starts with 1
 
-    n_true = int(nth_true_array.max())
+    n_true = int(nth_true_array[-1])
     out_shape = (n_true,)
     out = ndarray(out_shape, dtype=a.dtype)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1113,7 +1113,7 @@ cdef class ndarray:
                     advanced = True
                 elif issubclass(s.dtype.type, numpy.bool_):
                     if i == 0 and internal.vector_equal(self._shape, s._shape):
-                        return _boolean_array_indexing(self, s)
+                        return _getitem_mask(self, s)
                     else:
                         raise ValueError('Boolean array indexing is supported '
                                          'only for same sized array.')
@@ -2116,7 +2116,7 @@ cdef _boolean_array_indexing_nth = ElementwiseKernel(
     'cupy_boolean_array_indexing_nth')
 
 
-cpdef ndarray _boolean_array_indexing(ndarray a, ndarray boolean_array):
+cpdef ndarray _getitem_mask(ndarray a, ndarray boolean_array):
     a = a.flatten()
     boolean_array = boolean_array.flatten()
     nth_true_array = scan(boolean_array.astype(int)) - 1  # starts with 0

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2117,8 +2117,8 @@ cdef _boolean_array_indexing_nth = ElementwiseKernel(
 
 
 cpdef ndarray _getitem_mask(ndarray a, ndarray boolean_array):
-    a = a.flatten()
-    boolean_array = boolean_array.flatten()
+    a = a.ravel()
+    boolean_array = boolean_array.ravel()
     nth_true_array = scan(boolean_array.astype(int)) - 1  # starts with 0
 
     n_true = int(nth_true_array.max()) + 1

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2112,16 +2112,16 @@ cdef _scatter_add_kernel = ElementwiseKernel(
 cdef _boolean_array_indexing_nth = ElementwiseKernel(
     'T a, bool boolean_array, S nth',
     'raw T out',
-    'if (boolean_array) out[nth] = a',
+    'if (boolean_array) out[nth - 1] = a',
     'cupy_boolean_array_indexing_nth')
 
 
 cpdef ndarray _getitem_mask(ndarray a, ndarray boolean_array):
     a = a.ravel()
     boolean_array = boolean_array.ravel()
-    nth_true_array = scan(boolean_array.astype(int)) - 1  # starts with 0
+    nth_true_array = scan(boolean_array.astype(int))  # starts with 1
 
-    n_true = int(nth_true_array.max()) + 1
+    n_true = int(nth_true_array.max())
     out_shape = (n_true,)
     out = ndarray(out_shape, dtype=a.dtype)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2117,6 +2117,8 @@ cdef _boolean_array_indexing_nth = ElementwiseKernel(
 
 
 cpdef ndarray _getitem_mask(ndarray a, ndarray boolean_array):
+    cdef int n_true
+
     a = a.ravel()
     boolean_array = boolean_array.ravel()
     if boolean_array.size <= 2 ** 31 - 1:


### PR DESCRIPTION
This PR optimizes `__getitem__` when slices contain boolean array.

I did 4 optimizations.
+ stop using flatten and use ravel instead (no DtoD memcpy)
+ avoid unnecessary `cupy_subtract` (one less kernel call)
+ stop calling `cupy.max` on result of scan. The maximum of scan is always stored at the last index.
+ use `numpy.int32` for input and output of scan whenever possible. It is faster to compute than the case when they are `numpy.int64`.

I confirmed that all the optimizations contribute to speed up.


# Benchmark results
You can benchmark speed using the following code.
The average speed of calling a boolean array indexing improved by 6x.
Before optimizations, it took 56.68 ms.
After optimizations, it took 9.38 ms.

All experiments are conducted on CUDA8.0, TitanX Pascal.

```python
import cupy
import numpy as np

n = 2 ** 13
a = cupy.arange(n * n, dtype=np.float32).reshape(n, n)
mask = cupy.array(np.random.choice([True, False], size=(n, n)))

n_dry = 5
n_try = 10
for i in range(n_dry):
    b = a[mask]

times = []
with cupy.cuda.profile():
    for _ in range(n_try):
        start = cupy.cuda.Event()
        end = cupy.cuda.Event()
        start.record()
        b = a[mask]
        end.record()
        end.synchronize()
        time = cupy.cuda.get_elapsed_time(start, end)
        times.append(time)

print('mean={} std={}'.format(np.mean(times), np.std(times)))
```

Here are the results of kernel calls when `n_try=1` for the case with and without the optimizations. 

### with optimizations
```
Time(%)      Time     Calls       Avg       Min       Max  Name                            
 41.12%  3.5233ms         3  1.1744ms  3.9360us  3.3970ms  inclusive_scan_kernel           
 27.85%  2.3864ms         1  2.3864ms  2.3864ms  2.3864ms  cupy_boolean_array_indexing_nth 
 19.11%  1.6374ms         2  818.73us  140.52us  1.4969ms  add_scan_blocked_sum_kernel     
 11.90%  1.0198ms         1  1.0198ms  1.0198ms  1.0198ms  cupy_copy                       
  0.02%  1.4080us         1  1.4080us  1.4080us  1.4080us  [CUDA memcpy DtoH]              
```

### without optimizations
```
Time(%)      Time     Calls       Avg       Min       Max  Name                            
 70.31%  39.517ms         1  39.517ms  39.517ms  39.517ms  cupy_max                        
  6.58%  3.6989ms         3  1.2330ms  3.7120us  3.5922ms  inclusive_scan_kernel           
  5.68%  3.1904ms         2  1.5952ms  133.57us  3.0568ms  add_scan_blocked_sum_kernel     
  5.42%  3.0435ms         1  3.0435ms  3.0435ms  3.0435ms  cupy_subtract                   
  5.31%  2.9871ms         1  2.9871ms  2.9871ms  2.9871ms  cupy_boolean_array_indexing_nth 
  3.35%  1.8840ms         2  942.01us  378.86us  1.5052ms  [CUDA memcpy DtoD]              
  3.35%  1.8810ms         1  1.8810ms  1.8810ms  1.8810ms  cupy_copy                       
  0.00%     896ns         1     896ns     896ns     896ns  [CUDA memcpy DtoH]              
                                                                                           
```