### PR TITLE
Fix error handling when serializing uninitialized parameters

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -7,6 +7,7 @@ import six
 
 from chainer import cuda
 from chainer import initializers
+import chainer.serializer
 from chainer import variable
 
 
@@ -481,6 +482,9 @@ class Link(object):
             serializer(name, d[name].data)
         for name in self._persistent:
             d[name] = serializer(name, d[name])
+        if (self.has_uninitialized_params and
+                isinstance(serializer, chainer.serializer.Serializer)):
+            raise ValueError("uninitialized parameters cannot be serialized")
         for name in self._uninitialized_params.copy():
             # Note: There should only be uninitialized parameters
             # during deserialization.

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -5,6 +5,7 @@ import numpy
 
 import chainer
 from chainer import cuda
+import chainer.serializer
 from chainer import testing
 from chainer.testing import attr
 
@@ -198,6 +199,20 @@ class TestLink(unittest.TestCase):
         serializer.assert_any_call('y', l.y.data)
         serializer.assert_any_call('z', 1)
         self.assertEqual(l.z, 3)
+
+    def test_serialize_uninitialized_param(self):
+        class SerializerMock(chainer.serializer.Serializer):
+            def __getitem__(self, key):
+                pass
+
+            def __call__(self, key, value):
+                pass
+
+        serializer = SerializerMock()
+        l = chainer.Link()
+        l.add_uninitialized_param('x')
+        with self.assertRaises(ValueError):
+            l.serialize(serializer)
 
     def test_duplicate_uninitialized_param(self):
         l = chainer.Link(y=2)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -202,6 +202,7 @@ class TestLink(unittest.TestCase):
 
     def test_serialize_uninitialized_param(self):
         class SerializerMock(chainer.serializer.Serializer):
+
             def __getitem__(self, key):
                 pass
 


### PR DESCRIPTION
Fix https://github.com/pfnet/chainer/issues/2199