### PR TITLE
Support python3 on docker

### DIFF
--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -1,0 +1,9 @@
+FROM nvidia/cuda:7.5-cudnn5-devel
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    python-dev \
+    python-pip && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+RUN pip install chainer==1.20.0

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,9 +1,9 @@
 FROM nvidia/cuda:7.5-cudnn5-devel
 
 RUN apt-get update -y && \
-    apt-get install -y \
-    python-dev \
-    python-pip && \
+    apt-get install -y --no-install-recommends \
+    python3-dev \
+    python3-pip && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip install chainer==1.20.0
+RUN pip3 install chainer==1.20.0


### PR DESCRIPTION
## What I did
Add python3 version Dockerfile with a minor optimization(`--no-install-recommends`)
(expecting python3.4.3 by vanilla apt)

## Why I did it
Public docker image supports only python2

## Note
* If accept this PR, don't forget to change build settings on docker hub, file location and explicit tagging
* Maybe it is better to support not only python3.4.3 but python3.5+ and python3.6+ individually
