### PR TITLE
Deserializer strict option

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -82,6 +82,9 @@ class HDF5Deserializer(serializer.Deserializer):
 
     Args:
         group (h5py.Group): The group that the deserialization starts from.
+        strict (bool): If ``True``, the deserializer raises an error when an
+            expected value is not found in the given HDF5 file. Otherwise,
+            it ignores the value and skip deserialization.
 
     """
 

--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -85,15 +85,20 @@ class HDF5Deserializer(serializer.Deserializer):
 
     """
 
-    def __init__(self, group):
+    def __init__(self, group, strict=True):
         _check_available()
         self.group = group
+        self.strict = strict
 
     def __getitem__(self, key):
         name = self.group.name + '/' + key
         return HDF5Deserializer(self.group.require_group(name))
 
     def __call__(self, key, value):
+        if not self.strict and key not in self.group:
+            return value
+
+        self.group.keys
         dataset = self.group[key]
         if value is None:
             return numpy.asarray(dataset)

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -82,6 +82,9 @@ class NpzDeserializer(serializer.Deserializer):
     Args:
         npz: `npz` file object.
         path: The base path that the deserialization starts from.
+        strict (bool): If ``True``, the deserializer raises an error when an
+            expected value is not found in the given NPZ file. Otherwise,
+            it ignores the value and skip deserialization.
 
     """
 

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -85,17 +85,21 @@ class NpzDeserializer(serializer.Deserializer):
 
     """
 
-    def __init__(self, npz, path=''):
+    def __init__(self, npz, path='', strict=True):
         self.npz = npz
         self.path = path
+        self.strict = strict
 
     def __getitem__(self, key):
         key = key.strip('/')
         return NpzDeserializer(self.npz, self.path + key + '/')
 
     def __call__(self, key, value):
-        key = key.lstrip('/')
-        dataset = self.npz[self.path + key]
+        key = self.path + key.lstrip('/')
+        if not self.strict and key not in self.npz:
+            return value
+
+        dataset = self.npz[key]
         if value is None:
             return dataset
         elif isinstance(value, numpy.ndarray):

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -145,6 +145,33 @@ class TestHDF5Deserializer(unittest.TestCase):
 
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')
+class TestHDF5DeserializerNonStrict(unittest.TestCase):
+
+    def setUp(self):
+        self.data = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
+
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.temp_file_path = path
+        with h5py.File(path, 'w') as f:
+            f.require_group('x')
+
+        self.hdf5file = h5py.File(path, 'r')
+        self.deserializer = hdf5.HDF5Deserializer(self.hdf5file, strict=False)
+
+    def tearDown(self):
+        if hasattr(self, 'hdf5file'):
+            self.hdf5file.close()
+        if hasattr(self, 'temp_file_path'):
+            os.remove(self.temp_file_path)
+
+    def test_deserialize_partial(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        ret = self.deserializer('y', y)
+        self.assertIs(ret, y)
+
+
+@unittest.skipUnless(hdf5._available, 'h5py is not available')
 class TestSaveHDF5(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -148,8 +148,6 @@ class TestHDF5Deserializer(unittest.TestCase):
 class TestHDF5DeserializerNonStrict(unittest.TestCase):
 
     def setUp(self):
-        self.data = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
-
         fd, path = tempfile.mkstemp()
         os.close(fd)
         self.temp_file_path = path

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -143,6 +143,31 @@ class TestNpzDeserializer(unittest.TestCase):
         self.assertEqual(ret, 10)
 
 
+class TestNpzDeserializerNonStrict(unittest.TestCase):
+
+    def setUp(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.temp_file_path = path
+        with open(path, 'wb') as f:
+            numpy.savez(
+                f, **{'x': numpy.asarray(10)})
+
+        self.npzfile = numpy.load(path)
+        self.deserializer = npz.NpzDeserializer(self.npzfile, strict=False)
+
+    def tearDown(self):
+        if hasattr(self, 'npzfile'):
+            self.npzfile.close()
+        if hasattr(self, 'temp_file_path'):
+            os.remove(self.temp_file_path)
+
+    def test_deserialize_partial(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        ret = self.deserializer('y', y)
+        self.assertIs(ret, y)
+
+
 @testing.parameterize(*testing.product({'compress': [False, True]}))
 class TestSaveNpz(unittest.TestCase):
 


### PR DESCRIPTION
I added `strict` option to deserializers. It doesn't break compatibility.
fix #2053 
related to #2171 