### PR TITLE
Support boolean array indices for scatter_add

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2256,7 +2256,7 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v, int axis=0, op=''):
                           (numpy.int32, numpy.float32,
                            numpy.uint32, numpy.uint64, numpy.ulonglong)):
             raise TypeError(
-                'scatter_add only supports int32, float32, uint32, uint64 as'
+                'scatter_add only supports int32, float32, uint32, uint64 as '
                 'data type')
         _scatter_add_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2124,6 +2124,13 @@ cdef _scatter_update_mask_kernel = ElementwiseKernel(
     'cupy_scatter_update_mask')
 
 
+cdef _scatter_add_mask_kernel = ElementwiseKernel(
+    'raw T v, bool mask, S mask_scanned',
+    'T a',
+    'if (mask) a = a + v[mask_scanned - 1]',
+    'cupy_scatter_add_mask')
+
+
 cdef _boolean_array_indexing_nth = ElementwiseKernel(
     'T a, bool boolean_array, S nth',
     'raw T out',
@@ -2286,6 +2293,8 @@ cpdef _scatter_op_mask_single(ndarray a, ndarray mask, v, int axis, op):
 
     if op == 'update':
         _scatter_update_mask_kernel(v, mask_br, mask_br_scanned, a)
+    elif op == 'add':
+        _scatter_add_mask_kernel(v, mask_br, mask_br_scanned, a)
     else:
         raise ValueError('provided op is not supported')
 

--- a/cupy/ext/scatter.py
+++ b/cupy/ext/scatter.py
@@ -33,7 +33,8 @@ def scatter_add(a, slices, value):
         v (array-like): Values to increment ``a`` at referenced locations.
 
     .. note::
-        It only supports types that are supported by CUDA's atomicAdd.
+        It only supports types that are supported by CUDA's atomicAdd when
+        an integer array is included in ``slices``.
         The supported types are ``numpy.float32``, ``numpy.int32``,
         ``numpy.uint32``, ``numpy.uint64`` and ``numpy.ulonglong``.
 

--- a/cupy/ext/scatter.py
+++ b/cupy/ext/scatter.py
@@ -12,6 +12,9 @@ def scatter_add(a, slices, value):
     Note that just like an array indexing, negative indices are interpreted as
     counting from the end of an array.
 
+    Also note that :func:`scatter_add` behaves identically
+    to :func:`numpy.add.at`.
+
     Example
     -------
     >>> import numpy
@@ -41,6 +44,8 @@ def scatter_add(a, slices, value):
     .. note::
         :func:`scatter_add` does not raise an error when indices exceed size of
         axes. Instead, it wraps indices.
+
+    .. seealso:: :func:`numpy.add.at`.
 
     """
     a.scatter_add(slices, value)

--- a/cupy/ext/scatter.py
+++ b/cupy/ext/scatter.py
@@ -26,7 +26,7 @@ def scatter_add(a, slices, value):
     Args:
         a (ndarray): An array that gets added.
         slices: It is integer, slices, ellipsis, numpy.newaxis,
-            integer array-like or tuple of them.
+            integer array-like, boolean array-like or tuple of them.
             It works for slices used for
             :func:`cupy.ndarray.__getitem__` and
             :func:`cupy.ndarray.__setitem__`.


### PR DESCRIPTION
merge after #2099

This PR supports boolean array indices for `cupy.scatter_add`.