### PR TITLE
Add unit test asserting that pooling are (left) inverse of unpooling

### DIFF
--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -141,4 +141,20 @@ class TestMaxPooling2DCudnnCall(unittest.TestCase):
             self.assertEqual(func.called, self.use_cudnn)
 
 
+class TestMaxPoolingUnpooling(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_identity(self):
+        h = w = 5
+        kh = kw = 3
+        sh = sw = 3
+        ph = pw = 0
+        x = numpy.random.uniform(0, 1, (1, 1, h, w)).astype(numpy.float32)
+        y = chainer.functions.unpooling_2d(x, (kh, kw), (sh, sw), (ph, pw))
+        x_ = chainer.functions.max_pooling_2d(y, (kh, kw), (sh, sw), (ph, pw)).data
+        numpy.testing.assert_allclose(x, x_)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -141,38 +141,4 @@ class TestMaxPooling2DCudnnCall(unittest.TestCase):
             self.assertEqual(func.called, self.use_cudnn)
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'h': [5],
-    'k': [3],
-    's': [3],
-    'p': [0],
-    'cover_all': [True, False]
-}))
-class TestMaxPoolingUnpooling(unittest.TestCase):
-
-    def setUp(self):
-        pass
-
-    def check_left_inverse(self, xp, use_cudnn=False):
-        x = xp.arange(self.h * self.h).reshape(
-            (1, 1, self.h, self.h)).astype(self.dtype)
-        y = chainer.functions.unpooling_2d(
-            x, self.k, self.s, self.p, None, self.cover_all)
-        x_ = chainer.functions.max_pooling_2d(
-            y, self.k, self.s, self.p, self.cover_all, use_cudnn).data
-        chainer.testing.assert_allclose(x, x_)
-
-    def test_left_inverse_cpu(self):
-        self.check_left_inverse(numpy)
-
-    @attr.gpu
-    def test_left_inverse_cupy(self):
-        self.check_left_inverse(cuda.cupy)
-
-    @attr.gpu
-    def test_left_inverse_cudnn(self):
-        self.check_left_inverse(cuda.cupy, True)
-
-
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
@@ -120,9 +120,6 @@ class TestUnpooling2D(unittest.TestCase):
 }))
 class TestMaxPoolingUnpooling(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
     def check_left_inverse(self, xp, use_cudnn=False):
         x = xp.arange(self.h * self.h).reshape(
             (1, 1, self.h, self.h)).astype(self.dtype)
@@ -155,9 +152,6 @@ class TestMaxPoolingUnpooling(unittest.TestCase):
     'p': [0],
 }))
 class TestAveragePoolingUnpooling(unittest.TestCase):
-
-    def setUp(self):
-        pass
 
     def check_left_inverse(self, xp, use_cudnn=False):
         x = xp.arange(self.h * self.h).reshape(

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
@@ -110,4 +110,79 @@ class TestUnpooling2D(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'h': [5],
+    'k': [3],
+    's': [3],
+    'p': [0],
+    'cover_all': [True, False],
+}))
+class TestMaxPoolingUnpooling(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def check_left_inverse(self, xp, use_cudnn=False):
+        x = xp.arange(self.h * self.h).reshape(
+            (1, 1, self.h, self.h)).astype(self.dtype)
+        y = chainer.functions.unpooling_2d(
+            x, self.k, self.s, self.p, None, self.cover_all)
+        x_ = chainer.functions.max_pooling_2d(
+            y, self.k, self.s, self.p, self.cover_all, use_cudnn).data
+
+        self.assertEqual(x.shape, x_.shape)
+        self.assertEqual(x.dtype, x_.dtype)
+        chainer.testing.assert_allclose(x, x_)
+
+    def test_left_inverse_cpu(self):
+        self.check_left_inverse(numpy)
+
+    @attr.gpu
+    def test_left_inverse_cupy(self):
+        self.check_left_inverse(cuda.cupy)
+
+    @attr.gpu
+    def test_left_inverse_cudnn(self):
+        self.check_left_inverse(cuda.cupy, True)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'h': [5],
+    'k': [3],
+    's': [3],
+    'p': [0],
+}))
+class TestAveragePoolingUnpooling(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def check_left_inverse(self, xp, use_cudnn=False):
+        x = xp.arange(self.h * self.h).reshape(
+            (1, 1, self.h, self.h)).astype(self.dtype)
+        # average_pooling_2d does not have cover_all option
+        # as max_pooling_2d has.
+        y = chainer.functions.unpooling_2d(
+            x, self.k, self.s, self.p, None, False)
+        x_ = chainer.functions.average_pooling_2d(
+            y, self.k, self.s, self.p, use_cudnn).data
+
+        self.assertEqual(x.shape, x_.shape)
+        self.assertEqual(x.dtype, x_.dtype)
+        chainer.testing.assert_allclose(x, x_)
+
+    def test_left_inverse_cpu(self):
+        self.check_left_inverse(numpy)
+
+    @attr.gpu
+    def test_left_inverse_cupy(self):
+        self.check_left_inverse(cuda.cupy)
+
+    @attr.gpu
+    def test_left_inverse_cudnn(self):
+        self.check_left_inverse(cuda.cupy, True)
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
It is natural that pooling functions (`max_pooling` and `average_pooling`) should be the left inverse of the unpooling function (i.e. `pooling(unpooling(x)) = x`). This PR adds unit tests that checks this consistency.

I found this equality does not hold in some combination of parameters (window size(`ksize`), stride, and pad). Although such a consistency is natural, I am not certain it should hold for any parameters other than the default one. It is a problem of how we determine the specification of these functions.