### PR TITLE
Add training mode

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -84,6 +84,7 @@ def get_function_hooks():
 
 global_config.debug = bool(int(os.environ.get('CHAINER_DEBUG', '0')))
 global_config.enable_backprop = True
+global_config.train = True
 global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
 
 

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -104,9 +104,13 @@ def using_config(name, value, config=config):
     if hasattr(config._local, name):
         old_value = getattr(config, name)
         setattr(config, name, value)
-        yield
-        setattr(config, name, old_value)
+        try:
+            yield
+        finally:
+            setattr(config, name, old_value)
     else:
         setattr(config, name, value)
-        yield
-        delattr(config, name)
+        try:
+            yield
+        finally:
+            delattr(config, name)

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -6,6 +6,7 @@ import time
 import numpy
 import six
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.functions.activation import lstm
@@ -119,9 +120,8 @@ def _split(inputs, pos):
 
 class NStepLSTM(function.Function):
 
-    def __init__(self, n_layers, states, train=True):
+    def __init__(self, n_layers, states):
         self.n_layers = n_layers
-        self.train = train
         self.states = states
 
     def check_type_forward(self, in_types):
@@ -244,7 +244,7 @@ class NStepLSTM(function.Function):
         workspace = cuda.cupy.empty((work_size,), dtype='b')
         self.workspace = workspace
 
-        if not self.train:
+        if not configuration.config.train:
             libcudnn.RNNForwardInference(
                 handle, rnn_desc.value, length,
                 c_x_descs.data, xs.data.ptr, hx_desc.value, hx.data.ptr,
@@ -368,8 +368,7 @@ def _stack_weight(ws):
 
 
 def n_step_lstm(
-        n_layers, dropout_ratio, hx, cx, ws, bs, xs, train=True,
-        use_cudnn=True):
+        n_layers, dropout_ratio, hx, cx, ws, bs, xs, use_cudnn=True):
     """Stacked Long Short-Term Memory function for sequence inputs.
 
     This function calculates stacked LSTM with sequences. This function gets
@@ -431,7 +430,6 @@ def n_step_lstm(
             of :func:`~chainer.Variable` holding sequence.
             So ``xs`` needs to satisfy
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.
-        train (bool): If ``True``, this function executes dropout.
         use_cudnn (bool): If ``True``, this function uses cuDNN if available.
 
     Returns:
@@ -463,7 +461,7 @@ def n_step_lstm(
             itertools.chain.from_iterable(ws),
             itertools.chain.from_iterable(bs),
             xs))
-        rnn = NStepLSTM(n_layers, states, train=train)
+        rnn = NStepLSTM(n_layers, states)
         ret = rnn(*inputs)
         hy, cy = ret[:2]
         ys = ret[2:]
@@ -494,8 +492,8 @@ def n_step_lstm(
                 else:
                     h_rest = None
 
-                x = dropout.dropout(x, ratio=dropout_ratio, train=train)
-                h = dropout.dropout(h, ratio=dropout_ratio, train=train)
+                x = dropout.dropout(x, ratio=dropout_ratio)
+                h = dropout.dropout(h, ratio=dropout_ratio)
                 lstm_in = linear.linear(x, xws[layer], xbs[layer]) + \
                     linear.linear(h, hws[layer], hbs[layer])
 

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check
@@ -32,7 +33,7 @@ class Dropout(function.Function):
         return gy[0] * self.mask,
 
 
-def dropout(x, ratio=.5, train=True):
+def dropout(x, ratio=.5):
     """Drops elements of input variable randomly.
 
     This function drops input elements randomly with probability ``ratio`` and
@@ -42,7 +43,6 @@ def dropout(x, ratio=.5, train=True):
     Args:
         x (~chainer.Variable): Input variable.
         ratio (float): Dropout ratio.
-        train (bool): If ``True``, executes dropout. Otherwise, does nothing.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -51,6 +51,6 @@ def dropout(x, ratio=.5, train=True):
     co-adaptation of feature detectors <http://arxiv.org/abs/1207.0580>`_.
 
     """
-    if train:
+    if configuration.config.train:
         return Dropout(ratio)(x)
     return x

--- a/chainer/functions/noise/zoneout.py
+++ b/chainer/functions/noise/zoneout.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check
@@ -33,7 +34,7 @@ class Zoneout(function.Function):
         return gy[0] * self.flag_h, gy[0] * self.flag_x,
 
 
-def zoneout(h, x, ratio=.5, train=True):
+def zoneout(h, x, ratio=.5):
     """Drops elements of input variable and sets to previous variable randomly.
 
     This function drops input elements randomly with probability ``ratio`` and
@@ -44,7 +45,6 @@ def zoneout(h, x, ratio=.5, train=True):
         h (~chainer.Variable): Previous variable.
         x (~chainer.Variable): Input variable.
         ratio (float): Zoneout ratio.
