### PR TITLE
Add use_cudnn mode

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -86,6 +86,7 @@ global_config.debug = bool(int(os.environ.get('CHAINER_DEBUG', '0')))
 global_config.enable_backprop = True
 global_config.train = True
 global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
+global_config.use_cudnn = bool(int(os.environ.get('CHAINER_USE_CUDNN', '1')))
 
 
 def is_debug():

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -86,7 +86,50 @@ global_config.debug = bool(int(os.environ.get('CHAINER_DEBUG', '0')))
 global_config.enable_backprop = True
 global_config.train = True
 global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
-global_config.use_cudnn = bool(int(os.environ.get('CHAINER_USE_CUDNN', '1')))
+global_config.use_cudnn = os.environ.get('CHAINER_USE_CUDNN', 'auto')
+
+
+_SHOULD_USE_CUDNN = {
+    '==always': {'always': True, 'auto': False, 'never': False},
+    '>=auto':   {'always': True, 'auto': True,  'never': False},
+}
+
+
+_cudnn_version = cuda.cudnn.cudnn.getVersion() if cuda.cudnn_enabled else 1
+
+
+def should_use_cudnn(level, lowest_version=0):
+    """Determines if we should use cuDNN.
+
+    This function checks ``chainer.config.use_cudnn``,
+    ``chainer.cuda.cudnn_enabled``, and the cuDNN version. Note that
+    ``cudnn_enabled`` flag is fixed at loading of :mod:`chainer` module.
+
+    Args:
+        level (str): cuDNN use level. It must be either ``'==always'`` or
+            ``'>=auto'``. ``'==always'`` indicates that the ``use_cudnn``
+            config must be ``'always'`` to use cuDNN.
+        lowest_version (int): Required lowest cuDNN version. It must be
+            non-negative.
+
+    Returns:
+        bool: ``True`` if the caller should use cuDNN.
+
+    """
+    if _cudnn_version < lowest_version:
+        return False
+
+    if level not in _SHOULD_USE_CUDNN:
+        raise ValueError('invalid cuDNN use level: %s '
+                         '(must be either of "==always" or ">=auto")' %
+                         repr(level))
+    flags = _SHOULD_USE_CUDNN[level]
+
+    if config.use_cudnn not in flags:
+        raise ValueError('invalid use_cudnn configuration: %s '
+                         '(must be either of "always", "auto", or "never")' %
+                         repr(config.use_cudnn))
+    return flags[config.use_cudnn]
 
 
 def is_debug():

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer import utils
@@ -18,9 +19,6 @@ class ReLU(function.Function):
     """Rectified Linear Unit."""
     # TODO(beam2d): Implement in-place version.
 
