### PR TITLE
Move asfortranarray to core

### DIFF
--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -7,6 +7,7 @@ from cupy.core.core import absolute  # NOQA
 from cupy.core.core import add  # NOQA
 from cupy.core.core import array  # NOQA
 from cupy.core.core import ascontiguousarray  # NOQA
+from cupy.core.core import asfortranarray  # NOQA
 from cupy.core.core import bitwise_and  # NOQA
 from cupy.core.core import bitwise_or  # NOQA
 from cupy.core.core import bitwise_xor  # NOQA

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1759,7 +1759,7 @@ cpdef ndarray asfortranarray(ndarray a, dtype=None):
     newarray = ndarray(a.shape, dtype, order='F')
     if (a.flags.c_contiguous and
             (a.dtype == numpy.float32 or a.dtype == numpy.float64) and
-            a.ndim == 2 and dtype is None):
+            a.ndim == 2):
         m, n = a.shape
         if a.dtype == numpy.float32:
             cuda.cublas.sgeam(

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1759,7 +1759,7 @@ cpdef ndarray asfortranarray(ndarray a, dtype=None):
     newarray = ndarray(a.shape, dtype, order='F')
     if (a.flags.c_contiguous and
             (a.dtype == numpy.float32 or a.dtype == numpy.float64) and
-            a.ndim == 2):
+            a.ndim == 2 and dtype == a.dtype):
         m, n = a.shape
         if a.dtype == numpy.float32:
             cuda.cublas.sgeam(

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1742,6 +1742,45 @@ cpdef ndarray ascontiguousarray(ndarray a, dtype=None):
     elementwise_copy(a, newarray)
     return newarray
 
+
+cpdef ndarray asfortranarray(ndarray a, dtype=None):
+    cdef ndarray newarray
+    cdef int m, n
+
+    if dtype is None:
+        if a._f_contiguous:
+            return a
+        dtype = a.dtype
+    else:
+        dtype = numpy.dtype(dtype)
+        if a._f_contiguous and dtype == a.dtype:
+            return a
+
+    newarray = ndarray(a.shape, dtype, order='F')
+    if (a.flags.c_contiguous and
+            (a.dtype == numpy.float32 or a.dtype == numpy.float64) and
+            a.ndim == 2 and dtype is None):
+        m, n = a.shape
+        if a.dtype == numpy.float32:
+            cuda.cublas.sgeam(
+                cuda.Device().cublas_handle,
+                1,  # transpose a
+                1,  # transpose newarray
+                m, n, 1., a.data.ptr, n, 0., a.data.ptr, n,
+                newarray.data.ptr, m)
+        elif a.dtype == numpy.float64:
+            cuda.cublas.dgeam(
+                cuda.Device().cublas_handle,
+                1,  # transpose a
+                1,  # transpose newarray
+                m, n, 1., a.data.ptr, n, 0., a.data.ptr, n,
+                newarray.data.ptr, m)
+        return newarray
+    else:
+        elementwise_copy(a, newarray)
+        return newarray
+
+
 # -----------------------------------------------------------------------------
 # Array manipulation routines
 # -----------------------------------------------------------------------------

--- a/cupy/manipulation/kind.py
+++ b/cupy/manipulation/kind.py
@@ -1,6 +1,7 @@
 import numpy
 
 import cupy
+from cupy import core
 
 
 # TODO(okuta): Implement asfarray
@@ -20,30 +21,7 @@ def asfortranarray(a, dtype=None):
     .. seealso:: :func:`numpy.asfortranarray`
 
     """
-    ret = cupy.empty(a.shape[::-1], a.dtype if dtype is None else dtype).T
-    if (a.flags.c_contiguous and
-            (a.dtype == numpy.float32 or a.dtype == numpy.float64) and
-            a.ndim == 2 and
-            dtype is None):
-        m, n = a.shape
-        if a.dtype == numpy.float32:
-            cupy.cuda.cublas.sgeam(
-                cupy.cuda.Device().cublas_handle,
-                1,  # transpose a
-                1,  # transpose ret
-                m, n, 1., a.data.ptr, n, 0., a.data.ptr, n,
-                ret.data.ptr, m)
-        elif a.dtype == numpy.float64:
-            cupy.cuda.cublas.dgeam(
-                cupy.cuda.Device().cublas_handle,
-                1,  # transpose a
-                1,  # transpose ret
-                m, n, 1., a.data.ptr, n, 0., a.data.ptr, n,
-                ret.data.ptr, m)
-        return ret
-    else:
-        ret[...] = a
-        return ret
+    return core.asfortranarray(a, dtype)
 
 
 # TODO(okuta): Implement asarray_chkfinite

--- a/cupy/manipulation/kind.py
+++ b/cupy/manipulation/kind.py
@@ -1,6 +1,3 @@
-import numpy
-
-import cupy
 from cupy import core
 
 


### PR DESCRIPTION
This PR moves`cupy.asfortranarray` under cupy.core` just like `cupy.ascontiguousarray`.
Also, the function now detects the case when copy is not necessary. `cupy.ascontiguousarray` does this conditional handling too.