-        train (bool): If ``True``, executes zoneout. Otherwise, return x.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -53,6 +53,6 @@ def zoneout(h, x, ratio=.5, train=True):
     Activations <http://arxiv.org/abs/1606.01305>`_.
 
     """
-    if train:
+    if configuration.config.train:
         return Zoneout(ratio)(h, x)
     return x

--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer.functions.activation import relu
 from chainer.functions.array import concat
 from chainer.functions.pooling import average_pooling_2d
@@ -39,10 +40,6 @@ class InceptionBN(link.Chain):
             ``~batch_normalization.BatchNormalization``.
 
     .. seealso:: :class:`Inception`
-
-    Attributes:
-        train (bool): If ``True``, then batch normalization layers are used in
-            training mode. If ``False``, they are used in testing mode.
 
     """
 
@@ -96,25 +93,22 @@ class InceptionBN(link.Chain):
         if pooltype != 'max' and pooltype != 'avg':
             raise NotImplementedError()
 
-        self.train = True
-
     def __call__(self, x):
-        test = not self.train
         outs = []
 
         if self.out1 > 0:
             h1 = self.conv1(x)
-            h1 = self.conv1n(h1, test=test)
+            h1 = self.conv1n(h1)
             h1 = relu.relu(h1)
             outs.append(h1)
 
-        h3 = relu.relu(self.proj3n(self.proj3(x), test=test))
-        h3 = relu.relu(self.conv3n(self.conv3(h3), test=test))
+        h3 = relu.relu(self.proj3n(self.proj3(x)))
+        h3 = relu.relu(self.conv3n(self.conv3(h3)))
         outs.append(h3)
 
-        h33 = relu.relu(self.proj33n(self.proj33(x), test=test))
-        h33 = relu.relu(self.conv33an(self.conv33a(h33), test=test))
-        h33 = relu.relu(self.conv33bn(self.conv33b(h33), test=test))
+        h33 = relu.relu(self.proj33n(self.proj33(x)))
+        h33 = relu.relu(self.conv33an(self.conv33a(h33)))
+        h33 = relu.relu(self.conv33bn(self.conv33b(h33)))
         outs.append(h33)
 
         if self.pooltype == 'max':
@@ -124,7 +118,7 @@ class InceptionBN(link.Chain):
             p = average_pooling_2d.average_pooling_2d(x, 3, stride=self.stride,
                                                       pad=1)
         if self.proj_pool is not None:
-            p = relu.relu(self.poolpn(self.poolp(p), test=test))
+            p = relu.relu(self.poolpn(self.poolp(p)))
         outs.append(p)
 
         y = concat.concat(outs, axis=1)

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -70,7 +70,7 @@ class NStepLSTM(link.ChainList):
         self.dropout = dropout
         self.use_cudnn = use_cudnn
 
-    def __call__(self, hx, cx, xs, train=True):
+    def __call__(self, hx, cx, xs):
         """Calculate all hidden states and cell states.
 
         Args:
@@ -93,7 +93,7 @@ class NStepLSTM(link.ChainList):
 
         hy, cy, trans_y = rnn.n_step_lstm(
             self.n_layers, self.dropout, hx, cx, ws, bs, trans_x,
-            train=train, use_cudnn=self.use_cudnn)
+            use_cudnn=self.use_cudnn)
 
         hy = permutate.permutate(hy, indices, axis=1, inv=True)
         cy = permutate.permutate(cy, indices, axis=1, inv=True)

--- a/chainer/links/connection/zoneoutlstm.py
+++ b/chainer/links/connection/zoneoutlstm.py
@@ -15,8 +15,7 @@ from chainer import variable
 
 class StatefulZoneoutLSTM(link.Chain):
 
-    def __init__(self, in_size, out_size,
-                 c_ratio=0.5, h_ratio=0.5, train=True):
+    def __init__(self, in_size, out_size, c_ratio=0.5, h_ratio=0.5):
         super(StatefulZoneoutLSTM, self).__init__(
             upward=linear.Linear(in_size, 4 * out_size),
             lateral=linear.Linear(out_size, 4 * out_size, nobias=True),
@@ -24,7 +23,6 @@ class StatefulZoneoutLSTM(link.Chain):
         self.state_size = out_size
         self.c_ratio = c_ratio
         self.h_ratio = h_ratio
-        self.train = train
         self.reset_state()
 
     def to_cpu(self):
@@ -111,8 +109,8 @@ class StatefulZoneoutLSTM(link.Chain):
         o = reshape.reshape(o, (len(o.data), self.state_size))
 
         c_tmp = tanh.tanh(a) * sigmoid.sigmoid(i) + sigmoid.sigmoid(f) * self.c
-        self.c = zoneout.zoneout(self.c, c_tmp, self.c_ratio, self.train)
+        self.c = zoneout.zoneout(self.c, c_tmp, self.c_ratio)
         self.h = zoneout.zoneout(self.h,
                                  sigmoid.sigmoid(o) * tanh.tanh(c_tmp),
-                                 self.h_ratio, self.train)
+                                 self.h_ratio)
         return self.h

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -127,13 +127,12 @@ class ResNet50Layers(link.Chain):
         _transfer_resnet50(caffemodel, chainermodel)
         npz.save_npz(path_npz, chainermodel, compression=False)
 
-    def __call__(self, x, layers=['prob'], test=True):
+    def __call__(self, x, layers=['prob']):
         """Computes all the feature maps specified by ``layers``.
 
         Args:
             x (~chainer.Variable): Input variable.
             layers (list of str): The list of layer names you want to extract.
