### PR TITLE
Not to use for loop in convolution function

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -1,5 +1,4 @@
 import numpy
-from six import moves
 
 from chainer import cuda
 from chainer import function
@@ -133,15 +132,13 @@ class Convolution2DFunction(function.Function):
             self.col = conv.im2col_gpu(
                 x, kh, kw, self.sy, self.sx, self.ph, self.pw,
                 cover_all=self.cover_all)
-            W_mat = W.reshape(out_c, -1)
-            col_mats = self.col.reshape(n, -1, out_h * out_w)
-            y_mats = y.reshape(n, out_c, -1)
-            # TODO(beam2d): Use streams or batch gemm
-            for i in moves.range(n):
-                y_mats[i] = W_mat.dot(col_mats[i])
+            y = cuda.cupy.tensordot(
+                self.col, W, ((1, 2, 3), (1, 2, 3))).astype(x.dtype,
+                                                            copy=False)
             # TODO(beam2d): Support unshared bias
             if b is not None:
-                y += b[:, None, None]
+                y += b
+            y = cuda.cupy.rollaxis(y, 3, 1)
 
         return y,
 
@@ -236,20 +233,12 @@ class Convolution2DFunction(function.Function):
                     handle, one.data, gy_desc.value, gy.data.ptr,
                     zero.data, self.bias_desc.value, gb.data.ptr)
         else:
-            gW_mat = gW.reshape(out_c, c * kh * kw)
-            col_mats = self.col.reshape(n, c * kh * kw, out_h * out_w)
-            gy_mats = gy.reshape(n, out_c, out_h * out_w)
-            # TODO(beam2d): Use streams or batch gemm
-            gW_mat[...] = 0
-            for i in moves.range(n):
-                gW_mat += cuda.cupy.dot(gy_mats[i], col_mats[i].T)
-
-            W_mat = W.reshape(out_c, -1)
-            gcol = cuda.cupy.empty_like(self.col)
-            gcol_mats = gcol.reshape(n, c * kh * kw, out_h * out_w)
-
-            for i in moves.range(n):
-                gcol_mats[i] = cuda.cupy.dot(W_mat.T, gy_mats[i])
+            gW = cuda.cupy.tensordot(
+                gy, self.col, ((0, 2, 3), (0, 4, 5))).astype(W.dtype,
+                                                             copy=False)
+            gcol = cuda.cupy.tensordot(W, gy, (0, 1)).astype(x.dtype,
+                                                             copy=False)
+            gcol = cuda.cupy.rollaxis(gcol, 3)
 
             gx = conv.col2im_gpu(
                 gcol, self.sy, self.sx, self.ph, self.pw, h, w)

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -1,5 +1,4 @@
 import numpy
-from six import moves
 
 from chainer import cuda
 from chainer import function
@@ -159,13 +158,13 @@ class Deconvolution2DFunction(function.Function):
                     handle, one.data, self.bias_desc.value, b.data.ptr,
                     one.data, y_desc.value, y.data.ptr)
         else:
-            W_mat = W.reshape(in_c, c * kh * kw)
-            x_mats = x.reshape(n, in_c, in_h * in_w)
-            gcol = cuda.cupy.empty(
-                (n, c, kh, kw, in_h, in_w), dtype=x.dtype)
-            gcol_mats = gcol.reshape(n, c * kh * kw, in_h * in_w)
-            for i in moves.range(n):
-                gcol_mats[i] = cuda.cupy.dot(W_mat.T, x_mats[i])
+            gcol = cuda.cupy.tensordot(W, x, (0, 1)).astype(x.dtype,
+                                                            copy=False)
+            # - k, m, n: shape of out_channel
+            # - b: number of inputs
+            # - h, w: height and width of kernels
+            # k, m, n, b, h, w -> b, k, m, n, h, w
+            gcol = cuda.cupy.rollaxis(gcol, 3)
             y = conv.col2im_gpu(
                 gcol, self.sy, self.sx, self.ph, self.pw, self.outh, self.outw)
             if b is not None:
@@ -262,23 +261,15 @@ class Deconvolution2DFunction(function.Function):
             col = conv.im2col_gpu(
                 gy, kh, kw, self.sy, self.sx, self.ph, self.pw)
 
-            W_mat = W.reshape(in_c, c * kh * kw)
-            col_mats = col.reshape(
-                n, c * kh * kw, in_h * in_w)
-            gx_mats = gx.reshape(n, in_c, in_h * in_w)
-            for i in moves.range(n):
-                gx_mats[i] = W_mat.dot(col_mats[i])
+            gW = cuda.cupy.tensordot(
+                x, col, ([0, 2, 3], [0, 4, 5])).astype(W.dtype, copy=False)
+            gx = cuda.cupy.tensordot(
+                col, W, ([1, 2, 3], [1, 2, 3])).astype(x.dtype, copy=False)
+            gx = cuda.cupy.rollaxis(gx, 3, 1)
 
             # bias backward
             if b is not None:
                 gb = gy.sum(axis=(0, 2, 3))
-
-            # filter backward
-            gW = cuda.cupy.zeros_like(W)
-            gW_mat = gW.reshape(in_c, c * kh * kw)
-            x_mats = x.reshape(n, in_c, in_h * in_w)
-            for i in moves.range(n):
-                gW_mat += x_mats[i].dot(col_mats[i].T)
 
         if b is None:
             return gx, gW


### PR DESCRIPTION
Are there any reasons for using for loop?
In my environment, `tensordot` is faster. (Python 3.5, GTX 760, Ubuntu 16.04)

Here is test code.

```python
import cupy
import time
from chainer.utils import conv

sy, sx = 1, 1
ph, pw = 0, 0

x = cupy.arange(300000).reshape(10, 3, 100, 100)
col = conv.im2col_gpu(x, 100, 100, sy, sx, ph, pw)
W = cupy.arange(90000).reshape(3, 3, 100, 100)

out_c, _, kh, kw = W.shape
n, c, h, w = x.shape

out_h = conv.get_conv_outsize(h, kh, sy, ph)
out_w = conv.get_conv_outsize(w, kw, sx, pw)

start = time.time()
W_mat = W.reshape(out_c, -1)
col_mats = col.reshape(n, -1, out_h * out_w)
y = cupy.empty((n, out_c, out_h, out_w), dtype=x.dtype)
y_mats = y.reshape(n, out_c, -1)
for i in range(n):
    y_mats[i] = W_mat.dot(col_mats[i])
end = time.time() - start
print(end)

start = time.time()
y = cupy.tensordot(col, W, ((1, 2, 3), (1, 2, 3))).astype(x.dtype, copy=False)
end = time.time() - start
print(end)
```

using for loop: 0.11589 sec
tensordot: 0.00054 sec

