### PR TITLE
Helpful error message with invalid cupy.reshape.

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -385,7 +385,8 @@ cdef class ndarray:
             newarray = self.copy()
             strides = _get_strides_for_nocopy_reshape(newarray, shape)
 
-        assert shape.size() == strides.size()
+        if shape.size() != strides.size():
+            raise ValueError('total size of new array must be unchanged')
         newarray._set_shape_and_strides(shape, strides, False)
         return newarray
 

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -46,15 +46,15 @@ class TestShape(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return a.reshape(3, -1)
 
+    @testing.numpy_cupy_raises()
     def test_reshape_with_multiple_unknown_dimensions(self):
         a = testing.shaped_arange((2, 3, 4))
-        with self.assertRaises(ValueError):
-            a.reshape(3, -1, -1)
+        a.reshape(3, -1, -1)
 
+    @testing.numpy_cupy_raises()
     def test_reshape_with_changed_arraysize(self):
         a = testing.shaped_arange((2, 3, 4))
-        with self.assertRaises(ValueError):
-            a.reshape(2, 4, 4)
+        a.reshape(2, 4, 4)
 
     @testing.numpy_cupy_array_equal()
     def test_external_reshape(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -51,6 +51,11 @@ class TestShape(unittest.TestCase):
         with self.assertRaises(ValueError):
             a.reshape(3, -1, -1)
 
+    def test_reshape_with_changed_arraysize(self):
+        a = testing.shaped_arange((2, 3, 4))
+        with self.assertRaises(ValueError):
+            a.reshape(2, 4, 4)
+
     @testing.numpy_cupy_array_equal()
     def test_external_reshape(self, xp):
         a = xp.zeros((8,), dtype=xp.float32)


### PR DESCRIPTION
Raise same exception as numpy.
It's better to put an error message than mere assertion violation.