-            test (bool): If ``True``, BarchNormalization runs in test mode.
 
         Returns:
             Dictionary of ~chainer.Variable: A directory in which
@@ -149,18 +148,14 @@ class ResNet50Layers(link.Chain):
             if len(target_layers) == 0:
                 break
             for func in funcs:
-                if isinstance(func, BatchNormalization) or \
-                        isinstance(func, BuildingBlock):
-                    h = func(h, test=test)
-                else:
-                    h = func(h)
+                h = func(h)
             if key in target_layers:
                 activations[key] = h
                 target_layers.remove(key)
         return activations
 
     def extract(self, images, layers=['pool5'], size=(224, 224),
-                test=True, volatile=flag.OFF):
+                volatile=flag.OFF):
         """Extracts all the feature maps of given images.
 
         The difference of directly executing ``__call__`` is that
@@ -176,7 +171,6 @@ class ResNet50Layers(link.Chain):
                 an input of CNN. All the given images are not resized
                 if this argument is ``None``, but the resolutions of
                 all the images should be the same.
-            test (bool): If ``True``, BatchNormalization runs in test mode.
             volatile (~chainer.Flag): Volatility flag used for input variables.
 
         Returns:
@@ -188,7 +182,7 @@ class ResNet50Layers(link.Chain):
 
         x = concat_examples([prepare(img, size=size) for img in images])
         x = Variable(self.xp.asarray(x), volatile=volatile)
-        return self(x, layers=layers, test=test)
+        return self(x, layers=layers)
 
     def predict(self, images, oversample=True):
         """Computes all the probabilities of given images.
@@ -296,9 +290,9 @@ class BuildingBlock(link.Chain):
         super(BuildingBlock, self).__init__(**dict(links))
         self.forward = links
 
-    def __call__(self, x, test=True):
+    def __call__(self, x):
         for name, func in self.forward:
-            x = func(x, test=test)
+            x = func(x)
         return x
 
 
@@ -336,11 +330,11 @@ class BottleneckA(link.Chain):
             bn4=BatchNormalization(out_channels),
         )
 
-    def __call__(self, x, test=True):
-        h1 = relu(self.bn1(self.conv1(x), test=test))
-        h1 = relu(self.bn2(self.conv2(h1), test=test))
-        h1 = self.bn3(self.conv3(h1), test=test)
-        h2 = self.bn4(self.conv4(x), test=test)
+    def __call__(self, x):
+        h1 = relu(self.bn1(self.conv1(x)))
+        h1 = relu(self.bn2(self.conv2(h1)))
+        h1 = self.bn3(self.conv3(h1))
+        h2 = self.bn4(self.conv4(x))
         return relu(h1 + h2)
 
 
@@ -371,10 +365,10 @@ class BottleneckB(link.Chain):
             bn3=BatchNormalization(in_channels),
         )
 
-    def __call__(self, x, test=True):
-        h = relu(self.bn1(self.conv1(x), test=test))
-        h = relu(self.bn2(self.conv2(h), test=test))
-        h = self.bn3(self.conv3(h), test=test)
+    def __call__(self, x):
+        h = relu(self.bn1(self.conv1(x)))
+        h = relu(self.bn2(self.conv2(h)))
+        h = self.bn3(self.conv3(h))
         return relu(h + x)
 
 

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -154,13 +154,12 @@ class VGG16Layers(link.Chain):
         caffemodel = CaffeFunction(path_caffemodel)
         npz.save_npz(path_npz, caffemodel, compression=False)
 
-    def __call__(self, x, layers=['prob'], test=True):
+    def __call__(self, x, layers=['prob']):
         """Computes all the feature maps specified by ``layers``.
 
         Args:
             x (~chainer.Variable): Input variable.
             layers (list of str): The list of layer names you want to extract.
-            test (bool): If ``True``, dropout runs in test mode.
 
         Returns:
             Dictionary of ~chainer.Variable: A directory in which
@@ -176,17 +175,14 @@ class VGG16Layers(link.Chain):
             if len(target_layers) == 0:
                 break
             for func in funcs:
-                if func is dropout:
-                    h = func(h, train=not test)
-                else:
-                    h = func(h)
+                h = func(h)
             if key in target_layers:
                 activations[key] = h
                 target_layers.remove(key)
         return activations
 
     def extract(self, images, layers=['fc7'], size=(224, 224),
-                test=True, volatile=flag.OFF):
+                volatile=flag.OFF):
         """Extracts all the feature maps of given images.
 
         The difference of directly executing ``__call__`` is that
@@ -202,7 +198,6 @@ class VGG16Layers(link.Chain):
                 an input of CNN. All the given images are not resized
                 if this argument is ``None``, but the resolutions of
                 all the images should be the same.
-            test (bool): If ``True``, dropout runs in test mode.
             volatile (~chainer.Flag): Volatility flag used for input variables.
 
         Returns:
@@ -214,7 +209,7 @@ class VGG16Layers(link.Chain):
 
         x = concat_examples([prepare(img, size=size) for img in images])
         x = Variable(self.xp.asarray(x), volatile=volatile)
