### PR TITLE
Add order option to cupy.ndarray.copy

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -305,7 +305,8 @@ cdef class ndarray:
 
         Args:
             order ({'C', 'F'}): Row-major (C-style) or column-major
-                (Fortran-style) order.
+                (Fortran-style) order. This function currently does not
+                support order 'A' and 'K'.
 
         .. seealso::
            :func:`cupy.copy` for full documentation,

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -91,7 +91,8 @@ def copy(a, order='C'):
     Args:
         a (cupy.ndarray): The source array.
         order ({'C', 'F'}): Row-major (C-style) or column-major
-            (Fortran-style) order.
+            (Fortran-style) order. This function currently does not
+            support order 'A' and 'K'.
 
     Returns:
         cupy.ndarray: The copy of ``a`` on the current device.

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -81,7 +81,7 @@ def ascontiguousarray(a, dtype=None):
 # TODO(okuta): Implement asmatrix
 
 
-def copy(a):
+def copy(a, order='C'):
     """Creates a copy of a given array on the current device.
 
     This function allocates the new array on the current device. If the given
@@ -90,6 +90,8 @@ def copy(a):
 
     Args:
         a (cupy.ndarray): The source array.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: The copy of ``a`` on the current device.
@@ -100,8 +102,8 @@ def copy(a):
     # If the current device is different from the device of ``a``, then this
     # function allocates a new array on the current device, and copies the
     # contents over the devices.
-    # TODO(beam2d): Support ordering option
-    return a.copy()
+    # TODO(beam2d): Support ordering option 'A' and 'K'
+    return a.copy(order=order)
 
 
 # TODO(okuta): Implement frombuffer

--- a/tests/cupy_tests/core_tests/test_elementwise.py
+++ b/tests/cupy_tests/core_tests/test_elementwise.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 import cupy
 from cupy import core
 from cupy import cuda
@@ -30,14 +32,26 @@ class TestElementwise(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.check_copy(dtype, 0, 1)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_copy_zero_sized_array1(self, xp, dtype):
+    def test_copy_zero_sized_array1(self, xp, dtype, order):
         src = xp.empty((0,), dtype=dtype)
-        return xp.copy(src)
+        return xp.copy(src, order=order)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_copy_zero_sized_array2(self, xp, dtype):
+    def test_copy_zero_sized_array2(self, xp, dtype, order):
         src = xp.empty((1, 0, 2), dtype=dtype)
-        return xp.copy(src)
+        return xp.copy(src, order=order)
+
+    @testing.for_CF_orders()
+    def test_copy_orders(self, order):
+        a = cupy.empty((2, 3, 4))
+        b = cupy.copy(a, order)
+
+        a_cpu = numpy.empty((2, 3, 4))
+        b_cpu = numpy.copy(a_cpu, order)
+
+        self.assertEqual(b.strides, b_cpu.strides)

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -62,19 +62,21 @@ class TestFromData(unittest.TestCase):
         b = cupy.ascontiguousarray(a)
         self.assertIs(a, b)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_copy(self, xp, dtype):
+    def test_copy(self, xp, dtype, order):
         a = xp.zeros((2, 3, 4), dtype=dtype)
-        b = a.copy()
+        b = a.copy(order=order)
         a[1] = 1
         return b
 
     @testing.multi_gpu(2)
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
-    def test_copy_multigpu(self, dtype):
+    def test_copy_multigpu(self, dtype, order):
         with cuda.Device(0):
             src = cupy.random.uniform(-1, 1, (2, 3)).astype(dtype)
         with cuda.Device(1):
-            dst = src.copy()
+            dst = src.copy(order)
         testing.assert_allclose(src, dst, rtol=0, atol=0)


### PR DESCRIPTION
merge after #2176.
This PR adds order option to `cupy.ndarray.copy`.