-    def __init__(self, use_cudnn=True):
-        self.use_cudnn = use_cudnn
-
     def check_type_forward(self, in_types):
         type_check.expect(
             in_types.size() == 1,
@@ -31,7 +29,7 @@ class ReLU(function.Function):
         return utils.force_array(numpy.maximum(x[0], 0, dtype=x[0].dtype)),
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 x[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             y = cudnn.activation_forward(x[0], _mode)
@@ -44,7 +42,7 @@ class ReLU(function.Function):
         return utils.force_array(gy[0] * (x[0] > 0)),
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 x[0].flags.c_contiguous and gy[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             gx = cudnn.activation_backward(x[0], self.y, gy[0], _mode)
@@ -56,7 +54,7 @@ class ReLU(function.Function):
         return gx,
 
 
-def relu(x, use_cudnn=True):
+def relu(x):
     """Rectified Linear Unit function.
 
      .. math::`f(x)=\\max(0, x)`.
@@ -65,8 +63,6 @@ def relu(x, use_cudnn=True):
         x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`):
             Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
-        use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
-            uses cuDNN as the core implementation.
 
     Returns:
         ~chainer.Variable: Output variable. A
@@ -84,4 +80,4 @@ def relu(x, use_cudnn=True):
         (3, 4, 5)
 
     """
-    return ReLU(use_cudnn)(x)
+    return ReLU()(x)

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer import utils
@@ -29,7 +29,7 @@ class ReLU(function.Function):
         return utils.force_array(numpy.maximum(x[0], 0, dtype=x[0].dtype)),
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('==always') and
                 x[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             y = cudnn.activation_forward(x[0], _mode)
@@ -42,7 +42,7 @@ class ReLU(function.Function):
         return utils.force_array(gy[0] * (x[0] > 0)),
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('==always') and
                 x[0].flags.c_contiguous and gy[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             gx = cudnn.activation_backward(x[0], self.y, gy[0], _mode)

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check
@@ -16,9 +17,6 @@ class Softmax(function.Function):
 
     """Softmax activation function."""
 
-    def __init__(self, use_cudnn=True):
-        self.use_cudnn = use_cudnn
-
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
         x_type, = in_types
@@ -30,7 +28,8 @@ class Softmax(function.Function):
 
     def forward(self, x):
         xp = cuda.get_array_module(*x)
-        if (xp != numpy and cuda.cudnn_enabled and self.use_cudnn and
+        if (xp != numpy and cuda.cudnn_enabled and
+                configuration.config.use_cudnn and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             oz_dtype = 'd' if x[0].dtype == 'd' else 'f'
             one = numpy.array(1, dtype=oz_dtype).ctypes
@@ -52,7 +51,8 @@ class Softmax(function.Function):
 
     def backward(self, x, gy):
         xp = cuda.get_array_module(*x)
-        if (xp != numpy and cuda.cudnn_enabled and self.use_cudnn and
+        if (xp != numpy and cuda.cudnn_enabled and
+                configuration.config.use_cudnn and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             oz_dtype = 'd' if x[0].dtype == 'd' else 'f'
             one = numpy.array(1, dtype=oz_dtype).ctypes
@@ -73,7 +73,7 @@ class Softmax(function.Function):
         return gx,
 
 
-def softmax(x, use_cudnn=True):
+def softmax(x):
     """Channelwise softmax function.
 
     This function computes its softmax along the second axis. Let
@@ -85,11 +85,9 @@ def softmax(x, use_cudnn=True):
 
     Args:
         x (~chainer.Variable): Input variable.
-        use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
-            uses cuDNN as the core implementation.
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Softmax(use_cudnn)(x)
+    return Softmax()(x)

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check
@@ -28,8 +28,7 @@ class Softmax(function.Function):
 
     def forward(self, x):
         xp = cuda.get_array_module(*x)
-        if (xp != numpy and cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+        if (xp is not numpy and chainer.should_use_cudnn('>=auto') and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             oz_dtype = 'd' if x[0].dtype == 'd' else 'f'
             one = numpy.array(1, dtype=oz_dtype).ctypes
@@ -51,8 +50,7 @@ class Softmax(function.Function):
 
     def backward(self, x, gy):
         xp = cuda.get_array_module(*x)
-        if (xp != numpy and cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+        if (xp is not numpy and chainer.should_use_cudnn('>=auto') and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             oz_dtype = 'd' if x[0].dtype == 'd' else 'f'
             one = numpy.array(1, dtype=oz_dtype).ctypes

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer import utils
@@ -26,7 +26,7 @@ class Tanh(function.Function):
         return self.y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('==always') and
                 x[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             self.y = cudnn.activation_forward(x[0], _mode)
@@ -40,7 +40,7 @@ class Tanh(function.Function):
         return utils.force_array(gy[0] * (one - self.y * self.y)),
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('==always') and
                 x[0].flags.c_contiguous and gy[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
             gx = cudnn.activation_backward(x[0], self.y, gy[0], _mode)

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.utils import conv
@@ -87,8 +87,7 @@ class Convolution2DFunction(function.Function):
         assert out_w > 0, 'Width in the output should be positive.'
 
         y = cuda.cupy.empty((n, out_c, out_h, out_w), dtype=x.dtype)
-        if (not self.cover_all and cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+        if (not self.cover_all and chainer.should_use_cudnn('>=auto') and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)
@@ -169,8 +168,7 @@ class Convolution2DFunction(function.Function):
         kh, kw = W.shape[2:]
 
         gW = cuda.cupy.empty_like(W)
-        if (not self.cover_all and cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+        if (not self.cover_all and chainer.should_use_cudnn('>=auto') and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import conv
@@ -30,11 +31,9 @@ def _pair(x):
 
 class Convolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, use_cudnn=True, cover_all=False,
-                 deterministic=False):
+    def __init__(self, stride=1, pad=0, cover_all=False, deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
-        self.use_cudnn = use_cudnn
         self.cover_all = cover_all
         self.deterministic = deterministic
 
@@ -88,7 +87,8 @@ class Convolution2DFunction(function.Function):
         assert out_w > 0, 'Width in the output should be positive.'
 
         y = cuda.cupy.empty((n, out_c, out_h, out_w), dtype=x.dtype)
-        if (not self.cover_all and cuda.cudnn_enabled and self.use_cudnn and
+        if (not self.cover_all and cuda.cudnn_enabled and
+                configuration.config.use_cudnn and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)
@@ -169,7 +169,8 @@ class Convolution2DFunction(function.Function):
         kh, kw = W.shape[2:]
 
         gW = cuda.cupy.empty_like(W)
-        if (not self.cover_all and cuda.cudnn_enabled and self.use_cudnn and
+        if (not self.cover_all and cuda.cudnn_enabled and
+                configuration.config.use_cudnn and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)
@@ -252,7 +253,7 @@ class Convolution2DFunction(function.Function):
             return gx, gW, gb
 
 
-def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
+def convolution_2d(x, W, b=None, stride=1, pad=0,
                    cover_all=False, deterministic=False):
     """Two-dimensional convolution function.
 
@@ -279,8 +280,6 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
         pad (int or pair of ints): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
-        use_cudnn (bool): If ``True``, then this function uses cuDNN if
-            available.
         cover_all (bool): If ``True``, all spatial locations are convoluted
             into some output pixels. It may make the output size larger.
         deterministic (bool): The output of this function can be
@@ -319,7 +318,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
 
     """
     func = Convolution2DFunction(
-        stride, pad, use_cudnn, cover_all, deterministic)
+        stride, pad, cover_all, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -330,7 +330,7 @@ def convolution_nd(x, W, b=None, stride=1, pad=0, cover_all=False):
     computation if ALL of the following conditions are satisfied:
 
     - ``cuda.cudnn_enabled`` is ``True``
-    - ``chainer.config.use_cudnn`` is ``True``
+    - ``chainer.config.use_cudnn`` is ``'always'`` or ``'auto'``
     - The number of spatial dimensions is more than one.
     - ``cover_all`` is ``False``
     - The input's ``dtype`` is equal to the filter weight's.

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -2,7 +2,7 @@ import numpy
 
 from six import moves
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.functions.connection import convolution_2d
@@ -58,8 +58,7 @@ class ConvolutionND(function.Function):
 
     def _use_cudnn(self, x, W):
         return (not self.cover_all and
-                cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+                chainer.should_use_cudnn('>=auto') and
                 self.ndim > 1 and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype))
 

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.functions.connection import convolution_2d
@@ -106,7 +106,7 @@ class Deconvolution2DFunction(function.Function):
         if self.outw is None:
             self.outw = conv.get_deconv_outsize(in_w, kw, self.sx, self.pw)
             assert self.outw > 0, 'Width in the output should be positive.'
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('>=auto') and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)
@@ -198,7 +198,7 @@ class Deconvolution2DFunction(function.Function):
         c, h, w = gy.shape[1:]
         gx = cuda.cupy.empty((n, in_c, in_h, in_w), dtype=x.dtype)
 
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('>=auto') and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.functions.connection import convolution_2d
@@ -29,11 +30,9 @@ def _pair(x):
 
 class Deconvolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, outsize=None, use_cudnn=True,
-                 deterministic=False):
+    def __init__(self, stride=1, pad=0, outsize=None, deterministic=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
-        self.use_cudnn = use_cudnn
         self.outh, self.outw = (None, None) if outsize is None else outsize
         self.deterministic = deterministic
 
@@ -107,7 +106,7 @@ class Deconvolution2DFunction(function.Function):
         if self.outw is None:
             self.outw = conv.get_deconv_outsize(in_w, kw, self.sx, self.pw)
             assert self.outw > 0, 'Width in the output should be positive.'
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)
@@ -199,7 +198,7 @@ class Deconvolution2DFunction(function.Function):
         c, h, w = gy.shape[1:]
         gx = cuda.cupy.empty((n, in_c, in_h, in_w), dtype=x.dtype)
 
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)
@@ -278,7 +277,7 @@ class Deconvolution2DFunction(function.Function):
 
 
 def deconvolution_2d(x, W, b=None, stride=1, pad=0,
-                     outsize=None, use_cudnn=True, deterministic=False):
+                     outsize=None, deterministic=False):
     """Two dimensional deconvolution function.
 
     This is an implementation of two-dimensional deconvolution.
@@ -298,8 +297,6 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
             It should be pair of height and width :math:`(out_H, out_W)`.
             Default value is ``None`` and the outsize is estimated by
             input size, stride and pad.
-        use_cudnn (bool): If ``True``, then this function uses cuDNN if
-            available.
         deterministic (bool): The output of this function can be
             non-deterministic when it uses cuDNN.
             If this option is ``True``, then it forces cuDNN to use
@@ -324,8 +321,7 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
        w_O &= s_X (w - 1) + k_W - 2p_W.
 
     """
-    func = Deconvolution2DFunction(
-        stride, pad, outsize, use_cudnn, deterministic)
+    func = Deconvolution2DFunction(stride, pad, outsize, deterministic)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -1,6 +1,7 @@
 import numpy
 import six
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.functions.connection import convolution_2d
@@ -26,11 +27,10 @@ _check_cudnn_acceptable_type = convolution_2d._check_cudnn_acceptable_type
 
 class DeconvolutionND(function.Function):
 
-    def __init__(self, ndim, stride=1, pad=0, outsize=None, use_cudnn=True):
+    def __init__(self, ndim, stride=1, pad=0, outsize=None):
         self.ndim = ndim
         self.stride = conv_nd.as_tuple(stride, ndim)
         self.pad = conv_nd.as_tuple(pad, ndim)
-        self.use_cudnn = use_cudnn
         if outsize is not None:
             assert len(outsize) == ndim
         self.outs = outsize
@@ -66,7 +66,7 @@ class DeconvolutionND(function.Function):
 
     def _use_cudnn(self, x, W):
         return (cuda.cudnn_enabled and
-                self.use_cudnn and
+                configuration.config.use_cudnn and
                 self.ndim > 1 and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype))
 
@@ -298,8 +298,7 @@ class DeconvolutionND(function.Function):
             return self._backward_xp(x, W, b, gy, cuda.cupy)
 
 
-def deconvolution_nd(x, W, b=None, stride=1, pad=0, outsize=None,
-                     use_cudnn=True):
+def deconvolution_nd(x, W, b=None, stride=1, pad=0, outsize=None):
     """N-dimensional deconvolution function.
 
     This is an implementation of N-dimensional deconvolution which generalizes
@@ -323,9 +322,6 @@ def deconvolution_nd(x, W, b=None, stride=1, pad=0, outsize=None,
             operation. It should be a tuple of ints
             :math:`(out_1, out_2, ..., out_N)`. Default value is ``None`` and
             the outsize is estimated by input size, stride and pad.
-        use_cudnn (bool): If ``True``, then this function uses cuDNN if
-            available. Note that cuDNN supports more than one-dimensional
-            deconvolution operations only.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -353,7 +349,7 @@ def deconvolution_nd(x, W, b=None, stride=1, pad=0, outsize=None,
     .. seealso:: :class:`links.DeconvolutionND`, :func:`deconvolution_2d`
     """
     ndim = len(x.shape[2:])
-    func = DeconvolutionND(ndim, stride, pad, outsize, use_cudnn)
+    func = DeconvolutionND(ndim, stride, pad, outsize)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -1,7 +1,7 @@
 import numpy
 import six
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.functions.connection import convolution_2d
@@ -65,8 +65,7 @@ class DeconvolutionND(function.Function):
             )
 
     def _use_cudnn(self, x, W):
-        return (cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+        return (chainer.should_use_cudnn('>=auto') and
                 self.ndim > 1 and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype))
 

--- a/chainer/functions/connection/dilated_convolution_2d.py
+++ b/chainer/functions/connection/dilated_convolution_2d.py
@@ -1,7 +1,7 @@
 import numpy
 from six import moves
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.utils import conv
@@ -87,8 +87,7 @@ class DilatedConvolution2DFunction(function.Function):
                                       cover_all=self.cover_all, d=self.dx)
 
         y = cuda.cupy.zeros((n, out_c, out_h, out_w), dtype=x.dtype)
-        if (not self.cover_all and cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+        if (not self.cover_all and chainer.should_use_cudnn('>=auto') and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
 
             pad_x = cuda.cupy.zeros((n, c, h + 2 * self.ph, w + 2 * self.pw),
@@ -183,8 +182,7 @@ class DilatedConvolution2DFunction(function.Function):
         dkh, dkw = kh + (kh - 1) * (self.dy - 1), kw + (kw - 1) * (self.dx - 1)
 
         gW = cuda.cupy.empty_like(W)
-        if (not self.cover_all and cuda.cudnn_enabled and
-                configuration.config.use_cudnn and
+        if (not self.cover_all and chainer.should_use_cudnn('>=auto') and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
 
             pad_x = cuda.cupy.zeros(

--- a/chainer/functions/connection/dilated_convolution_2d.py
+++ b/chainer/functions/connection/dilated_convolution_2d.py
@@ -1,6 +1,7 @@
 import numpy
 from six import moves
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import conv
@@ -31,12 +32,10 @@ def _pair(x):
 
 class DilatedConvolution2DFunction(function.Function):
 
-    def __init__(self, stride=1, pad=0, dilate=1,
-                 use_cudnn=True, cover_all=False):
+    def __init__(self, stride=1, pad=0, dilate=1, cover_all=False):
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
         self.dy, self.dx = _pair(dilate)
-        self.use_cudnn = use_cudnn
         self.cover_all = cover_all
 
     def check_type_forward(self, in_types):
@@ -88,7 +87,8 @@ class DilatedConvolution2DFunction(function.Function):
                                       cover_all=self.cover_all, d=self.dx)
 
         y = cuda.cupy.zeros((n, out_c, out_h, out_w), dtype=x.dtype)
-        if (not self.cover_all and cuda.cudnn_enabled and self.use_cudnn and
+        if (not self.cover_all and cuda.cudnn_enabled and
+                configuration.config.use_cudnn and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
 
             pad_x = cuda.cupy.zeros((n, c, h + 2 * self.ph, w + 2 * self.pw),
@@ -183,7 +183,8 @@ class DilatedConvolution2DFunction(function.Function):
         dkh, dkw = kh + (kh - 1) * (self.dy - 1), kw + (kw - 1) * (self.dx - 1)
 
         gW = cuda.cupy.empty_like(W)
-        if (not self.cover_all and cuda.cudnn_enabled and self.use_cudnn and
+        if (not self.cover_all and cuda.cudnn_enabled and
+                configuration.config.use_cudnn and
                 _check_cudnn_acceptable_type(x.dtype, W.dtype)):
 
             pad_x = cuda.cupy.zeros(
@@ -303,7 +304,7 @@ class DilatedConvolution2DFunction(function.Function):
 
 
 def dilated_convolution_2d(x, W, b=None, stride=1, pad=0, dilate=1,
-                           use_cudnn=True, cover_all=False):
+                           cover_all=False):
     """Two-dimensional dilated convolution function.
 
     This is an implementation of two-dimensional dilated convolution
@@ -332,8 +333,6 @@ def dilated_convolution_2d(x, W, b=None, stride=1, pad=0, dilate=1,
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         dilate (int or pair of ints): Dilation factor of filter applications.
             ``dilate=d`` and ``dilate=(d, d)`` are equivalent.
-        use_cudnn (bool): If ``True``, then this function uses cuDNN if
-            available.
         cover_all (bool): If ``True``, all spatial locations are convoluted
             into some output pixels. It may make the output size larger.
 
@@ -367,8 +366,7 @@ def dilated_convolution_2d(x, W, b=None, stride=1, pad=0, dilate=1,
     .. seealso:: :class:`DilatedConvolution2D`
 
     """
-    func = DilatedConvolution2DFunction(
-        stride, pad, dilate, use_cudnn, cover_all)
+    func = DilatedConvolution2DFunction(stride, pad, dilate, cover_all)
     if b is None:
         return func(x, W)
     else:

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -6,7 +6,7 @@ import time
 import numpy
 import six
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.functions.activation import lstm
@@ -22,7 +22,6 @@ from chainer.utils import type_check
 if cuda.cudnn_enabled:
     cudnn = cuda.cudnn
     libcudnn = cuda.cudnn.cudnn
-    _cudnn_version = libcudnn.getVersion()
 
 
 class PointerArray(object):
@@ -446,8 +445,7 @@ def n_step_lstm(
 
     xp = cuda.get_array_module(hx, hx.data)
 
-    if configuration.config.use_cudnn and xp is not numpy and \
-       cuda.cudnn_enabled and _cudnn_version >= 5000:
+    if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
         states = get_random_state().create_dropout_states(dropout_ratio)
         # flatten all input variables
         inputs = tuple(itertools.chain(

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -7,6 +7,7 @@ import numpy
 import six
 
 import chainer
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.functions.activation import lstm

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -363,7 +363,7 @@ def _stack_weight(ws):
 
 
 def n_step_lstm(
-        n_layers, dropout_ratio, hx, cx, ws, bs, xs, use_cudnn=True):
+        n_layers, dropout_ratio, hx, cx, ws, bs, xs):
     """Stacked Long Short-Term Memory function for sequence inputs.
 
     This function calculates stacked LSTM with sequences. This function gets
@@ -425,7 +425,6 @@ def n_step_lstm(
             of :func:`~chainer.Variable` holding sequence.
             So ``xs`` needs to satisfy
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.
-        use_cudnn (bool): If ``True``, this function uses cuDNN if available.
 
     Returns:
         tuple: This functions returns a tuple concaining three elements,
@@ -447,8 +446,8 @@ def n_step_lstm(
 
     xp = cuda.get_array_module(hx, hx.data)
 
-    if use_cudnn and xp is not numpy and cuda.cudnn_enabled and \
-       _cudnn_version >= 5000:
+    if configuration.config.use_cudnn and xp is not numpy and \
+       cuda.cudnn_enabled and _cudnn_version >= 5000:
         states = get_random_state().create_dropout_states(dropout_ratio)
         # flatten all input variables
         inputs = tuple(itertools.chain(

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.functions import sigmoid
@@ -13,8 +14,7 @@ class SigmoidCrossEntropy(function.Function):
 
     ignore_label = -1
 
-    def __init__(self, use_cudnn=True, normalize=True):
-        self.use_cudnn = use_cudnn
+    def __init__(self, normalize=True):
         self.normalize = normalize
 
     def check_type_forward(self, in_types):
@@ -46,14 +46,14 @@ class SigmoidCrossEntropy(function.Function):
         xp = cuda.get_array_module(*inputs)
         x, t = inputs
         gloss = grad_outputs[0]
-        y, = sigmoid.Sigmoid(self.use_cudnn).forward((x,))
+        y, = sigmoid.Sigmoid().forward((x,))
         gx = xp.divide(
             gloss * self.ignore_mask * (y - t), self.count,
             dtype=y.dtype)
         return gx, None
 
 
-def sigmoid_cross_entropy(x, t, use_cudnn=True, normalize=True):
+def sigmoid_cross_entropy(x, t, normalize=True):
     """Computes cross entropy loss for pre-sigmoid activations.
 
     Args:
@@ -77,4 +77,4 @@ def sigmoid_cross_entropy(x, t, use_cudnn=True, normalize=True):
        This function is differentiable only by ``x``.
 
     """
-    return SigmoidCrossEntropy(use_cudnn, normalize)(x, t)
+    return SigmoidCrossEntropy(normalize)(x, t)

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -1,6 +1,5 @@
 import numpy
 
-from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.functions import sigmoid

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -2,7 +2,6 @@ import numpy
 import six
 
 import chainer
-from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.functions.activation import log_softmax

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -1,6 +1,7 @@
 import numpy
 
 import chainer
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -305,13 +305,8 @@ def batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None,
     .. seealso:: :class:`links.BatchNormalization`
 
     """
-<<<<<<< HEAD
     return BatchNormalizationFunction(eps, running_mean, running_var,
-                                      decay, use_cudnn)(x, gamma, beta)
-=======
-    return BatchNormalizationFunction(eps, running_mean, running_var, True,
                                       decay)(x, gamma, beta)
->>>>>>> Add use_cudnn configuration
 
 
 def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5):
@@ -335,11 +330,6 @@ def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5):
        :class:`links.BatchNormalization`
 
     """
-<<<<<<< HEAD
     with configuration.using_config('train', False):
-        return BatchNormalizationFunction(eps, None, None, 0.0,
-                                          use_cudnn)(x, gamma, beta, mean, var)
-=======
-    return BatchNormalizationFunction(eps, None, None, False, 0.0)(
-        x, gamma, beta, mean, var)
->>>>>>> Add use_cudnn configuration
+        return BatchNormalizationFunction(eps, None, None, 0.0)(
+            x, gamma, beta, mean, var)

--- a/chainer/functions/pooling/average_pooling_2d.py
+++ b/chainer/functions/pooling/average_pooling_2d.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer.functions.pooling import pooling_2d
 from chainer.utils import conv
@@ -21,7 +22,7 @@ class AveragePooling2D(pooling_2d.Pooling2D):
         return y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and \
                 pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
             return super(AveragePooling2D, self).forward_gpu(x)
 
@@ -65,7 +66,7 @@ class AveragePooling2D(pooling_2d.Pooling2D):
         return gx,
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
             return super(AveragePooling2D, self).backward_gpu(x, gy)
 
@@ -107,7 +108,7 @@ class AveragePooling2D(pooling_2d.Pooling2D):
             libcudnn.CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
 
 
-def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
+def average_pooling_2d(x, ksize, stride=None, pad=0):
     """Spatial average pooling function.
 
     This function acts similarly to :class:`~functions.Convolution2D`, but
@@ -123,8 +124,6 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
             specified, then it uses same stride as the pooling window size.
         pad (int or pair of ints): Spatial padding width for the input array.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
-        use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
-            uses cuDNN as the core implementation.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -135,4 +134,4 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
        :func:`max_pooling_2d`. Average pooling runs in non-cover-all mode.
 
     """
-    return AveragePooling2D(ksize, stride, pad, False, use_cudnn)(x)
+    return AveragePooling2D(ksize, stride, pad, False)(x)

--- a/chainer/functions/pooling/average_pooling_2d.py
+++ b/chainer/functions/pooling/average_pooling_2d.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer.functions.pooling import pooling_2d
 from chainer.utils import conv
@@ -22,7 +22,7 @@ class AveragePooling2D(pooling_2d.Pooling2D):
         return y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and \
+        if (chainer.should_use_cudnn('>=auto') and
                 pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
             return super(AveragePooling2D, self).forward_gpu(x)
 
@@ -66,8 +66,7 @@ class AveragePooling2D(pooling_2d.Pooling2D):
         return gx,
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
-                pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
+        if self._used_cudnn:
             return super(AveragePooling2D, self).backward_gpu(x, gy)
 
         n, c, h, w = x[0].shape

--- a/chainer/functions/pooling/average_pooling_nd.py
+++ b/chainer/functions/pooling/average_pooling_nd.py
@@ -4,6 +4,7 @@ import functools
 import operator
 import six
 
+from chainer import configuration
 from chainer import cuda
 from chainer.functions.pooling import average_pooling_nd_kernel
 from chainer.functions.pooling import pooling_nd
@@ -21,8 +22,7 @@ class AveragePoolingND(pooling_nd._PoolingND):
 
     """Average pooling over a set of N-dimensional planes."""
 
-    def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=False,
-                 use_cudnn=True):
+    def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=False):
         utils.experimental('chainer.functions.pooling.AveragePoolingND')
 
         # TODO(takagi) Support cover_all mode.
@@ -30,8 +30,7 @@ class AveragePoolingND(pooling_nd._PoolingND):
             raise ValueError('`cover_all` mode is not supported yet.')
 
         super(AveragePoolingND, self).__init__(
-            ndim, ksize, stride=stride, pad=pad, cover_all=cover_all,
-            use_cudnn=use_cudnn)
+            ndim, ksize, stride=stride, pad=pad, cover_all=cover_all)
 
     def forward_cpu(self, x):
         col = conv_nd.im2col_nd_cpu(
@@ -43,7 +42,7 @@ class AveragePoolingND(pooling_nd._PoolingND):
         return y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 pooling_nd._check_cudnn_acceptable_type(x[0].dtype)):
             # With cuDNN v3 or greater, use cuDNN implementation for inputs
             # with spatial dimensions of two or more.
@@ -86,7 +85,7 @@ class AveragePoolingND(pooling_nd._PoolingND):
         return gx,
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 pooling_nd._check_cudnn_acceptable_type(x[0].dtype)):
             # With cuDNN v3 or greater, use cuDNN implementation for inputs
             # with spatial dimensions of two or more.
@@ -118,7 +117,7 @@ class AveragePoolingND(pooling_nd._PoolingND):
             libcudnn.CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
 
 
-def average_pooling_nd(x, ksize, stride=None, pad=0, use_cudnn=True):
+def average_pooling_nd(x, ksize, stride=None, pad=0):
     """N-dimensionally spatial average pooling function.
 
     This function provides a N-dimensionally generalized version of
@@ -137,9 +136,6 @@ def average_pooling_nd(x, ksize, stride=None, pad=0, use_cudnn=True):
             window size.
         pad (int or tuple of ints): Spatial padding width for the input array.
             ``pad=p`` and ``pad=(p, p, ..., p)`` are equivalent.
-        use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
-            uses cuDNN as the core implementation. cuDNN supports more than
-            one-dimensional pooling.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -151,5 +147,4 @@ def average_pooling_nd(x, ksize, stride=None, pad=0, use_cudnn=True):
 
     """
     ndim = len(x.shape[2:])
-    return AveragePoolingND(
-        ndim, ksize, stride=stride, pad=pad, use_cudnn=use_cudnn)(x)
+    return AveragePoolingND(ndim, ksize, stride=stride, pad=pad)(x)

--- a/chainer/functions/pooling/average_pooling_nd.py
+++ b/chainer/functions/pooling/average_pooling_nd.py
@@ -4,7 +4,7 @@ import functools
 import operator
 import six
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer.functions.pooling import average_pooling_nd_kernel
 from chainer.functions.pooling import pooling_nd
@@ -42,7 +42,7 @@ class AveragePoolingND(pooling_nd._PoolingND):
         return y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('>=auto') and
                 pooling_nd._check_cudnn_acceptable_type(x[0].dtype)):
             # With cuDNN v3 or greater, use cuDNN implementation for inputs
             # with spatial dimensions of two or more.
@@ -85,16 +85,8 @@ class AveragePoolingND(pooling_nd._PoolingND):
         return gx,
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
-                pooling_nd._check_cudnn_acceptable_type(x[0].dtype)):
-            # With cuDNN v3 or greater, use cuDNN implementation for inputs
-            # with spatial dimensions of two or more.
-            if _cudnn_version >= 3000 and self.ndim >= 2:
-                return super(AveragePoolingND, self).backward_gpu(x, gy)
-            # With cuDNN v2, use cuDNN implementation only for inputs with
-            # spatial dimensions of two.
-            elif self.ndim == 2:
-                return super(AveragePoolingND, self).backward_gpu(x, gy)
+        if self._used_cudnn:
+            return super(AveragePoolingND, self).backward_gpu(x, gy)
 
         n, c = x[0].shape[:2]
         dims = x[0].shape[2:]

--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer.functions.pooling import pooling_2d
 from chainer.utils import conv
@@ -27,7 +28,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
         return y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
             return super(MaxPooling2D, self).forward_gpu(x)
 
@@ -97,7 +98,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
         return gx,
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
             return super(MaxPooling2D, self).backward_gpu(x, gy)
 
@@ -144,8 +145,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
             libcudnn.CUDNN_POOLING_MAX)
 
 
-def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
-                   use_cudnn=True):
+def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True):
     """Spatial max pooling function.
 
     This function acts similarly to :class:`~functions.Convolution2D`, but
@@ -163,11 +163,9 @@ def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         cover_all (bool): If ``True``, all spatial locations are pooled into
             some output pixels. It may make the output size larger.
-        use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
-            uses cuDNN as the core implementation.
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return MaxPooling2D(ksize, stride, pad, cover_all, use_cudnn)(x)
+    return MaxPooling2D(ksize, stride, pad, cover_all)(x)

--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import configuration
+import chainer
 from chainer import cuda
 from chainer.functions.pooling import pooling_2d
 from chainer.utils import conv
@@ -28,7 +28,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
         return y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
+        if (chainer.should_use_cudnn('>=auto') and
                 pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
             return super(MaxPooling2D, self).forward_gpu(x)
 
@@ -98,8 +98,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
         return gx,
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
-                pooling_2d._check_cudnn_acceptable_type(x[0].dtype)):
+        if self._used_cudnn:
             return super(MaxPooling2D, self).backward_gpu(x, gy)
 
         n, c, h, w = x[0].shape

--- a/chainer/functions/pooling/max_pooling_nd.py
+++ b/chainer/functions/pooling/max_pooling_nd.py
@@ -4,6 +4,7 @@ import functools
 from operator import mul
 import six
 
+from chainer import configuration
 from chainer import cuda
 from chainer.functions.pooling import max_pooling_nd_kernel
 from chainer.functions.pooling import pooling_nd
@@ -21,12 +22,10 @@ class MaxPoolingND(pooling_nd._PoolingND):
 
     """Max pooling over a set of N-dimensional planes."""
 
-    def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=True,
-                 use_cudnn=True):
+    def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=True):
         utils.experimental('chainer.functions.pooling.MaxPoolingND')
         super(MaxPoolingND, self).__init__(
-            ndim, ksize, stride=stride, pad=pad, cover_all=cover_all,
-            use_cudnn=use_cudnn)
+            ndim, ksize, stride=stride, pad=pad, cover_all=cover_all)
 
     def forward_cpu(self, x):
         col = conv_nd.im2col_nd_cpu(
@@ -47,7 +46,7 @@ class MaxPoolingND(pooling_nd._PoolingND):
         return y,
 
     def forward_gpu(self, x):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 pooling_nd._check_cudnn_acceptable_type(x[0].dtype)):
             # With cuDNN v3 or greater, use cuDNN implementation for inputs
             # with spatial dimensions of two or more.
@@ -100,7 +99,7 @@ class MaxPoolingND(pooling_nd._PoolingND):
         return gx,
 
     def backward_gpu(self, x, gy):
-        if (cuda.cudnn_enabled and self.use_cudnn and
+        if (cuda.cudnn_enabled and configuration.config.use_cudnn and
                 pooling_nd._check_cudnn_acceptable_type(x[0].dtype)):
             # With cuDNN v3 or greater, use cuDNN implementation for inputs
             # with spatial dimensions of two or more.
@@ -129,8 +128,7 @@ class MaxPoolingND(pooling_nd._PoolingND):
             self.ksize, self.stride, self.pad, libcudnn.CUDNN_POOLING_MAX)
 
 
-def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True,
-                   use_cudnn=True):
+def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True):
     """N-dimensionally spatial max pooling function.
 
     This function provides a N-dimensionally generalized version of
@@ -151,13 +149,10 @@ def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True,
             ``pad=p`` and ``pad=(p, p, ..., p)`` are equivalent.
         cover_all (bool): If ``True``, all spatial locations are pooled into
             some output pixels. It may make the output size larger.
-        use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
-            uses cuDNN as the core implementation. cuDNN supports more than
-            one-dimensional pooling.
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
     ndim = len(x.shape[2:])
-    return MaxPoolingND(ndim, ksize, stride, pad, cover_all, use_cudnn)(x)
+    return MaxPoolingND(ndim, ksize, stride, pad, cover_all)(x)

--- a/chainer/functions/pooling/pooling_2d.py
+++ b/chainer/functions/pooling/pooling_2d.py
@@ -2,6 +2,7 @@ import collections
 
 import numpy
 
+from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import conv
@@ -28,8 +29,7 @@ class Pooling2D(function.Function):
 
     """Base class of pooling function over a set of 2d planes."""
 
-    def __init__(self, ksize, stride=None, pad=0, cover_all=True,
-                 use_cudnn=True):
+    def __init__(self, ksize, stride=None, pad=0, cover_all=True):
         if stride is None:
             stride = ksize
 
@@ -38,7 +38,6 @@ class Pooling2D(function.Function):
         self.ph, self.pw = _pair(pad)
 
         self.cover_all = cover_all
-        self.use_cudnn = use_cudnn
 
     def check_type_forward(self, in_types):
         type_check.expect(

--- a/chainer/functions/pooling/pooling_2d.py
+++ b/chainer/functions/pooling/pooling_2d.py
@@ -2,7 +2,6 @@ import collections
 
 import numpy
 
-from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import conv
@@ -38,6 +37,7 @@ class Pooling2D(function.Function):
         self.ph, self.pw = _pair(pad)
 
         self.cover_all = cover_all
+        self._used_cudnn = False
 
     def check_type_forward(self, in_types):
         type_check.expect(
@@ -47,6 +47,8 @@ class Pooling2D(function.Function):
         )
 
     def forward_gpu(self, x):
+        self._used_cudnn = True
+
         # Implementation using cudnn
         x = x[0]
         n, c, h, w = x.shape

--- a/chainer/functions/pooling/pooling_nd.py
+++ b/chainer/functions/pooling/pooling_nd.py
@@ -22,9 +22,7 @@ class _PoolingND(function.Function):
 
     """Base class of pooling function over a set of N-dimensional planes."""
 
-    def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=True,
-                 use_cudnn=True):
-
+    def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=True):
         if stride is None:
             stride = ksize
 
@@ -34,7 +32,7 @@ class _PoolingND(function.Function):
         self.pad = conv_nd.as_tuple(pad, ndim)
 
         self.cover_all = cover_all
-        self.use_cudnn = use_cudnn
+        self._used_cudnn = False
 
     def check_type_forward(self, in_types):
         type_check.expect(
@@ -44,6 +42,8 @@ class _PoolingND(function.Function):
         )
 
     def forward_gpu(self, x):
+        self._used_cudnn = True
+
         # Implementation using cuDNN.
         x = x[0]
         n, c = x.shape[:2]

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -1,6 +1,7 @@
 import numpy
 import six
 
+from chainer import configuration
 from chainer import cuda
 from chainer.functions.array import concat
 from chainer.functions.pooling import max_pooling_2d
@@ -11,7 +12,7 @@ class SpatialPyramidPooling2D(pooling_2d.Pooling2D):
 
     """Spatial pyramid pooling over a set of 2d planes."""
 
-    def __init__(self, x_shape, pyramid_height, pooling_class, use_cudnn=True):
+    def __init__(self, x_shape, pyramid_height, pooling_class):
         bottom_c, bottom_h, bottom_w = x_shape
         self.pyramid_height = pyramid_height
 
@@ -35,7 +36,7 @@ class SpatialPyramidPooling2D(pooling_2d.Pooling2D):
 
             if pooling_class is max_pooling_2d.MaxPooling2D:
                 pooler = pooling_class(ksize=ksize, stride=None, pad=pad,
-                                       cover_all=True, use_cudnn=use_cudnn)
+                                       cover_all=True)
                 self.poolers.append(pooler)
             else:
                 raise NotImplementedError()
@@ -64,8 +65,7 @@ class SpatialPyramidPooling2D(pooling_2d.Pooling2D):
         return gx,
 
 
-def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
-                               use_cudnn=True):
+def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class):
     """Spatial pyramid pooling function.
 
     It outputs a fixed-length vector regardless of input feature map size.
@@ -100,8 +100,6 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
         pyramid_height (int): Number of pyramid levels
         pooling_class (MaxPooling2D or AveragePooling2D):
             Only MaxPooling2D class can be available for now.
-        use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
-            uses cuDNN as the core implementation.
 
     Returns:
         ~chainer.Variable: Output variable. The shape of the output variable
@@ -118,4 +116,4 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
     """
 
     return SpatialPyramidPooling2D(x.shape[1:], pyramid_height,
-                                   pooling_class, use_cudnn=use_cudnn)(x)
+                                   pooling_class)(x)

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -1,7 +1,6 @@
 import numpy
 import six
 
-from chainer import configuration
 from chainer import cuda
 from chainer.functions.array import concat
 from chainer.functions.pooling import max_pooling_2d

--- a/chainer/functions/pooling/upsampling_2d.py
+++ b/chainer/functions/pooling/upsampling_2d.py
@@ -1,3 +1,4 @@
+from chainer import configuration
 from chainer import cuda
 from chainer.functions.pooling import pooling_2d
 from chainer.utils import conv
@@ -160,12 +161,13 @@ def upsampling_2d(
 
     .. admonition:: Example
 
-        It should be noted that you need to specify ``use_cudnn=False`` when
-        you create MaxPooling2D object because if cuDNN used for operating
-        max pooling, ``indexes`` is never created and stored in the
-        MaxPooling2D object.
+        It should be noted that you need to turn off
+        ``chainer.config.use_cudnn`` flag when you create MaxPooling2D object
+        because if cuDNN used for operating max pooling, ``indexes`` is never
+        created and stored in the MaxPooling2D object.
 
-        >>> p = F.MaxPooling2D(2, 2, use_cudnn=False)
+        >>> with chainer.using_config('train', False):
+        ...     p = F.MaxPooling2D(2, 2)
         >>> x = np.arange(1, 37).reshape(1, 1, 6, 6).astype('f')
         >>> x = chainer.Variable(x)
         >>> x.data

--- a/chainer/functions/pooling/upsampling_2d.py
+++ b/chainer/functions/pooling/upsampling_2d.py
@@ -165,7 +165,7 @@ def upsampling_2d(
         because if cuDNN used for operating max pooling, ``indexes`` is never
         created and stored in the MaxPooling2D object.
 
-        >>> with chainer.using_config('use_cudnn', False):
+        >>> with chainer.using_config('use_cudnn', 'never'):
         ...     p = F.MaxPooling2D(2, 2)
         >>> x = np.arange(1, 37).reshape(1, 1, 6, 6).astype('f')
         >>> x = chainer.Variable(x)

--- a/chainer/functions/pooling/upsampling_2d.py
+++ b/chainer/functions/pooling/upsampling_2d.py
@@ -1,4 +1,3 @@
-from chainer import configuration
 from chainer import cuda
 from chainer.functions.pooling import pooling_2d
 from chainer.utils import conv
@@ -166,7 +165,7 @@ def upsampling_2d(
         because if cuDNN used for operating max pooling, ``indexes`` is never
         created and stored in the MaxPooling2D object.
 
-        >>> with chainer.using_config('train', False):
+        >>> with chainer.using_config('use_cudnn', False):
         ...     p = F.MaxPooling2D(2, 2)
         >>> x = np.arange(1, 37).reshape(1, 1, 6, 6).astype('f')
         >>> x = chainer.Variable(x)

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -423,9 +423,9 @@ class CaffeFunction(link.Chain):
         if layer.softmax_param.engine == 0:  # DEFAULT
             fw = functions.softmax
         elif layer.softmax_param.engine == 1:  # CAFFE
-            fw = _SingleArgumentFunction(functions.softmax, use_cudnn=False)
+            fw = _SingleArgumentFunctionWithCudnn(False, functions.softmax)
         elif layer.softmax_param.engine == 2:  # CUDNN
-            fw = _SingleArgumentFunction(functions.softmax, use_cudnn=True)
+            fw = _SingleArgumentFunctionWithCudnn(True, functions.softmax)
 
         self.forwards[layer.name] = fw
         self._add_layer(layer)
@@ -552,6 +552,18 @@ class _ListArgumentFcuntion(object):
 
     def __call__(self, *xs):
         return self.func(xs, **self.kwargs)
+
+
+class _SingleArgumentFunctionWithCudnn(_SingleArgumentFunction):
+
+    def __init__(self, use_cudnn, func, *args, **kwargs):
+        super(_SingleArgumentFunctionWithCudnn, self).__init__(
+            func, *args, **kwargs)
+        self.use_cudnn = use_cudnn
+
+    def __call__(self, x):
+        with configuration.using_config('use_cudnn', self.use_cudnn):
+            return  super(_SingleArgumentFunctionWithCudnn, self).__call__(x)
 
 
 class _CallChildLink(object):

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -563,7 +563,7 @@ class _SingleArgumentFunctionWithCudnn(_SingleArgumentFunction):
 
     def __call__(self, x):
         with configuration.using_config('use_cudnn', self.use_cudnn):
-            return  super(_SingleArgumentFunctionWithCudnn, self).__call__(x)
+            return super(_SingleArgumentFunctionWithCudnn, self).__call__(x)
 
 
 class _CallChildLink(object):

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -24,7 +24,6 @@ class Convolution2D(link.Link):
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         bias (float): Initial bias value.
         nobias (bool): If ``True``, then this link does not use the bias term.
-        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
         initialW (4-D array): Initial weight value. If ``None``, then this
             function uses the default initializer to initialize
             the weight tensor.
@@ -51,13 +50,12 @@ class Convolution2D(link.Link):
     """
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
-                 bias=0, nobias=False, use_cudnn=True,
+                 bias=0, nobias=False,
                  initialW=None, initial_bias=None, deterministic=False):
         super(Convolution2D, self).__init__()
         self.ksize = ksize
         self.stride = _pair(stride)
         self.pad = _pair(pad)
-        self.use_cudnn = use_cudnn
         self.out_channels = out_channels
         self.deterministic = deterministic
 
@@ -98,7 +96,7 @@ class Convolution2D(link.Link):
             with cuda.get_device(self._device_id):
                 self._initialize_params(x.shape[1])
         return convolution_2d.convolution_2d(
-            x, self.W, self.b, self.stride, self.pad, self.use_cudnn,
+            x, self.W, self.b, self.stride, self.pad,
             deterministic=self.deterministic)
 
 

--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -27,9 +27,6 @@ class ConvolutionND(link.Link):
             initializer instance or another value except ``None`` that
             :func:`~chainer.init_weight` helper function can take. If ``None``
             is given, this link does not use the bias vector.
-        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
-            See :func:`~chainer.functions.convolution_nd` for exact conditions
-            of cuDNN availability.
         cover_all (bool): If ``True``, all spatial locations are convoluted
             into some output pixels. It may make the output size larger.
             ``cover_all`` needs to be ``False`` if you want to use cuDNN.
@@ -48,12 +45,10 @@ class ConvolutionND(link.Link):
     """
 
     def __init__(self, ndim, in_channels, out_channels, ksize, stride=1, pad=0,
-                 initialW=None, initial_bias=None, use_cudnn=True,
-                 cover_all=False):
+                 initialW=None, initial_bias=None, cover_all=False):
         ksize = conv_nd.as_tuple(ksize, ndim)
         self.stride = stride
         self.pad = pad
-        self.use_cudnn = use_cudnn
         self.cover_all = cover_all
 
         super(ConvolutionND, self).__init__()
@@ -79,5 +74,4 @@ class ConvolutionND(link.Link):
 
         """
         return convolution_nd.convolution_nd(
-            x, self.W, self.b, self.stride, self.pad,
-            use_cudnn=self.use_cudnn, cover_all=self.cover_all)
+            x, self.W, self.b, self.stride, self.pad, cover_all=self.cover_all)

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -31,8 +31,6 @@ class Deconvolution2D(link.Link):
             It should be pair of height and width :math:`(out_H, out_W)`.
             Default value is ``None`` and the outsize is estimated by
             input size, stride and pad.
-        use_cudnn (bool): If ``True``, then this function uses cuDNN if
-            available.
         initialW (4-D array): Initial weight value. If ``None``, then this
             function uses the default initializer to initialize
             the weight tensor.
@@ -67,14 +65,13 @@ class Deconvolution2D(link.Link):
     """
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
-                 bias=0, nobias=False, outsize=None, use_cudnn=True,
+                 bias=0, nobias=False, outsize=None,
                  initialW=None, initial_bias=None, deterministic=False):
         super(Deconvolution2D, self).__init__()
         self.ksize = ksize
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.outsize = (None, None) if outsize is None else outsize
-        self.use_cudnn = use_cudnn
         self.initialW = initialW
         self.out_channels = out_channels
         self.deterministic = deterministic
@@ -106,8 +103,7 @@ class Deconvolution2D(link.Link):
                 self._initialize_params(x.shape[1])
         return deconvolution_2d.deconvolution_2d(
             x, self.W, self.b, self.stride, self.pad,
-            self.outsize, self.use_cudnn,
-            deterministic=self.deterministic)
+            self.outsize, deterministic=self.deterministic)
 
 
 def _pair(x):

--- a/chainer/links/connection/deconvolution_nd.py
+++ b/chainer/links/connection/deconvolution_nd.py
@@ -31,7 +31,6 @@ class DeconvolutionND(link.Link):
             initializer instance or another value except ``None`` the same with
             that :func:`~chainer.init_weight` function can take. If ``None`` is
             supplied, this link does not use the bias vector.
-        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
 
     .. seealso::
        :func:`~chainer.functions.deconvolution_nd`
@@ -44,11 +43,10 @@ class DeconvolutionND(link.Link):
     """
 
     def __init__(self, ndim, in_channels, out_channels, ksize, stride=1, pad=0,
-                 outsize=None, initialW=None, initial_bias=0, use_cudnn=True):
+                 outsize=None, initialW=None, initial_bias=0):
         ksize = conv_nd.as_tuple(ksize, ndim)
         self.stride = stride
         self.pad = pad
-        self.use_cudnn = use_cudnn
         self.outsize = outsize
 
         super(DeconvolutionND, self).__init__()
@@ -66,4 +64,4 @@ class DeconvolutionND(link.Link):
     def __call__(self, x):
         return deconvolution_nd.deconvolution_nd(
             x, self.W, b=self.b, stride=self.stride, pad=self.pad,
-            outsize=self.outsize, use_cudnn=self.use_cudnn)
+            outsize=self.outsize)

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -26,7 +26,6 @@ class DilatedConvolution2D(link.Link):
             ``dilate=d`` and ``dilate=(d, d)`` are equivalent.
         bias (float): Initial bias value.
         nobias (bool): If ``True``, then this link does not use the bias term.
-        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
         initialW (4-D array): Initial weight value. If ``None``, the default
             initializer is used to initialize the weight matrix.
             May also be a callable that takes ``numpy.ndarray`` or
@@ -47,14 +46,13 @@ class DilatedConvolution2D(link.Link):
     """
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
-                 dilate=1, bias=0, nobias=False, use_cudnn=True,
+                 dilate=1, bias=0, nobias=False,
                  initialW=None, initial_bias=None):
         super(DilatedConvolution2D, self).__init__()
         self.ksize = ksize
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.dilate = _pair(dilate)
-        self.use_cudnn = use_cudnn
         self.out_channels = out_channels
         self.initialW = initialW
 
@@ -91,8 +89,7 @@ class DilatedConvolution2D(link.Link):
             with cuda.get_device(self._device_id):
                 self._initialize_params(x.shape[1])
         return dilated_convolution_2d.dilated_convolution_2d(
-            x, self.W, self.b, self.stride,
-            self.pad, self.dilate, self.use_cudnn)
+            x, self.W, self.b, self.stride, self.pad, self.dilate)
 
 
 def _pair(x):

--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -31,7 +31,6 @@ class MLPConvolution2D(link.ChainList):
             equivalent.
         activation (function): Activation function for internal hidden units.
             Note that this function is not applied to the output of this link.
-        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
         conv_init: An initializer of weight matrices
             passed to the convolution layers.
         bias_init: An initializer of bias vectors
@@ -45,18 +44,16 @@ class MLPConvolution2D(link.ChainList):
     """
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
-                 activation=relu.relu, use_cudnn=True,
+                 activation=relu.relu, wscale=1,
                  conv_init=None, bias_init=None):
         assert len(out_channels) > 0
         convs = [convolution_2d.Convolution2D(
             in_channels, out_channels[0], ksize, stride, pad,
-            use_cudnn=use_cudnn, initialW=conv_init,
-            initial_bias=bias_init)]
+            initialW=conv_init, initial_bias=bias_init)]
         for n_in, n_out in zip(out_channels, out_channels[1:]):
             convs.append(convolution_2d.Convolution2D(
                 n_in, n_out, 1, initialW=conv_init,
-                initial_bias=bias_init,
-                use_cudnn=use_cudnn))
+                initial_bias=bias_init))
         super(MLPConvolution2D, self).__init__(*convs)
         self.activation = activation
 

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -40,15 +40,13 @@ class NStepLSTM(link.ChainList):
         in_size (int): Dimensionality of input vectors.
         out_size (int): Dimensionality of hidden states and output vectors.
         dropout (float): Dropout ratio.
-        use_cudnn (bool): Use cuDNN.
 
     .. seealso::
         :func:`chainer.functions.n_step_lstm`
 
     """
 
-    def __init__(
-            self, n_layers, in_size, out_size, dropout, use_cudnn=True):
+    def __init__(self, n_layers, in_size, out_size, dropout):
         weights = []
         for i in six.moves.range(n_layers):
             weight = link.Link()
@@ -68,7 +66,6 @@ class NStepLSTM(link.ChainList):
 
         self.n_layers = n_layers
         self.dropout = dropout
-        self.use_cudnn = use_cudnn
 
     def __call__(self, hx, cx, xs):
         """Calculate all hidden states and cell states.
@@ -92,8 +89,7 @@ class NStepLSTM(link.ChainList):
         bs = [[w.b0, w.b1, w.b2, w.b3, w.b4, w.b5, w.b6, w.b7] for w in self]
 
         hy, cy, trans_y = rnn.n_step_lstm(
-            self.n_layers, self.dropout, hx, cx, ws, bs, trans_x,
-            use_cudnn=self.use_cudnn)
+            self.n_layers, self.dropout, hx, cx, ws, bs, trans_x)
 
         hy = permutate.permutate(hy, indices, axis=1, inv=True)
         cy = permutate.permutate(cy, indices, axis=1, inv=True)

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -41,7 +41,6 @@ class BatchNormalization(link.Link):
             unit(1) which makes no effect.
         use_beta (bool): If ``True``, use shifting parameter. Otherwise, use
             unit(0) which makes no effect.
-        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
 
     See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
           Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_
@@ -59,13 +58,12 @@ class BatchNormalization(link.Link):
         decay (float): Decay rate of moving average. It is used on training.
         eps (float): Epsilon value for numerical stability. This value is added
             to the batch variances.
-        use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
 
     """
 
     def __init__(self, size, decay=0.9, eps=2e-5, dtype=numpy.float32,
                  use_gamma=True, use_beta=True,
-                 initial_gamma=None, initial_beta=None, use_cudnn=True):
+                 initial_gamma=None, initial_beta=None):
         super(BatchNormalization, self).__init__()
         if use_gamma:
             self.add_param('gamma', size, dtype=dtype)
@@ -82,7 +80,6 @@ class BatchNormalization(link.Link):
         self.add_persistent('N', 0)
         self.decay = decay
         self.eps = eps
-        self.use_cudnn = use_cudnn
 
     def __call__(self, x, finetune=False):
         """Invokes the forward propagation of BatchNormalization.
@@ -121,7 +118,7 @@ class BatchNormalization(link.Link):
                 decay = self.decay
 
             func = batch_normalization.BatchNormalizationFunction(
-                self.eps, self.avg_mean, self.avg_var, decay, self.use_cudnn)
+                self.eps, self.avg_mean, self.avg_var, decay)
             ret = func(x, gamma, beta)
 
             self.avg_mean[:] = func.running_mean
@@ -131,7 +128,7 @@ class BatchNormalization(link.Link):
             mean = variable.Variable(self.avg_mean, volatile='auto')
             var = variable.Variable(self.avg_var, volatile='auto')
             ret = batch_normalization.fixed_batch_normalization(
-                x, gamma, beta, mean, var, self.eps, self.use_cudnn)
+                x, gamma, beta, mean, var, self.eps)
         return ret
 
     def start_finetuning(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -34,7 +34,7 @@ class TestLogSoftmax(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
-    def check_forward(self, x_data, use_cudnn=True):
+    def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.log_softmax(x)
@@ -59,9 +59,9 @@ class TestLogSoftmax(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), False)
+        self.check_forward(cuda.to_gpu(self.x), 'never')
 
-    def check_backward(self, x_data, gy_data, use_cudnn=True):
+    def check_backward(self, x_data, gy_data, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 functions.LogSoftmax(), x_data, gy_data,
@@ -79,11 +79,11 @@ class TestLogSoftmax(unittest.TestCase):
     @attr.gpu
     @condition.retry(10)
     def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -92,7 +92,8 @@ class TestLogSoftmaxCudnnCall(unittest.TestCase):
     def setUp(self):
         self.x = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
-        self.expect = self.use_cudnn and cuda.cudnn.cudnn.getVersion() >= 3000
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expect = chainer.should_use_cudnn('>=auto', 3000)
 
     def forward(self):
         x = chainer.Variable(self.x)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -28,7 +28,7 @@ class TestSigmoid(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
-    def check_forward(self, x_data, use_cudnn=True):
+    def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.sigmoid(x)
@@ -41,19 +41,20 @@ class TestSigmoid(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x), True)
+        self.check_forward(cuda.to_gpu(self.x), 'always')
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
-        self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)), True)
+        self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+                           'always')
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), False)
+        self.check_forward(cuda.to_gpu(self.x), 'never')
 
-    def check_backward(self, x_data, y_grad, use_cudnn=True):
+    def check_backward(self, x_data, y_grad, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 functions.Sigmoid(), x_data, y_grad,
@@ -77,11 +78,11 @@ class TestSigmoid(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -90,9 +91,10 @@ class TestSigmoidCudnnCall(unittest.TestCase):
     def setUp(self):
         self.x = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
-        self.expect = self.use_cudnn and (
-            cuda.cudnn.cudnn.getVersion() >= 3000 or
-            self.dtype != numpy.float16)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expect = chainer.should_use_cudnn('==always') and (
+                cuda.cudnn.cudnn.getVersion() >= 3000 or
+                self.dtype != numpy.float16)
 
     def forward(self):
         x = chainer.Variable(self.x)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -34,7 +34,7 @@ class TestSoftmax(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
-    def check_forward(self, x_data, use_cudnn=True):
+    def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.softmax(x)
@@ -60,9 +60,9 @@ class TestSoftmax(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), False)
+        self.check_forward(cuda.to_gpu(self.x), 'never')
 
-    def check_backward(self, x_data, gy_data, use_cudnn=True):
+    def check_backward(self, x_data, gy_data, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 functions.Softmax(), x_data, gy_data,
@@ -80,11 +80,11 @@ class TestSoftmax(unittest.TestCase):
     @attr.gpu
     @condition.retry(10)
     def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -93,9 +93,10 @@ class TestSoftmaxCudnnCall(unittest.TestCase):
     def setUp(self):
         self.x = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
-        self.expect = self.use_cudnn and (
-            cuda.cudnn.cudnn.getVersion() >= 3000 or
-            self.dtype != numpy.float16)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expect = chainer.should_use_cudnn('>=auto') and (
+                cuda.cudnn.cudnn.getVersion() >= 3000 or
+                self.dtype != numpy.float16)
 
     def forward(self):
         x = chainer.Variable(self.x)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -28,7 +28,8 @@ class TestTanh(unittest.TestCase):
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)
-        y = functions.tanh(x, use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.tanh(x)
         self.assertEqual(y.data.dtype, self.dtype)
         y_expect = functions.tanh(chainer.Variable(self.x))
         testing.assert_allclose(y_expect.data, y.data)
@@ -49,9 +50,10 @@ class TestTanh(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, gy_data, use_cudnn=True):
-        gradient_check.check_backward(
-            functions.Tanh(use_cudnn), x_data, gy_data,
-            **self.check_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_backward(
+                functions.Tanh(), x_data, gy_data,
+                **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -90,19 +92,21 @@ class TestTanhCudnnCall(unittest.TestCase):
 
     def forward(self):
         x = chainer.Variable(self.x)
-        return functions.tanh(x, use_cudnn=self.use_cudnn)
+        return functions.tanh(x)
 
     def test_call_cudnn_forward(self):
-        with mock.patch('cupy.cudnn.cudnn.activationForward_v3') as func:
-            self.forward()
-            self.assertEqual(func.called, self.expect)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.cudnn.activationForward_v3') as func:
+                self.forward()
+                self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backward(self):
-        y = self.forward()
-        y.grad = self.gy
-        with mock.patch('cupy.cudnn.cudnn.activationBackward_v3') as func:
-            y.backward()
-            self.assertEqual(func.called, self.expect)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            y.grad = self.gy
+            with mock.patch('cupy.cudnn.cudnn.activationBackward_v3') as func:
+                y.backward()
+                self.assertEqual(func.called, self.expect)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -26,7 +26,7 @@ class TestTanh(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-3}
 
-    def check_forward(self, x_data, use_cudnn=True):
+    def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.tanh(x)
@@ -37,19 +37,20 @@ class TestTanh(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x), True)
+        self.check_forward(cuda.to_gpu(self.x), 'always')
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
-        self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)), True)
+        self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+                           'always')
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), False)
+        self.check_forward(cuda.to_gpu(self.x), 'never')
 
-    def check_backward(self, x_data, gy_data, use_cudnn=True):
+    def check_backward(self, x_data, gy_data, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 functions.Tanh(), x_data, gy_data,
@@ -73,11 +74,11 @@ class TestTanh(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -86,9 +87,10 @@ class TestTanhCudnnCall(unittest.TestCase):
     def setUp(self):
         self.x = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
-        self.expect = self.use_cudnn and (
-            cuda.cudnn.cudnn.getVersion() >= 3000 or
-            self.dtype != numpy.float16)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expect = chainer.should_use_cudnn('==always') and (
+                cuda.cudnn.cudnn.getVersion() >= 3000 or
+                self.dtype != numpy.float16)
 
     def forward(self):
         x = chainer.Variable(self.x)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -32,7 +32,7 @@ class TestConvolution2DFunction(unittest.TestCase):
         kh, kw = (3, 3)
         self.stride = 2
         self.pad = 1
-        self.use_cudnn = True
+        self.use_cudnn = 'always'
         self.W = numpy.random.normal(
             0, numpy.sqrt(1. / (kh * kw * in_channels)),
             (out_channels, in_channels, kh, kw)).astype(self.W_dtype)
@@ -76,12 +76,12 @@ class TestConvolution2DFunction(unittest.TestCase):
 
     @attr.gpu
     def test_forward_consistency_im2col(self):
-        self.use_cudnn = False
+        self.use_cudnn = 'never'
         self.test_forward_consistency()
 
     @attr.gpu
     def test_forward_consistency_im2col_nobias(self):
-        self.use_cudnn = False
+        self.use_cudnn = 'never'
         self.test_forward_consistency(nobias=True)
 
     def check_backward(self, x_data, W_data, b_data, y_grad):
@@ -132,20 +132,20 @@ class TestConvolution2DFunction(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
-        self.use_cudnn = False
+        self.use_cudnn = 'never'
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             cuda.to_gpu(self.b), cuda.to_gpu(self.gy))
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_im2col_nobias(self):
-        self.use_cudnn = False
+        self.use_cudnn = 'never'
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             None, cuda.to_gpu(self.gy))
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -164,9 +164,10 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
             (out_channels, in_channels, kh, kw)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(
             -1, 1, (2, 2, 2, 2)).astype(self.dtype)
-        self.expect = self.use_cudnn and (
-            cuda.cudnn.cudnn.getVersion() >= 3000 or
-            self.dtype != numpy.float16)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expect = chainer.should_use_cudnn('>=auto') and (
+                cuda.cudnn.cudnn.getVersion() >= 3000 or
+                self.dtype != numpy.float16)
 
     def forward(self):
         x = chainer.Variable(self.x)
@@ -272,7 +273,8 @@ class TestConvolution2DFunctionDeterministic(unittest.TestCase):
         return x_data, W_data, b_data, gy_data
 
     def _run(self):
-        with chainer.using_config('use_cudnn', True):
+        with chainer.using_config('use_cudnn', 'always'):
+            print(chainer.should_use_cudnn('>=auto'))
             # verify data continuity and move to gpu
             x_data, W_data, b_data, gy_data = \
                 tuple(cuda.to_gpu(data) for data in self._contiguous(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -68,7 +68,7 @@ class TestDeconvolutionND(unittest.TestCase):
             self.check_backward_options = {
                 'eps': 2 ** -3, 'atol': 1e-3, 'rtol': 1e-2}
 
-    def check_forward_consistency(self, use_cudnn=True):
+    def check_forward_consistency(self, use_cudnn='always'):
         x_cpu = chainer.Variable(self.x)
         W_cpu = chainer.Variable(self.W)
         b_cpu = None if self.nobias else chainer.Variable(self.b)
@@ -91,14 +91,14 @@ class TestDeconvolutionND(unittest.TestCase):
 
     @attr.cudnn
     def test_forward_consistency_cudnn(self):
-        self.check_forward_consistency(use_cudnn=True)
+        self.check_forward_consistency(use_cudnn='always')
 
     @attr.gpu
     def test_forward_consistency_im2col(self):
-        self.check_forward_consistency(use_cudnn=False)
+        self.check_forward_consistency(use_cudnn='never')
 
     def check_forward_consistency_regression(self, x_data, W_data, b_data,
-                                             use_cudnn=True):
+                                             use_cudnn='always'):
         x = chainer.Variable(x_data)
         W = chainer.Variable(W_data)
         b = None if self.nobias else chainer.Variable(b_data)
@@ -123,7 +123,7 @@ class TestDeconvolutionND(unittest.TestCase):
         if len(self.dims) == 2:
             self.check_forward_consistency_regression(
                 cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b),
-                use_cudnn=True)
+                use_cudnn='always')
 
     @attr.gpu
     def test_forward_consistency_regression_im2col(self):
@@ -131,9 +131,9 @@ class TestDeconvolutionND(unittest.TestCase):
         if len(self.dims) == 2:
             self.check_forward_consistency_regression(
                 cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b),
-                use_cudnn=False)
+                use_cudnn='never')
 
-    def check_backward(self, x_data, W_data, b_data, y_grad, use_cudnn=False):
+    def check_backward(self, x_data, W_data, b_data, y_grad, use_cudnn='never'):
         if not self.c_contiguous:
             xp = cuda.get_array_module(x_data)
             x_data = xp.asfortranarray(x_data)
@@ -169,7 +169,7 @@ class TestDeconvolutionND(unittest.TestCase):
         b = None if self.b is None else cuda.to_gpu(self.b)
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.W), b,
-            cuda.to_gpu(self.gy), use_cudnn=True)
+            cuda.to_gpu(self.gy), use_cudnn='always')
 
     @attr.gpu
     @condition.retry(3)
@@ -177,12 +177,12 @@ class TestDeconvolutionND(unittest.TestCase):
         b = None if self.b is None else cuda.to_gpu(self.b)
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.W), b,
-            cuda.to_gpu(self.gy), use_cudnn=False)
+            cuda.to_gpu(self.gy), use_cudnn='never')
 
 
 @testing.parameterize(*testing.product({
     'dims': [(5, 4, 3), (4, 3), (3,)],
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -207,9 +207,11 @@ class TestDeconvolutionNDCudnnCall(unittest.TestCase):
         self.x = cuda.cupy.random.uniform(-1, 1, x_shape).astype(self.dtype)
         gy_shape = (2, out_channels) + outs
         self.gy = cuda.cupy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
-        self.expected = self.use_cudnn and ndim > 1 and (
-            cuda.cudnn.cudnn.getVersion() >= 3000 or
-            self.dtype != numpy.float16)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expected = (chainer.should_use_cudnn('>=auto') and
+                             ndim > 1 and (
+                                 cuda.cudnn.cudnn.getVersion() >= 3000 or
+                                 self.dtype != numpy.float16))
 
     def forward(self):
         x = chainer.Variable(self.x)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -133,7 +133,8 @@ class TestDeconvolutionND(unittest.TestCase):
                 cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b),
                 use_cudnn='never')
 
-    def check_backward(self, x_data, W_data, b_data, y_grad, use_cudnn='never'):
+    def check_backward(self, x_data, W_data, b_data, y_grad,
+                       use_cudnn='never'):
         if not self.c_contiguous:
             xp = cuda.get_array_module(x_data)
             x_data = xp.asfortranarray(x_data)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -20,7 +20,7 @@ def _split(inputs, pos):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'never'],
 }))
 class TestNStepLSTM(unittest.TestCase):
 
@@ -167,7 +167,7 @@ class TestNStepLSTM(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
 }))
 @attr.cudnn
 class TestNStepLSTMCudnnCall(unittest.TestCase):
@@ -211,8 +211,8 @@ class TestNStepLSTMCudnnCall(unittest.TestCase):
             for b in self.batches]
         self.dcy = cuda.cupy.random.uniform(-1, 1, h_shape).astype('f')
         self.dhy = cuda.cupy.random.uniform(-1, 1, h_shape).astype('f')
-        self.expect = self.use_cudnn and (
-            cuda.cudnn.cudnn.getVersion() >= 5000)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expect = chainer.should_use_cudnn('>=auto', 5000)
 
     def forward(self, train):
         volatile = not train

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -57,7 +57,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         else:
             self.class_weight = None
 
-    def check_forward(self, x_data, t_data, class_weight, use_cudnn=True):
+    def check_forward(self, x_data, t_data, class_weight, use_cudnn='always'):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
         with chainer.using_config('use_cudnn', use_cudnn):
@@ -117,7 +117,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             None if not self.weight_apply else cuda.to_gpu(self.class_weight),
             False)
 
-    def check_backward(self, x_data, t_data, class_weight, use_cudnn=True):
+    def check_backward(self, x_data, t_data, class_weight, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             func = functions.SoftmaxCrossEntropy(
                 cache_score=self.cache_score, class_weight=class_weight)
@@ -191,7 +191,7 @@ class TestSoftmaxCrossEntropyValueCheck(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -215,7 +215,8 @@ class TestSoftmaxCrossEntropyCudnnCall(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             with mock.patch('cupy.cudnn.cudnn.softmaxForward') as func:
                 self.forward()
-                self.assertEqual(func.called, self.use_cudnn)
+                self.assertEqual(func.called,
+                                 chainer.should_use_cudnn('>=auto'))
 
     # Note that SoftmaxCrossEntropy does not use cudnn on backward
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -115,7 +115,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         self.check_forward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
             None if not self.weight_apply else cuda.to_gpu(self.class_weight),
-            False)
+            'never')
 
     def check_backward(self, x_data, t_data, class_weight, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
@@ -144,7 +144,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
             None if not self.weight_apply else cuda.to_gpu(self.class_weight),
-            False)
+            'never')
 
 
 @testing.parameterize(
@@ -179,15 +179,16 @@ class TestSoftmaxCrossEntropyValueCheck(unittest.TestCase):
     # numpy.broadcast_to is available only from numpy>=1.10
     @testing.with_requires('numpy>=1.10')
     def test_value_check_cpu(self):
-        self.check_value_check(self.x, self.t, False)
+        self.check_value_check(self.x, self.t, 'never')
 
     @attr.gpu
     def test_value_check_gpu(self):
-        self.check_value_check(self.x, self.t, False)
+        self.check_value_check(self.x, self.t, 'never')
 
     @attr.gpu
     def test_value_check_gpu_cudnn(self):
-        self.check_value_check(cuda.to_gpu(self.x), cuda.to_gpu(self.t), True)
+        self.check_value_check(cuda.to_gpu(self.x), cuda.to_gpu(self.t),
+                               'always')
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -76,7 +76,7 @@ class TestBatchNormalization(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward([cuda.to_gpu(i) for i in self.args], False)
+        self.check_forward([cuda.to_gpu(i) for i in self.args], 'never')
 
     def check_backward(self, args, y_grad):
         with chainer.using_config('train', self.train):
@@ -151,7 +151,7 @@ class TestFixedBatchNormalization(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward([cuda.to_gpu(i) for i in self.args], False)
+        self.check_forward([cuda.to_gpu(i) for i in self.args], 'never')
 
     def check_backward(self, args, y_grad):
         with chainer.using_config('train', self.train):

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -211,7 +211,9 @@ class TestBatchNormalizationCudnnCall(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             y = self.forward()
             y.grad = self.gy
-            with mock.patch('cupy.cudnn.cudnn.batchNormalizationBackward') as func:
+            with mock.patch(
+                    'cupy.cudnn.cudnn.batchNormalizationBackward'
+            ) as func:
                 y.backward()
                 self.assertEqual(func.called, self.expect)
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -32,8 +32,8 @@ class TestAveragePooling2D(unittest.TestCase):
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)
-        y = functions.average_pooling_2d(x, 3, stride=2,
-                                         pad=1, use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.average_pooling_2d(x, 3, stride=2, pad=1)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -62,9 +62,10 @@ class TestAveragePooling2D(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        gradient_check.check_backward(
-            functions.AveragePooling2D(3, 2, 1, False, use_cudnn),
-            x_data, y_grad, **self.check_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_backward(
+                functions.AveragePooling2D(3, 2, 1, False),
+                x_data, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -96,26 +97,27 @@ class TestAveragePooling2DCudnnCall(unittest.TestCase):
 
     def forward(self):
         x = chainer.Variable(self.x)
-        return functions.average_pooling_2d(
-            x, 3, stride=2, pad=1, use_cudnn=self.use_cudnn)
+        return functions.average_pooling_2d(x, 3, stride=2, pad=1)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports average-pooling2d')
     def test_call_cudnn_forward(self):
-        with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
-            self.forward()
-            self.assertEqual(func.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
+                self.forward()
+                self.assertEqual(func.called, self.use_cudnn)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports average-pooling2d')
     def test_call_cudnn_backward(self):
-        y = self.forward()
-        y.grad = self.gy
-        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-            y.backward()
-            self.assertEqual(func.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            y.grad = self.gy
+            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+                y.backward()
+                self.assertEqual(func.called, self.use_cudnn)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -30,7 +30,7 @@ class TestAveragePooling2D(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
-    def check_forward(self, x_data, use_cudnn=True):
+    def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.average_pooling_2d(x, 3, stride=2, pad=1)
@@ -59,9 +59,9 @@ class TestAveragePooling2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), False)
+        self.check_forward(cuda.to_gpu(self.x), 'never')
 
-    def check_backward(self, x_data, y_grad, use_cudnn=True):
+    def check_backward(self, x_data, y_grad, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 functions.AveragePooling2D(3, 2, 1, False),
@@ -79,11 +79,11 @@ class TestAveragePooling2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -106,18 +106,21 @@ class TestAveragePooling2DCudnnCall(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
                 self.forward()
-                self.assertEqual(func.called, self.use_cudnn)
+                self.assertEqual(func.called,
+                                 chainer.should_use_cudnn('>=auto'))
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports average-pooling2d')
     def test_call_cudnn_backward(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
+            expect = chainer.should_use_cudnn('>=auto')
             y = self.forward()
-            y.grad = self.gy
-            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-                y.backward()
-                self.assertEqual(func.called, self.use_cudnn)
+        # should be consistent to forward regardless of use_cudnn config
+        y.grad = self.gy
+        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+            y.backward()
+            self.assertEqual(func.called, expect)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
@@ -51,8 +51,8 @@ class TestAveragePoolingND(unittest.TestCase):
         stride = self.stride
         pad = self.pad
         x = chainer.Variable(x_data)
-        y = functions.average_pooling_nd(x, ksize, stride, pad,
-                                         use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.average_pooling_nd(x, ksize, stride, pad)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -92,10 +92,11 @@ class TestAveragePoolingND(unittest.TestCase):
         stride = self.stride
         pad = self.pad
 
-        y_nd = functions.average_pooling_nd(x_data, ksize, stride=stride,
-                                            pad=pad, use_cudnn=use_cudnn)
-        y_2d = functions.average_pooling_2d(x_data, ksize, stride=stride,
-                                            pad=pad, use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y_nd = functions.average_pooling_nd(x_data, ksize, stride=stride,
+                                                pad=pad)
+            y_2d = functions.average_pooling_2d(x_data, ksize, stride=stride,
+                                                pad=pad)
         testing.assert_allclose(y_nd.data, y_2d.data)
 
     @condition.retry(3)
@@ -113,11 +114,11 @@ class TestAveragePoolingND(unittest.TestCase):
         self.check_forward_consistency_regression(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        gradient_check.check_backward(
-            functions.AveragePoolingND(
-                self.ndim, self.ksize, self.stride, self.pad,
-                use_cudnn=use_cudnn),
-            x_data, y_grad, **self.check_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_backward(
+                functions.AveragePoolingND(
+                    self.ndim, self.ksize, self.stride, self.pad),
+                x_data, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -159,25 +160,27 @@ class TestAveragePoolingNDCudnnCall(unittest.TestCase):
     def forward(self):
         x = chainer.Variable(self.x)
         return functions.average_pooling_nd(
-            x, self.ksize, self.stride, self.pad, use_cudnn=self.use_cudnn)
+            x, self.ksize, self.stride, self.pad)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports average-pooling-nd')
     def test_call_cudnn_forward(self):
-        with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
-            self.forward()
-            self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
+                self.forward()
+                self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports average-pooling-nd')
     def test_call_cudnn_backward(self):
-        y = self.forward()
-        y.grad = self.gy
-        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-            y.backward()
-            self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            y.grad = self.gy
+            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+                y.backward()
+                self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
 
 
 class TestAveragePoolingNDCoverAllNotSupported(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -35,9 +35,9 @@ class TestMaxPooling2D(unittest.TestCase):
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)
-        y = functions.max_pooling_2d(x, 3, stride=2, pad=1,
-                                     cover_all=self.cover_all,
-                                     use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.max_pooling_2d(x, 3, stride=2, pad=1,
+                                         cover_all=self.cover_all)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -76,11 +76,11 @@ class TestMaxPooling2D(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        gradient_check.check_backward(
-            functions.MaxPooling2D(
-                3, stride=2, pad=1, cover_all=self.cover_all,
-                use_cudnn=use_cudnn),
-            x_data, y_grad, **self.check_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_backward(
+                functions.MaxPooling2D(
+                    3, stride=2, pad=1, cover_all=self.cover_all),
+                x_data, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -120,25 +120,27 @@ class TestMaxPooling2DCudnnCall(unittest.TestCase):
     def forward(self):
         x = chainer.Variable(self.x)
         return functions.max_pooling_2d(
-            x, 3, stride=2, pad=1, cover_all=False, use_cudnn=self.use_cudnn)
+            x, 3, stride=2, pad=1, cover_all=False)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports max-pooling2d')
     def test_call_cudnn_forward(self):
-        with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
-            self.forward()
-            self.assertEqual(func.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
+                self.forward()
+                self.assertEqual(func.called, self.use_cudnn)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports max-pooling2d')
     def test_call_cudnn_backward(self):
-        y = self.forward()
-        y.grad = self.gy
-        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-            y.backward()
-            self.assertEqual(func.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            y.grad = self.gy
+            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+                y.backward()
+                self.assertEqual(func.called, self.use_cudnn)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -55,9 +55,9 @@ class TestMaxPoolingND(unittest.TestCase):
         stride = self.stride
         pad = self.pad
         x = chainer.Variable(x_data)
-        y = functions.max_pooling_nd(x, ksize, stride=stride, pad=pad,
-                                     cover_all=self.cover_all,
-                                     use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.max_pooling_nd(x, ksize, stride=stride, pad=pad,
+                                         cover_all=self.cover_all)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -103,20 +103,20 @@ class TestMaxPoolingND(unittest.TestCase):
         stride = self.stride
         pad = self.pad
 
-        y_nd = functions.max_pooling_nd(self.x, ksize, stride=stride, pad=pad,
-                                        use_cudnn=False,
-                                        cover_all=self.cover_all)
-        y_2d = functions.max_pooling_2d(self.x, ksize, stride=stride, pad=pad,
-                                        use_cudnn=False,
-                                        cover_all=self.cover_all)
+        with chainer.using_config('use_cudnn', False):
+            y_nd = functions.max_pooling_nd(self.x, ksize, stride=stride, pad=pad,
+                                            cover_all=self.cover_all)
+            y_2d = functions.max_pooling_2d(self.x, ksize, stride=stride, pad=pad,
+                                            cover_all=self.cover_all)
         testing.assert_allclose(y_nd.data, y_2d.data)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        gradient_check.check_backward(
-            functions.MaxPoolingND(
-                self.ndim, self.ksize, stride=self.stride, pad=self.pad,
-                cover_all=self.cover_all, use_cudnn=use_cudnn),
-            x_data, y_grad, **self.check_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_backward(
+                functions.MaxPoolingND(
+                    self.ndim, self.ksize, stride=self.stride, pad=self.pad,
+                    cover_all=self.cover_all),
+                x_data, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -166,26 +166,27 @@ class TestMaxPoolingNDCudnnCall(unittest.TestCase):
     def forward(self):
         x = chainer.Variable(self.x)
         return functions.max_pooling_nd(
-            x, self.ksize, self.stride, self.pad, cover_all=False,
-            use_cudnn=self.use_cudnn)
+            x, self.ksize, self.stride, self.pad, cover_all=False)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports max-pooling-nd')
     def test_call_cudnn_forward(self):
-        with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
-            self.forward()
-            self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
+                self.forward()
+                self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports max-pooling-nd')
     def test_call_cudnn_backward(self):
-        y = self.forward()
-        y.grad = self.gy
-        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-            y.backward()
-            self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            y.grad = self.gy
+            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+                y.backward()
+                self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -49,7 +49,7 @@ class TestMaxPoolingND(unittest.TestCase):
             self.check_backward_options = {
                 'eps': 2.0 ** -8, 'atol': 1e-03, 'rtol': 1e-03}
 
-    def check_forward(self, x_data, use_cudnn=True):
+    def check_forward(self, x_data, use_cudnn='always'):
         dims = self.dims
         ksize = self.ksize
         stride = self.stride
@@ -73,7 +73,7 @@ class TestMaxPoolingND(unittest.TestCase):
 
     @condition.retry(3)
     def test_forward_cpu(self):
-        self.check_forward(self.x, use_cudnn=False)
+        self.check_forward(self.x, use_cudnn='never')
 
     def test_forward_cpu_wide(self):  # see #120
         ndim = self.ndim
@@ -91,7 +91,7 @@ class TestMaxPoolingND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), False)
+        self.check_forward(cuda.to_gpu(self.x), 'never')
 
     def test_forward_consistency_regression(self):
         # Regression test to max_pooling_2d.
@@ -103,14 +103,14 @@ class TestMaxPoolingND(unittest.TestCase):
         stride = self.stride
         pad = self.pad
 
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             y_nd = functions.max_pooling_nd(self.x, ksize, stride=stride, pad=pad,
                                             cover_all=self.cover_all)
             y_2d = functions.max_pooling_2d(self.x, ksize, stride=stride, pad=pad,
                                             cover_all=self.cover_all)
         testing.assert_allclose(y_nd.data, y_2d.data)
 
-    def check_backward(self, x_data, y_grad, use_cudnn=True):
+    def check_backward(self, x_data, y_grad, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 functions.MaxPoolingND(
@@ -130,7 +130,7 @@ class TestMaxPoolingND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
     def test_backward_cpu_more_than_once(self):
         func = functions.MaxPoolingND(
@@ -143,7 +143,7 @@ class TestMaxPoolingND(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'dims': [(4, 3, 2), (3, 2), (2,)],
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -175,18 +175,22 @@ class TestMaxPoolingNDCudnnCall(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
                 self.forward()
-                self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
+                self.assertEqual(func.called,
+                                 chainer.should_use_cudnn('>=auto') and
+                                 self.ndim > 1)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports max-pooling-nd')
     def test_call_cudnn_backward(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
+            expect = chainer.should_use_cudnn('>=auto') and self.ndim > 1
             y = self.forward()
-            y.grad = self.gy
-            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-                y.backward()
-                self.assertEqual(func.called, self.use_cudnn and self.ndim > 1)
+        # should be consistent to forward regardless of use_cudnn config
+        y.grad = self.gy
+        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+            y.backward()
+            self.assertEqual(func.called, expect)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -104,10 +104,10 @@ class TestMaxPoolingND(unittest.TestCase):
         pad = self.pad
 
         with chainer.using_config('use_cudnn', 'never'):
-            y_nd = functions.max_pooling_nd(self.x, ksize, stride=stride, pad=pad,
-                                            cover_all=self.cover_all)
-            y_2d = functions.max_pooling_2d(self.x, ksize, stride=stride, pad=pad,
-                                            cover_all=self.cover_all)
+            y_nd = functions.max_pooling_nd(self.x, ksize, stride=stride,
+                                            pad=pad, cover_all=self.cover_all)
+            y_2d = functions.max_pooling_2d(self.x, ksize, stride=stride,
+                                            pad=pad, cover_all=self.cover_all)
         testing.assert_allclose(y_nd.data, y_2d.data)
 
     def check_backward(self, x_data, y_grad, use_cudnn='always'):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -45,9 +45,9 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
 
     def check_forward(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)
-        y = functions.spatial_pyramid_pooling_2d(
-            x, self.pyramid_height, self.pooling_class,
-            use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.spatial_pyramid_pooling_2d(
+                x, self.pyramid_height, self.pooling_class)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -55,8 +55,9 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
 
     def check_forward_ones(self, x_data, use_cudnn=True):
         x = chainer.Variable(x_data)
-        y = functions.spatial_pyramid_pooling_2d(
-            x, self.pyramid_height, self.pooling_class, use_cudnn=use_cudnn)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.spatial_pyramid_pooling_2d(
+                x, self.pyramid_height, self.pooling_class)
         y_data = cuda.to_cpu(y.data)
 
         self.assertEqual(y_data.shape, (self.n, self.output_dim, 1, 1))
@@ -81,11 +82,11 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         self.check_forward_ones(cuda.to_gpu(self.one), False)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
-        gradient_check.check_backward(
-            functions.SpatialPyramidPooling2D(
-                x_data.shape[1:], self.pyramid_height, self.pooling_class,
-                use_cudnn=use_cudnn),
-            x_data, y_grad, **self.check_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_backward(
+                functions.SpatialPyramidPooling2D(
+                    x_data.shape[1:], self.pyramid_height, self.pooling_class),
+                x_data, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -140,26 +141,27 @@ class TestMaxPooling2DCudnnCall(unittest.TestCase):
     def forward(self):
         x = chainer.Variable(self.x)
         return functions.spatial_pyramid_pooling_2d(
-            x, 3, functions.MaxPooling2D,
-            use_cudnn=self.use_cudnn)
+            x, 3, functions.MaxPooling2D)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports spatial-pyramid-pooling2d')
     def test_call_cudnn_forward(self):
-        with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
-            self.forward()
-            self.assertEqual(func.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
+                self.forward()
+                self.assertEqual(func.called, self.use_cudnn)
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports spatial-pyramid-pooling2d')
     def test_call_cudnn_backward(self):
-        y = self.forward()
-        y.grad = self.gy
-        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-            y.backward()
-            self.assertEqual(func.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            y.grad = self.gy
+            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+                y.backward()
+                self.assertEqual(func.called, self.use_cudnn)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -43,7 +43,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
 
-    def check_forward(self, x_data, use_cudnn=True):
+    def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.spatial_pyramid_pooling_2d(
@@ -53,7 +53,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
 
         self.assertEqual(self.gy.shape, y_data.shape)
 
-    def check_forward_ones(self, x_data, use_cudnn=True):
+    def check_forward_ones(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.spatial_pyramid_pooling_2d(
@@ -78,10 +78,10 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), False)
-        self.check_forward_ones(cuda.to_gpu(self.one), False)
+        self.check_forward(cuda.to_gpu(self.x), 'never')
+        self.check_forward_ones(cuda.to_gpu(self.one), 'never')
 
-    def check_backward(self, x_data, y_grad, use_cudnn=True):
+    def check_backward(self, x_data, y_grad, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 functions.SpatialPyramidPooling2D(
@@ -100,7 +100,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), False)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
 
 class TestInvalidDtype(unittest.TestCase):
@@ -125,7 +125,7 @@ class TestInvalidDtype(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @attr.cudnn
@@ -150,18 +150,21 @@ class TestMaxPooling2DCudnnCall(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             with mock.patch('cupy.cudnn.cudnn.poolingForward') as func:
                 self.forward()
-                self.assertEqual(func.called, self.use_cudnn)
+                self.assertEqual(func.called,
+                                 chainer.should_use_cudnn('>=auto'))
 
     @unittest.skipIf(cuda.cudnn_enabled and
                      cuda.cudnn.cudnn.getVersion() < 3000,
                      'Only cudnn ver>=3 supports spatial-pyramid-pooling2d')
     def test_call_cudnn_backward(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
+            expect = chainer.should_use_cudnn('>=auto')
             y = self.forward()
-            y.grad = self.gy
-            with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
-                y.backward()
-                self.assertEqual(func.called, self.use_cudnn)
+        y.grad = self.gy
+        # should be consistent to forward regardless of use_cudnn config
+        with mock.patch('cupy.cudnn.cudnn.poolingBackward') as func:
+            y.backward()
+            self.assertEqual(func.called, expect)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
@@ -120,13 +120,14 @@ class TestUnpooling2D(unittest.TestCase):
 }))
 class TestMaxPoolingUnpooling(unittest.TestCase):
 
-    def check_left_inverse(self, xp, use_cudnn=False):
+    def check_left_inverse(self, xp, use_cudnn='never'):
         x = xp.arange(self.h * self.h).reshape(
             (1, 1, self.h, self.h)).astype(self.dtype)
-        y = chainer.functions.unpooling_2d(
-            x, self.k, self.s, self.p, None, self.cover_all)
-        x_ = chainer.functions.max_pooling_2d(
-            y, self.k, self.s, self.p, self.cover_all, use_cudnn).data
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = chainer.functions.unpooling_2d(
+                x, self.k, self.s, self.p, None, self.cover_all)
+            x_ = chainer.functions.max_pooling_2d(
+                y, self.k, self.s, self.p, self.cover_all).data
 
         self.assertEqual(x.shape, x_.shape)
         self.assertEqual(x.dtype, x_.dtype)
@@ -141,7 +142,7 @@ class TestMaxPoolingUnpooling(unittest.TestCase):
 
     @attr.gpu
     def test_left_inverse_cudnn(self):
-        self.check_left_inverse(cuda.cupy, True)
+        self.check_left_inverse(cuda.cupy, 'always')
 
 
 @testing.parameterize(*testing.product({
@@ -153,15 +154,16 @@ class TestMaxPoolingUnpooling(unittest.TestCase):
 }))
 class TestAveragePoolingUnpooling(unittest.TestCase):
 
-    def check_left_inverse(self, xp, use_cudnn=False):
+    def check_left_inverse(self, xp, use_cudnn='never'):
         x = xp.arange(self.h * self.h).reshape(
             (1, 1, self.h, self.h)).astype(self.dtype)
-        # average_pooling_2d does not have cover_all option
-        # as max_pooling_2d has.
-        y = chainer.functions.unpooling_2d(
-            x, self.k, self.s, self.p, None, False)
-        x_ = chainer.functions.average_pooling_2d(
-            y, self.k, self.s, self.p, use_cudnn).data
+        with chainer.using_config('use_cudnn', use_cudnn):
+            # average_pooling_2d does not have cover_all option
+            # as max_pooling_2d has.
+            y = chainer.functions.unpooling_2d(
+                x, self.k, self.s, self.p, None, False)
+            x_ = chainer.functions.average_pooling_2d(
+                y, self.k, self.s, self.p).data
 
         self.assertEqual(x.shape, x_.shape)
         self.assertEqual(x.dtype, x_.dtype)
@@ -176,7 +178,7 @@ class TestAveragePoolingUnpooling(unittest.TestCase):
 
     @attr.gpu
     def test_left_inverse_cudnn(self):
-        self.check_left_inverse(cuda.cupy, True)
+        self.check_left_inverse(cuda.cupy, 'always')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
@@ -1,3 +1,4 @@
+import chainer
 from chainer import cuda
 from chainer import gradient_check
 from chainer import testing
@@ -18,8 +19,9 @@ class TestUpsampling2D(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.in_shape).astype('f')
-        self.p = F.MaxPooling2D(2, 2, use_cudnn=False)
-        self.pooled_y = self.p(self.x)
+        self.p = F.MaxPooling2D(2, 2)
+        with chainer.using_config('use_cudnn', False):
+            self.pooled_y = self.p(self.x)
         self.gy = numpy.random.uniform(
             -1, 1, self.in_shape).astype(numpy.float32)
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
@@ -20,7 +20,7 @@ class TestUpsampling2D(unittest.TestCase):
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.in_shape).astype('f')
         self.p = F.MaxPooling2D(2, 2)
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.pooled_y = self.p(self.x)
         self.gy = numpy.random.uniform(
             -1, 1, self.in_shape).astype(numpy.float32)

--- a/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
+++ b/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
@@ -74,6 +74,7 @@ class TestCaffeFunctionBaseMock(TestCaffeFunctionBase):
 
         ret_value = outs[0] if len(outs) == 1 else tuple(outs)
         m = mock.MagicMock(name=self.func_name, return_value=ret_value)
+        print(self.func_name, m.return_value)
         self.patch = mock.patch(self.func_name, m)
         self.mock = self.patch.start()
 
@@ -1086,9 +1087,11 @@ class TestSoftmaxCaffeEngine(TestCaffeFunctionBaseMock):
     }
 
     def test_softmax_caffe_engine(self):
+        # TODO(beam2d): Check if the mock is called with
+        # chainer.config.use_cudnn == False
         self.init_func()
         self.call(['x'], ['y'])
-        self.mock.assert_called_once_with(self.inputs[0], use_cudnn=False)
+        self.mock.assert_called_once_with(self.inputs[0])
 
 
 class TestSoftmaxcuDnnEngine(TestCaffeFunctionBaseMock):
@@ -1112,9 +1115,11 @@ class TestSoftmaxcuDnnEngine(TestCaffeFunctionBaseMock):
     }
 
     def test_softmax_cuDNN_engine(self):
+        # TODO(beam2d): Check if the mock is called with
+        # chainer.config.use_cudnn == True
         self.init_func()
         self.call(['x'], ['y'])
-        self.mock.assert_called_once_with(self.inputs[0], use_cudnn=True)
+        self.mock.assert_called_once_with(self.inputs[0])
 
 
 class TestSoftmaxInvalidAxis(TestCaffeFunctionBase):

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -68,8 +68,8 @@ class TestConvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        self.link.use_cudnn = False
-        self.check_forward_consistency()
+        with chainer.using_config('use_cudnn', False):
+            self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
@@ -89,9 +89,9 @@ class TestConvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
-        self.link.use_cudnn = False
         self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', False):
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):
         x = chainer.Variable(x_data)
@@ -167,8 +167,8 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        self.link.use_cudnn = False
-        self.check_forward_consistency()
+        with chainer.using_config('use_cudnn', False):
+            self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
@@ -187,9 +187,9 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
-        self.link.use_cudnn = False
         self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', False):
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -68,7 +68,7 @@ class TestConvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
@@ -90,7 +90,7 @@ class TestConvolution2D(unittest.TestCase):
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
         self.link.to_gpu()
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):
@@ -167,7 +167,7 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
@@ -188,7 +188,7 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
         self.link.to_gpu()
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -80,8 +80,8 @@ class TestConvolutionND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        self.link.use_cudnn = False
-        self.check_forward_consistency()
+        with chainer.using_config('use_cudnn', False):
+            self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
@@ -101,9 +101,9 @@ class TestConvolutionND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
-        self.link.use_cudnn = False
         self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', False):
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -80,7 +80,7 @@ class TestConvolutionND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
@@ -102,7 +102,7 @@ class TestConvolutionND(unittest.TestCase):
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
         self.link.to_gpu()
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -69,8 +69,8 @@ class TestDeconvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency(self):
-        self.link.use_cudnn = self.use_cudnn
-        self.check_forward_consistency()
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
         params = [self.link.W]
@@ -87,9 +87,9 @@ class TestDeconvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.link.use_cudnn = self.use_cudnn
         self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
 @parameterize(
@@ -140,8 +140,8 @@ class TestDeconvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency(self):
-        self.link.use_cudnn = self.use_cudnn
-        self.check_forward_consistency()
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
         params = [self.link.W]
@@ -158,9 +158,9 @@ class TestDeconvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.link.use_cudnn = self.use_cudnn
         self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -22,7 +22,7 @@ def _pair(x):
 @parameterize(
     *testing.product({
         'nobias': [True, False],
-        'use_cudnn': [True, False]
+        'use_cudnn': ['always', 'never']
     })
 )
 class TestDeconvolution2D(unittest.TestCase):
@@ -95,7 +95,7 @@ class TestDeconvolution2D(unittest.TestCase):
 @parameterize(
     *testing.product({
         'nobias': [True, False],
-        'use_cudnn': [True, False]
+        'use_cudnn': ['always', 'never']
     })
 )
 class TestDeconvolution2DParameterShapePlaceholder(unittest.TestCase):

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
@@ -94,8 +94,8 @@ class TestDeconvolutionND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency(self):
-        self.link.use_cudnn = self.use_cudnn
-        self.check_forward_consistency(self.link, self.x)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.check_forward_consistency(self.link, self.x)
 
     def check_backward(self, link, x_data, y_grad):
         params = [link.W]
@@ -112,10 +112,10 @@ class TestDeconvolutionND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.link.use_cudnn = self.use_cudnn
         self.link.to_gpu()
-        self.check_backward(
-            self.link, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.check_backward(
+                self.link, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
 class TestDeconvolutionNDNoInitialBias(unittest.TestCase):

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
@@ -18,13 +18,13 @@ from chainer.utils import conv
     'dims': [(5, 4, 3), (4, 3), (3,)],
     'nobias': [True, False],
     'dtype': [numpy.float32],
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'auto', 'never'],
     'used_outsize': ['case1', 'case2', 'None'],
 }) + testing.product({
     'dims': [(5, 4, 3)],
     'nobias': [False],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'use_cudnn': [True],
+    'use_cudnn': ['always'],
     'used_outsize': ['None'],
 }))
 class TestDeconvolutionND(unittest.TestCase):

--- a/tests/chainer_tests/links_tests/connection_tests/test_dilated_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_dilated_convolution_2d.py
@@ -63,8 +63,8 @@ class TestDilatedConvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        self.link.use_cudnn = False
-        self.check_forward_consistency()
+        with chainer.using_config('use_cudnn', False):
+            self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
@@ -83,9 +83,9 @@ class TestDilatedConvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
-        self.link.use_cudnn = False
         self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', False):
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):
         x = chainer.Variable(x_data)
@@ -164,8 +164,8 @@ class TestDilatedConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        self.link.use_cudnn = False
-        self.check_forward_consistency()
+        with chainer.using_config('use_cudnn', False):
+            self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
@@ -184,9 +184,9 @@ class TestDilatedConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
-        self.link.use_cudnn = False
         self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        with chainer.using_config('use_cudnn', False):
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/links_tests/connection_tests/test_dilated_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_dilated_convolution_2d.py
@@ -63,7 +63,7 @@ class TestDilatedConvolution2D(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
@@ -84,7 +84,7 @@ class TestDilatedConvolution2D(unittest.TestCase):
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
         self.link.to_gpu()
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):
@@ -164,7 +164,7 @@ class TestDilatedConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_forward_consistency()
 
     def check_backward(self, x_data, y_grad):
@@ -185,7 +185,7 @@ class TestDilatedConvolution2DParameterShapePlaceholder(unittest.TestCase):
     @condition.retry(3)
     def test_backward_gpu_im2col(self):
         self.link.to_gpu()
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_pickling(self, x_data):

--- a/tests/chainer_tests/links_tests/connection_tests/test_mlp_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_mlp_convolution_2d.py
@@ -19,9 +19,7 @@ class TestMLPConvolution2D(unittest.TestCase):
 
     def setUp(self):
         self.mlp = links.MLPConvolution2D(
-            3, (96, 96, 96), 11,
-            activation=functions.sigmoid,
-            use_cudnn=self.use_cudnn)
+            3, (96, 96, 96), 11, activation=functions.sigmoid)
         self.x = numpy.zeros((10, 3, 20, 20), dtype=numpy.float32)
 
     def test_init(self):
@@ -30,17 +28,17 @@ class TestMLPConvolution2D(unittest.TestCase):
         self.assertEqual(len(self.mlp), 3)
         for i, conv in enumerate(self.mlp):
             self.assertIsInstance(conv, links.Convolution2D)
-            self.assertEqual(conv.use_cudnn, self.use_cudnn)
             if i == 0:
                 self.assertEqual(conv.W.data.shape, (96, 3, 11, 11))
             else:
                 self.assertEqual(conv.W.data.shape, (96, 96, 1, 1))
 
     def check_call(self, x_data):
-        x = chainer.Variable(x_data)
-        actual = self.mlp(x)
-        act = functions.sigmoid
-        expect = self.mlp[2](act(self.mlp[1](act(self.mlp[0](x)))))
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            x = chainer.Variable(x_data)
+            actual = self.mlp(x)
+            act = functions.sigmoid
+            expect = self.mlp[2](act(self.mlp[1](act(self.mlp[0](x)))))
         numpy.testing.assert_array_equal(
             cuda.to_cpu(expect.data), cuda.to_cpu(actual.data))
 
@@ -62,9 +60,7 @@ class TestMLPConvolution2DCudnnCall(unittest.TestCase):
 
     def setUp(self):
         self.mlp = links.MLPConvolution2D(
-            3, (96, 96, 96), 11,
-            activation=functions.sigmoid,
-            use_cudnn=self.use_cudnn)
+            3, (96, 96, 96), 11, activation=functions.sigmoid)
         self.mlp.to_gpu()
         self.x = cuda.cupy.zeros((10, 3, 20, 20), dtype=numpy.float32)
         self.gy = cuda.cupy.zeros((10, 96, 10, 10), dtype=numpy.float32)
@@ -74,19 +70,21 @@ class TestMLPConvolution2DCudnnCall(unittest.TestCase):
         return self.mlp(x)
 
     def test_call_cudnn_forward(self):
-        with mock.patch('cupy.cudnn.cudnn.convolutionForward') as func:
-            self.forward()
-            self.assertEqual(func.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.cudnn.convolutionForward') as func:
+                self.forward()
+                self.assertEqual(func.called, self.use_cudnn)
 
     def test_call_cudnn_backrward(self):
-        y = self.forward()
-        print(y.data.shape)
-        y.grad = self.gy
-        v2 = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
-        v3 = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
-        with mock.patch(v2) as func_v2,  mock.patch(v3) as func_v3:
-            y.backward()
-            self.assertEqual(func_v2.called or func_v3.called, self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            print(y.data.shape)
+            y.grad = self.gy
+            v2 = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
+            v3 = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
+            with mock.patch(v2) as func_v2,  mock.patch(v3) as func_v3:
+                y.backward()
+                self.assertEqual(func_v2.called or func_v3.called, self.use_cudnn)
 
 
 @testing.parameterize(
@@ -107,15 +105,15 @@ class TestMLPConvolution2DShapePlaceholder(unittest.TestCase):
         self.assertEqual(len(self.mlp), 3)
 
     def check_call(self, x_data):
-        x = chainer.Variable(x_data)
-        actual = self.mlp(x)
-        act = functions.sigmoid
-        expect = self.mlp[2](act(self.mlp[1](act(self.mlp[0](x)))))
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            x = chainer.Variable(x_data)
+            actual = self.mlp(x)
+            act = functions.sigmoid
+            expect = self.mlp[2](act(self.mlp[1](act(self.mlp[0](x)))))
         numpy.testing.assert_array_equal(
             cuda.to_cpu(expect.data), cuda.to_cpu(actual.data))
         for i, conv in enumerate(self.mlp):
             self.assertIsInstance(conv, links.Convolution2D)
-            self.assertEqual(conv.use_cudnn, self.use_cudnn)
             if i == 0:
                 self.assertEqual(conv.W.data.shape, (96, 3, 11, 11))
             else:

--- a/tests/chainer_tests/links_tests/connection_tests/test_mlp_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_mlp_convolution_2d.py
@@ -84,7 +84,8 @@ class TestMLPConvolution2DCudnnCall(unittest.TestCase):
             v3 = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
             with mock.patch(v2) as func_v2,  mock.patch(v3) as func_v3:
                 y.backward()
-                self.assertEqual(func_v2.called or func_v3.called, self.use_cudnn)
+                self.assertEqual(func_v2.called or func_v3.called,
+                                 self.use_cudnn)
 
 
 @testing.parameterize(

--- a/tests/chainer_tests/links_tests/connection_tests/test_mlp_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_mlp_convolution_2d.py
@@ -12,8 +12,8 @@ from chainer.testing import attr
 
 
 @testing.parameterize(
-    {'use_cudnn': True},
-    {'use_cudnn': False},
+    {'use_cudnn': 'always'},
+    {'use_cudnn': 'never'},
 )
 class TestMLPConvolution2D(unittest.TestCase):
 
@@ -52,8 +52,8 @@ class TestMLPConvolution2D(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'use_cudnn': True},
-    {'use_cudnn': False},
+    {'use_cudnn': 'always'},
+    {'use_cudnn': 'never'},
 )
 @attr.cudnn
 class TestMLPConvolution2DCudnnCall(unittest.TestCase):
@@ -73,7 +73,8 @@ class TestMLPConvolution2DCudnnCall(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             with mock.patch('cupy.cudnn.cudnn.convolutionForward') as func:
                 self.forward()
-                self.assertEqual(func.called, self.use_cudnn)
+                self.assertEqual(func.called,
+                                 chainer.should_use_cudnn('>=auto'))
 
     def test_call_cudnn_backrward(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
@@ -85,20 +86,19 @@ class TestMLPConvolution2DCudnnCall(unittest.TestCase):
             with mock.patch(v2) as func_v2,  mock.patch(v3) as func_v3:
                 y.backward()
                 self.assertEqual(func_v2.called or func_v3.called,
-                                 self.use_cudnn)
+                                 chainer.should_use_cudnn('>=auto'))
 
 
 @testing.parameterize(
-    {'use_cudnn': True},
-    {'use_cudnn': False},
+    {'use_cudnn': 'always'},
+    {'use_cudnn': 'never'},
 )
 class TestMLPConvolution2DShapePlaceholder(unittest.TestCase):
 
     def setUp(self):
         self.mlp = links.MLPConvolution2D(
             None, (96, 96, 96), 11,
-            activation=functions.sigmoid,
-            use_cudnn=self.use_cudnn)
+            activation=functions.sigmoid)
         self.x = numpy.zeros((10, 3, 20, 20), dtype=numpy.float32)
 
     def test_init(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
@@ -15,7 +15,7 @@ def sigmoid(x):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'never'],
 }))
 class TestNStepLSTM(unittest.TestCase):
 

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -93,8 +93,8 @@ class BatchNormalizationTest(unittest.TestCase):
 
     @attr.cudnn
     def test_forward_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
-        self.test_forward_gpu()
+        with chainer.using_config('use_cudnn', False):
+            self.test_forward_gpu()
 
     @attr.multi_gpu(2)
     @condition.retry(3)
@@ -122,8 +122,8 @@ class BatchNormalizationTest(unittest.TestCase):
 
     @attr.cudnn
     def test_backward_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
-        self.test_backward_gpu()
+        with chainer.using_config('use_cudnn', False):
+            self.test_backward_gpu()
 
 
 @testing.parameterize(
@@ -169,8 +169,8 @@ class TestPopulationStatistics(unittest.TestCase):
 
     @attr.cudnn
     def test_statistics_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
-        self.test_statistics_gpu()
+        with chainer.using_config('use_cudnn', False):
+            self.test_statistics_gpu()
 
     def check_statistics2(self, x, y):
         x = chainer.Variable(x)
@@ -205,8 +205,8 @@ class TestPopulationStatistics(unittest.TestCase):
 
     @attr.cudnn
     def test_statistics2_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
-        self.test_statistics2_gpu()
+        with chainer.using_config('use_cudnn', False):
+            self.test_statistics2_gpu()
 
 
 @testing.parameterize(*testing.product({
@@ -271,8 +271,8 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 
     @attr.cudnn
     def test_forward_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
-        self.test_forward_gpu()
+        with chainer.using_config('use_cudnn', False):
+            self.test_forward_gpu()
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(self.link, x_data, y_grad,
@@ -292,8 +292,8 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 
     @attr.cudnn
     def test_backward_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
-        self.test_backward_gpu()
+        with chainer.using_config('use_cudnn', False):
+            self.test_backward_gpu()
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -93,7 +93,7 @@ class BatchNormalizationTest(unittest.TestCase):
 
     @attr.cudnn
     def test_forward_gpu_without_cudnn(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.test_forward_gpu()
 
     @attr.multi_gpu(2)
@@ -122,7 +122,7 @@ class BatchNormalizationTest(unittest.TestCase):
 
     @attr.cudnn
     def test_backward_gpu_without_cudnn(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.test_backward_gpu()
 
 
@@ -169,7 +169,7 @@ class TestPopulationStatistics(unittest.TestCase):
 
     @attr.cudnn
     def test_statistics_gpu_without_cudnn(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.test_statistics_gpu()
 
     def check_statistics2(self, x, y):
@@ -205,7 +205,7 @@ class TestPopulationStatistics(unittest.TestCase):
 
     @attr.cudnn
     def test_statistics2_gpu_without_cudnn(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.test_statistics2_gpu()
 
 
@@ -271,7 +271,7 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 
     @attr.cudnn
     def test_forward_gpu_without_cudnn(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.test_forward_gpu()
 
     def check_backward(self, x_data, y_grad):
@@ -292,7 +292,7 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 
     @attr.cudnn
     def test_backward_gpu_without_cudnn(self):
-        with chainer.using_config('use_cudnn', False):
+        with chainer.using_config('use_cudnn', 'never'):
             self.test_backward_gpu()
 
 

--- a/tests/chainer_tests/test_init.py
+++ b/tests/chainer_tests/test_init.py
@@ -1,0 +1,49 @@
+import unittest
+
+import chainer
+from chainer import cuda
+from chainer.testing import attr
+
+
+class TestUseCuDNN(unittest.TestCase):
+
+    @attr.cudnn
+    def test_valid_case_combination(self):
+        with chainer.using_config('use_cudnn', 'always'):
+            self.assertTrue(chainer.should_use_cudnn('==always'))
+            self.assertTrue(chainer.should_use_cudnn('>=auto'))
+
+        with chainer.using_config('use_cudnn', 'auto'):
+            self.assertFalse(chainer.should_use_cudnn('==always'))
+            self.assertTrue(chainer.should_use_cudnn('>=auto'))
+
+        with chainer.using_config('use_cudnn', 'never'):
+            self.assertFalse(chainer.should_use_cudnn('==always'))
+            self.assertFalse(chainer.should_use_cudnn('>=auto'))
+
+    @unittest.skip(not cuda.cudnn_enabled)
+    def test_no_cudnn_available(self):
+        with chainer.using_config('use_cudnn', 'always'):
+            self.assertFalse(chainer.should_use_cudnn('==always'))
+            self.assertFalse(chainer.should_use_cudnn('>=auto'))
+
+    def test_invalid_level(self):
+        self.assertRaises(ValueError, chainer.should_use_cudnn, '==auto')
+
+    def test_invalid_config(self):
+        with chainer.using_config('use_cudnn', True):
+            self.assertRaises(ValueError, chainer.should_use_cudnn, '>=auto')
+
+        with chainer.using_config('use_cudnn', False):
+            self.assertRaises(ValueError, chainer.should_use_cudnn, '>=auto')
+
+        with chainer.using_config('use_cudnn', 'on'):
+            self.assertRaises(ValueError, chainer.should_use_cudnn, '>=auto')
+
+    @attr.cudnn
+    def test_higher_version_required(self):
+        with chainer.using_config('use_cudnn', 'always'):
+            self.assertFalse(chainer.should_use_cudnn('>=auto', cuda.cudnn.cudnn.getVersion() + 1))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_init.py
+++ b/tests/chainer_tests/test_init.py
@@ -2,6 +2,7 @@ import unittest
 
 import chainer
 from chainer import cuda
+from chainer import testing
 from chainer.testing import attr
 
 
@@ -43,7 +44,8 @@ class TestUseCuDNN(unittest.TestCase):
     @attr.cudnn
     def test_higher_version_required(self):
         with chainer.using_config('use_cudnn', 'always'):
-            self.assertFalse(chainer.should_use_cudnn('>=auto', cuda.cudnn.cudnn.getVersion() + 1))
+            self.assertFalse(chainer.should_use_cudnn(
+                '>=auto', cuda.cudnn.cudnn.getVersion() + 1))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This is a PR that fixes a part of #2048. It introduces `chainer.config.use_cudnn` boolean configuration. When it is True, all functions that support cuDNN use it if possible, and otherwise it uses our own implementations. It replaces the `use_cudnn` argument of many functions so that these APIs are made simpler.