-        return self(x, layers=layers, test=test)
+        return self(x, layers=layers)
 
     def predict(self, images, oversample=True):
         """Computes all the probabilities of given images.

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -2,6 +2,7 @@ import copy
 
 import six
 
+from chainer import configuration
 from chainer.dataset import convert
 from chainer.dataset import iterator as iterator_module
 from chainer import link
@@ -38,7 +39,8 @@ class Evaluator(extension.Extension):
     overriding the :meth:`evaluate` method. In latter case, users have to
     create and handle a reporter object manually. Users also have to copy the
     iterators before using them, in order to reuse them at the next time of
-    evaluation.
+    evaluation. In both cases, the functions are called in testing mode
+    (i.e., ``chainer.config.train`` is set to false).
 
     This extension is called at the end of each epoch by default.
 
@@ -131,7 +133,8 @@ class Evaluator(extension.Extension):
                                    target.namedlinks(skipself=True))
 
         with reporter:
-            result = self.evaluate()
+            with configuration.using_config('train', False):
+                result = self.evaluate()
 
         reporter_module.report(result)
         return result

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -40,7 +40,7 @@ class Evaluator(extension.Extension):
     create and handle a reporter object manually. Users also have to copy the
     iterators before using them, in order to reuse them at the next time of
     evaluation. In both cases, the functions are called in testing mode
-    (i.e., ``chainer.config.train`` is set to false).
+    (i.e., ``chainer.config.train`` is set to ``False``).
 
     This extension is called at the end of each epoch by default.
 

--- a/examples/cifar/models/VGG.py
+++ b/examples/cifar/models/VGG.py
@@ -29,9 +29,9 @@ class Block(chainer.Chain):
             bn=L.BatchNormalization(out_channels)
         )
 
-    def __call__(self, x, train=True):
+    def __call__(self, x):
         h = self.conv(x)
-        h = self.bn(h, test=not train)
+        h = self.bn(h)
         return F.relu(h)
 
 
@@ -78,48 +78,47 @@ class VGG(chainer.Chain):
             bn_fc1=L.BatchNormalization(512),
             fc2=L.Linear(None, class_labels, nobias=True)
         )
-        self.train = True
 
     def __call__(self, x):
         # 64 channel blocks:
-        h = self.block1_1(x, self.train)
-        h = F.dropout(h, ratio=0.3, train=self.train)
-        h = self.block1_2(h, self.train)
+        h = self.block1_1(x)
+        h = F.dropout(h, ratio=0.3)
+        h = self.block1_2(h)
         h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 128 channel blocks:
-        h = self.block2_1(h, self.train)
-        h = F.dropout(h, ratio=0.4, train=self.train)
-        h = self.block2_2(h, self.train)
+        h = self.block2_1(h)
+        h = F.dropout(h, ratio=0.4)
+        h = self.block2_2(h)
         h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 256 channel blocks:
-        h = self.block3_1(h, self.train)
-        h = F.dropout(h, ratio=0.4, train=self.train)
-        h = self.block3_2(h, self.train)
-        h = F.dropout(h, ratio=0.4, train=self.train)
-        h = self.block3_3(h, self.train)
+        h = self.block3_1(h)
+        h = F.dropout(h, ratio=0.4)
+        h = self.block3_2(h)
+        h = F.dropout(h, ratio=0.4)
+        h = self.block3_3(h)
         h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 512 channel blocks:
-        h = self.block4_1(h, self.train)
-        h = F.dropout(h, ratio=0.4, train=self.train)
-        h = self.block4_2(h, self.train)
-        h = F.dropout(h, ratio=0.4, train=self.train)
-        h = self.block4_3(h, self.train)
+        h = self.block4_1(h)
+        h = F.dropout(h, ratio=0.4)
+        h = self.block4_2(h)
+        h = F.dropout(h, ratio=0.4)
+        h = self.block4_3(h)
         h = F.max_pooling_2d(h, ksize=2, stride=2)
 
         # 512 channel blocks:
-        h = self.block5_1(h, self.train)
-        h = F.dropout(h, ratio=0.4, train=self.train)
-        h = self.block5_2(h, self.train)
-        h = F.dropout(h, ratio=0.4, train=self.train)
-        h = self.block5_3(h, self.train)
+        h = self.block5_1(h)
+        h = F.dropout(h, ratio=0.4)
+        h = self.block5_2(h)
+        h = F.dropout(h, ratio=0.4)
+        h = self.block5_3(h)
         h = F.max_pooling_2d(h, ksize=2, stride=2)
 
-        h = F.dropout(h, ratio=0.5, train=self.train)
+        h = F.dropout(h, ratio=0.5)
         h = self.fc1(h)
-        h = self.bn_fc1(h, test=not self.train)
+        h = self.bn_fc1(h)
         h = F.relu(h)
-        h = F.dropout(h, ratio=0.5, train=self.train)
+        h = F.dropout(h, ratio=0.5)
         return self.fc2(h)

--- a/examples/cifar/train_cifar.py
+++ b/examples/cifar/train_cifar.py
@@ -12,16 +12,6 @@ from chainer.datasets import get_cifar100
 import models.VGG
 
 
-class TestModeEvaluator(extensions.Evaluator):
-
-    def evaluate(self):
-        model = self.get_target('main')
-        model.train = False
-        ret = super(TestModeEvaluator, self).evaluate()
-        model.train = True
-        return ret
-
-
 def main():
     parser = argparse.ArgumentParser(description='Chainer CIFAR example:')
     parser.add_argument('--dataset', '-d', default='cifar10',
@@ -73,7 +63,7 @@ def main():
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
 
     # Evaluate the model with the test dataset for each epoch
-    trainer.extend(TestModeEvaluator(test_iter, model, device=args.gpu))
+    trainer.extend(extensions.Evaluator(test_iter, model, device=args.gpu))
 
     # Reduce the learning rate by half every 25 epochs.
     trainer.extend(extensions.ExponentialShift('lr', 0.5),

--- a/examples/dcgan/updater.py
+++ b/examples/dcgan/updater.py
@@ -38,11 +38,11 @@ class DCGANUpdater(chainer.training.StandardUpdater):
         gen, dis = self.gen, self.dis
         batchsize = len(batch)
 
-        y_real = dis(x_real, test=False)
+        y_real = dis(x_real)
 
         z = Variable(xp.asarray(gen.make_hidden(batchsize)))
-        x_fake = gen(z, test=False)
-        y_fake = dis(x_fake, test=False)
+        x_fake = gen(z)
+        y_fake = dis(x_fake)
 
         dis_optimizer.update(self.loss_dis, dis, y_fake, y_real)
         gen_optimizer.update(self.loss_gen, gen, y_fake)

--- a/examples/dcgan/visualize.py
+++ b/examples/dcgan/visualize.py
@@ -17,7 +17,8 @@ def out_generated_image(gen, dis, rows, cols, seed, dst):
         n_images = rows * cols
         xp = gen.xp
         z = Variable(xp.asarray(gen.make_hidden(n_images)))
-        x = gen(z, test=True)
+        with chainer.using_config('train', False):
+            x = gen(z)
         x = chainer.cuda.to_cpu(x.data)
         np.random.seed()
 

--- a/examples/imagenet/alex.py
+++ b/examples/imagenet/alex.py
@@ -23,7 +23,6 @@ class Alex(chainer.Chain):
             fc7=L.Linear(None, 4096),
             fc8=L.Linear(None, 1000),
         )
-        self.train = True
 
     def __call__(self, x, t):
         h = F.max_pooling_2d(F.local_response_normalization(
@@ -33,8 +32,8 @@ class Alex(chainer.Chain):
         h = F.relu(self.conv3(h))
         h = F.relu(self.conv4(h))
         h = F.max_pooling_2d(F.relu(self.conv5(h)), 3, stride=2)
-        h = F.dropout(F.relu(self.fc6(h)), train=self.train)
-        h = F.dropout(F.relu(self.fc7(h)), train=self.train)
+        h = F.dropout(F.relu(self.fc6(h)))
+        h = F.dropout(F.relu(self.fc7(h)))
         h = self.fc8(h)
 
         loss = F.softmax_cross_entropy(h, t)
@@ -64,7 +63,6 @@ class AlexFp16(Alex):
             fc7=L.Linear(None, 4096, initialW=W, bias=bias),
             fc8=L.Linear(None, 1000, initialW=W, bias=bias),
         )
-        self.train = True
 
     def __call__(self, x, t):
         return Alex.__call__(self, F.cast(x, self.dtype), t)

--- a/examples/imagenet/googlenet.py
+++ b/examples/imagenet/googlenet.py
@@ -31,7 +31,6 @@ class GoogLeNet(chainer.Chain):
             loss2_fc1=L.Linear(None, 1024),
             loss2_fc2=L.Linear(None, 1000)
         )
-        self.train = True
 
     def __call__(self, x, t):
         h = F.relu(self.conv1(x))
@@ -69,7 +68,7 @@ class GoogLeNet(chainer.Chain):
         h = self.inc5b(h)
 
         h = F.average_pooling_2d(h, 7, stride=1)
-        h = self.loss3_fc(F.dropout(h, 0.4, train=self.train))
+        h = self.loss3_fc(F.dropout(h, 0.4))
         loss3 = F.softmax_cross_entropy(h, t)
 
         loss = 0.3 * (loss1 + loss2) + loss3

--- a/examples/imagenet/googlenetbn.py
+++ b/examples/imagenet/googlenetbn.py
@@ -42,33 +42,12 @@ class GoogLeNetBN(chainer.Chain):
             normb2=L.BatchNormalization(1024),
             outb=L.Linear(None, 1000),
         )
-        self._train = True
-
-    @property
-    def train(self):
-        return self._train
-
-    @train.setter
-    def train(self, value):
-        self._train = value
-        self.inc3a.train = value
-        self.inc3b.train = value
-        self.inc3c.train = value
-        self.inc4a.train = value
-        self.inc4b.train = value
-        self.inc4c.train = value
-        self.inc4d.train = value
-        self.inc4e.train = value
-        self.inc5a.train = value
-        self.inc5b.train = value
 
     def __call__(self, x, t):
-        test = not self.train
-
         h = F.max_pooling_2d(
-            F.relu(self.norm1(self.conv1(x), test=test)),  3, stride=2, pad=1)
+            F.relu(self.norm1(self.conv1(x))),  3, stride=2, pad=1)
         h = F.max_pooling_2d(
-            F.relu(self.norm2(self.conv2(h), test=test)), 3, stride=2, pad=1)
+            F.relu(self.norm2(self.conv2(h))), 3, stride=2, pad=1)
 
         h = self.inc3a(h)
         h = self.inc3b(h)
@@ -76,8 +55,8 @@ class GoogLeNetBN(chainer.Chain):
         h = self.inc4a(h)
 
         a = F.average_pooling_2d(h, 5, stride=3)
-        a = F.relu(self.norma(self.conva(a), test=test))
-        a = F.relu(self.norma2(self.lina(a), test=test))
+        a = F.relu(self.norma(self.conva(a)))
+        a = F.relu(self.norma2(self.lina(a)))
         a = self.outa(a)
         loss1 = F.softmax_cross_entropy(a, t)
 
@@ -86,8 +65,8 @@ class GoogLeNetBN(chainer.Chain):
         h = self.inc4d(h)
 
         b = F.average_pooling_2d(h, 5, stride=3)
-        b = F.relu(self.normb(self.convb(b), test=test))
-        b = F.relu(self.normb2(self.linb(b), test=test))
+        b = F.relu(self.normb(self.convb(b)))
+        b = F.relu(self.normb2(self.linb(b)))
         b = self.outb(b)
         loss2 = F.softmax_cross_entropy(b, t)
 
@@ -163,7 +142,6 @@ class GoogLeNetBNFp16(GoogLeNetBN):
             normb2=L.BatchNormalization(1024, dtype=dtype),
             outb=L.Linear(None, 1000, initialW=W, bias=bias),
         )
-        self._train = True
 
     def __call__(self, x, t):
         return GoogLeNetBN.__call__(self, F.cast(x, self.dtype), t)

--- a/examples/imagenet/nin.py
+++ b/examples/imagenet/nin.py
@@ -22,13 +22,12 @@ class NIN(chainer.Chain):
             mlpconv4=L.MLPConvolution2D(
                 None, (1024, 1024, 1000), 3, pad=1, conv_init=conv_init),
         )
-        self.train = True
 
     def __call__(self, x, t):
         h = F.max_pooling_2d(F.relu(self.mlpconv1(x)), 3, stride=2)
         h = F.max_pooling_2d(F.relu(self.mlpconv2(h)), 3, stride=2)
         h = F.max_pooling_2d(F.relu(self.mlpconv3(h)), 3, stride=2)
-        h = self.mlpconv4(F.dropout(h, train=self.train))
+        h = self.mlpconv4(F.dropout(h))
         h = F.reshape(F.average_pooling_2d(h, 6), (x.data.shape[0], 1000))
 
         loss = F.softmax_cross_entropy(h, t)

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -65,16 +65,6 @@ class PreprocessedDataset(chainer.dataset.DatasetMixin):
         return image, label
 
 
-class TestModeEvaluator(extensions.Evaluator):
-
-    def evaluate(self):
-        model = self.get_target('main')
-        model.train = False
-        ret = super(TestModeEvaluator, self).evaluate()
-        model.train = True
-        return ret
-
-
 def main():
     archs = {
         'alex': alex.Alex,
@@ -146,7 +136,7 @@ def main():
     val_interval = (10 if args.test else 100000), 'iteration'
     log_interval = (10 if args.test else 1000), 'iteration'
 
-    trainer.extend(TestModeEvaluator(val_iter, model, device=args.gpu),
+    trainer.extend(extensions.Evaluator(val_iter, model, device=args.gpu),
                    trigger=val_interval)
     trainer.extend(extensions.dump_graph('main/loss'))
     trainer.extend(extensions.snapshot(), trigger=val_interval)

--- a/examples/modelzoo/evaluate_caffe_net.py
+++ b/examples/modelzoo/evaluate_caffe_net.py
@@ -43,6 +43,8 @@ if args.gpu >= 0:
 xp = cuda.cupy if args.gpu >= 0 else np
 assert args.batchsize > 0
 
+chainer.config.train = False  # All the codes will run in test mode
+
 
 dataset = []
 with open(args.dataset) as list_file:
@@ -66,7 +68,7 @@ if args.model_type == 'alexnet' or args.model_type == 'caffenet':
     mean_image = np.load(args.mean)
 
     def forward(x, t):
-        y, = func(inputs={'data': x}, outputs=['fc8'], train=False)
+        y, = func(inputs={'data': x}, outputs=['fc8'])
         return F.softmax_cross_entropy(y, t), F.accuracy(y, t)
 elif args.model_type == 'googlenet':
     in_size = 224
@@ -78,15 +80,14 @@ elif args.model_type == 'googlenet':
 
     def forward(x, t):
         y, = func(inputs={'data': x}, outputs=['loss3/classifier'],
-                  disable=['loss1/ave_pool', 'loss2/ave_pool'],
-                  train=False)
+                  disable=['loss1/ave_pool', 'loss2/ave_pool'])
         return F.softmax_cross_entropy(y, t), F.accuracy(y, t)
 elif args.model_type == 'resnet':
     in_size = 224
     mean_image = np.load(args.mean)
 
     def forward(x, t):
-        y, = func(inputs={'data': x}, outputs=['prob'], train=False)
+        y, = func(inputs={'data': x}, outputs=['prob'])
         return F.softmax_cross_entropy(y, t), F.accuracy(y, t)
 
 

--- a/examples/ptb/gentxt.py
+++ b/examples/ptb/gentxt.py
@@ -40,6 +40,7 @@ def main():
     args = parser.parse_args()
 
     np.random.seed(args.seed)
+    chainer.config.train = False
 
     xp = cuda.cupy if args.gpu >= 0 else np
 
@@ -52,7 +53,7 @@ def main():
     # should be same as n_units , described in train_ptb.py
     n_units = args.unit
 
-    lm = train_ptb.RNNForLM(len(vocab), n_units, train=False)
+    lm = train_ptb.RNNForLM(len(vocab), n_units)
     model = L.Classifier(lm)
 
     serializers.load_npz(args.model, model)

--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -21,7 +21,7 @@ from chainer.training import extensions
 # Definition of a recurrent net for language modeling
 class RNNForLM(chainer.Chain):
 
-    def __init__(self, n_vocab, n_units, train=True):
+    def __init__(self, n_vocab, n_units):
         super(RNNForLM, self).__init__(
             embed=L.EmbedID(n_vocab, n_units),
             l1=L.LSTM(n_units, n_units),
@@ -30,7 +30,6 @@ class RNNForLM(chainer.Chain):
         )
         for param in self.params():
             param.data[...] = np.random.uniform(-0.1, 0.1, param.data.shape)
-        self.train = train
 
     def reset_state(self):
         self.l1.reset_state()
@@ -38,9 +37,9 @@ class RNNForLM(chainer.Chain):
 
     def __call__(self, x):
         h0 = self.embed(x)
-        h1 = self.l1(F.dropout(h0, train=self.train))
-        h2 = self.l2(F.dropout(h1, train=self.train))
-        y = self.l3(F.dropout(h2, train=self.train))
+        h1 = self.l1(F.dropout(h0))
+        h2 = self.l2(F.dropout(h1))
+        y = self.l3(F.dropout(h2))
         return y
 
 
@@ -206,7 +205,6 @@ def main():
 
     eval_model = model.copy()  # Model with shared params and distinct states
     eval_rnn = eval_model.predictor
-    eval_rnn.train = False
     trainer.extend(extensions.Evaluator(
         val_iter, eval_model, device=args.gpu,
         # Reset the RNN state at the beginning of each evaluation

--- a/examples/vae/net.py
+++ b/examples/vae/net.py
@@ -38,7 +38,7 @@ class VAE(chainer.Chain):
         else:
             return h2
 
-    def get_loss_func(self, C=1.0, k=1, train=True):
+    def get_loss_func(self, C=1.0, k=1):
         """Get loss function of VAE.
 
         The loss value is equal to ELBO (Evidence Lower Bound)
@@ -48,7 +48,6 @@ class VAE(chainer.Chain):
             C (int): Usually this is 1.0. Can be changed to control the
                 second term of ELBO bound, which works as regularization.
             k (int): Number of Monte Carlo samples used in encoded vector.
-            train (bool): If true loss_function is used for training.
         """
         def lf(x):
             mu, ln_var = self.encode(x)

--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -114,7 +114,7 @@ for epoch in six.moves.range(1, n_epoch + 1):
     for i in six.moves.range(0, N_test, batchsize):
         x = chainer.Variable(xp.asarray(x_test[i:i + batchsize]),
                              volatile='on')
-        loss_func = model.get_loss_func(k=10, train=False)
+        loss_func = model.get_loss_func(k=10)
         loss_func(x)
         sum_loss += float(model.loss.data) * len(x.data)
         sum_rec_loss += float(model.rec_loss.data) * len(x.data)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -223,9 +223,10 @@ class TestNStepLSTMCudnnCall(unittest.TestCase):
               for ws in self.ws]
         bs = [[chainer.Variable(b, volatile=volatile) for b in bs]
               for bs in self.bs]
-        return functions.n_step_lstm(
-            self.n_layers, self.dropout, h, c, ws, bs, xs,
-            train=train, use_cudnn=self.use_cudnn)
+        with chainer.using_config('train', train):
+            return functions.n_step_lstm(
+                self.n_layers, self.dropout, h, c, ws, bs, xs,
+                use_cudnn=self.use_cudnn)
 
     def test_call_cudnn_forward_training(self):
         with mock.patch('cupy.cuda.cudnn.RNNForwardTraining') as func:

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -79,11 +79,12 @@ class TestBatchNormalization(unittest.TestCase):
         self.check_forward([cuda.to_gpu(i) for i in self.args], False)
 
     def check_backward(self, args, y_grad):
-        gradient_check.check_backward(
-            batch_normalization.BatchNormalizationFunction(
-                mean=None, var=None, train=self.train,
-                decay=self.decay, eps=self.eps), args, y_grad,
-            **self.check_backward_options)
+        with chainer.using_config('train', self.train):
+            gradient_check.check_backward(
+                batch_normalization.BatchNormalizationFunction(
+                    mean=None, var=None,
+                    decay=self.decay, eps=self.eps), args, y_grad,
+                **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -153,11 +154,12 @@ class TestFixedBatchNormalization(unittest.TestCase):
         self.check_forward([cuda.to_gpu(i) for i in self.args], False)
 
     def check_backward(self, args, y_grad):
-        gradient_check.check_backward(
-            batch_normalization.BatchNormalizationFunction(
-                mean=None, var=None, train=self.train,
-                decay=self.decay, eps=self.eps),
-            args, y_grad,  **self.check_backward_options)
+        with chainer.using_config('train', self.train):
+            gradient_check.check_backward(
+                batch_normalization.BatchNormalizationFunction(
+                    mean=None, var=None,
+                    decay=self.decay, eps=self.eps),
+                args, y_grad,  **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
+++ b/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
@@ -90,8 +90,9 @@ class TestCaffeFunctionBaseMock(TestCaffeFunctionBase):
             invars.append(chainer.Variable(data))
         self.inputs = invars
 
-        out = self.func(inputs=dict(zip(inputs, invars)),
-                        outputs=outputs, train=False)
+        with chainer.using_config('train', False):
+            out = self.func(inputs=dict(zip(inputs, invars)),
+                            outputs=outputs)
         self.assertEqual(len(out), len(self.outputs))
         for actual, expect in zip(out, self.outputs):
             self.assertIs(actual, expect)
@@ -219,7 +220,7 @@ class TestDropout(TestCaffeFunctionBaseMock):
         self.assertEqual(len(self.func.layers), 1)
         self.call(['x'], ['y'])
         self.mock.assert_called_once_with(
-            self.inputs[0], ratio=0.25, train=False)
+            self.inputs[0], ratio=0.25)
 
 
 class TestInnerProduct(TestCaffeFunctionBaseMock):
@@ -587,8 +588,7 @@ class TestBatchNorm(TestCaffeFunctionBaseMock):
         self.init_func()
         self.assertEqual(len(self.func.layers), 1)
         self.call(['x'], ['y'])
-        self.mock.assert_called_once_with(self.inputs[0],
-                                          test=False, finetune=False)
+        self.mock.assert_called_once_with(self.inputs[0], finetune=False)
 
 
 class TestBatchNormUsingGlobalStats(TestCaffeFunctionBaseMock):
@@ -631,8 +631,7 @@ class TestBatchNormUsingGlobalStats(TestCaffeFunctionBaseMock):
         self.init_func()
         self.assertEqual(len(self.func.layers), 1)
         self.call(['x'], ['y'])
-        self.mock.assert_called_once_with(self.inputs[0],
-                                          test=True, finetune=False)
+        self.mock.assert_called_once_with(self.inputs[0], finetune=False)
 
 
 class TestEltwiseProd(TestCaffeFunctionBaseMock):

--- a/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
@@ -108,6 +108,7 @@ class TestZoneoutlstm(unittest.TestCase):
             self.check_forward(c, h, x)
 
     def check_backward(self, c_data, h_data, x_data, y_grad):
+        print(chainer.config.train)
         x = chainer.Variable(x_data)
         y = self._forward(self.link, x)
         c = self.link.c

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -69,9 +69,10 @@ class BatchNormalizationTest(unittest.TestCase):
             self.check_backward_optionss = {'atol': 5e-1, 'rtol': 1e-1}
 
     def check_forward(self, x_data):
-        x = chainer.Variable(x_data, volatile=self.volatile)
-        y = self.link(x, test=self.test)
-        self.assertEqual(y.data.dtype, self.dtype)
+        with chainer.using_config('train', not self.test):
+            x = chainer.Variable(x_data, volatile=self.volatile)
+            y = self.link(x)
+            self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_normalization(
             self.expander, self.gamma, self.beta, self.x, self.mean,
@@ -151,7 +152,8 @@ class TestPopulationStatistics(unittest.TestCase):
         testing.assert_allclose(unbiased_var, self.link.avg_var)
 
         y = chainer.Variable(y)
-        self.link(y, test=True, finetune=True)
+        with chainer.using_config('train', False):
+            self.link(y, finetune=True)
         testing.assert_allclose(mean, self.link.avg_mean)
         testing.assert_allclose(unbiased_var, self.link.avg_var)
 
@@ -246,7 +248,8 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
-        y = self.link(x, test=self.test)
+        with chainer.using_config('train', not self.test):
+            y = self.link(x)
         testing.assert_allclose(self.y_expected, y.data)
 
     def test_forward_cpu(self):


### PR DESCRIPTION
This PR, related to #2048 and #2102, adds the training mode configuration. We have been using ad-hoc ways to switch the training/test phase behaviors of each component, e.g. train/test argument of functions or train/test attributes of objects. This PR replaces them with the unified `train` config. This is a boolean flag that the true value indicates training mode and false value indicates test mode.

It also makes Evaluator extension turn off the train flag during its evaluation so that users do not have to manually switch these ad-hoc flags by themselves before/after the evaluation.