### PR TITLE
Support mask for cupy.ndarray.__getitem__ when mask and array's shape differ

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2259,6 +2259,10 @@ cpdef _prepare_mask_indexing_single(ndarray a, ndarray mask, int axis):
     rshape = a.shape[axis + mask.ndim:]
     masked_shape = lshape + (n_true,) + rshape
 
+    # when mask covers the entire array, broadcasting is not necessary
+    if mask.ndim == a.ndim and axis == 0:
+        return mask, mask_scanned._reshape(mask._shape), masked_shape
+
     mask_br = mask._reshape(
         axis * (1,) + mask.shape + (a.ndim - axis - mask.ndim) * (1,))
     mask_br = broadcast_to(mask_br, a.shape)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2262,7 +2262,11 @@ cpdef _prepare_mask_indexing_single(ndarray a, ndarray mask, int axis):
     mask_br = mask._reshape(
         axis * (1,) + mask.shape + (a.ndim - axis - mask.ndim) * (1,))
     mask_br = broadcast_to(mask_br, a.shape)
-    mask_br_scanned = scan(mask_br.astype(numpy.int32).ravel())
+    if mask.size <= 2 ** 31 - 1:
+        mask_type = numpy.int32
+    else:
+        mask_type = numpy.int64
+    mask_br_scanned = scan(mask_br.astype(mask_type).ravel())
     mask_br_scanned = mask_br_scanned._reshape(mask_br._shape)
     return mask_br, mask_br_scanned, masked_shape
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2256,6 +2256,8 @@ cpdef _prepare_mask_indexing_single(ndarray a, ndarray mask, int axis):
     cdef int n_true
     cdef tuple lshape, rshape, out_shape
 
+    # Get number of True in the mask to determine the shape of the array
+    # after masking.
     if mask.size <= 2 ** 31 - 1:
         mask_type = numpy.int32
     else:
@@ -2266,10 +2268,11 @@ cpdef _prepare_mask_indexing_single(ndarray a, ndarray mask, int axis):
     rshape = a.shape[axis + mask.ndim:]
     masked_shape = lshape + (n_true,) + rshape
 
-    # when mask covers the entire array, broadcasting is not necessary
+    # When mask covers the entire array, broadcasting is not necessary.
     if mask.ndim == a.ndim and axis == 0:
         return mask, mask_scanned._reshape(mask._shape), masked_shape
 
+    # The scan of the broadcasted array is used to index on kernel.
     mask_br = mask._reshape(
         axis * (1,) + mask.shape + (a.ndim - axis - mask.ndim) * (1,))
     mask_br = broadcast_to(mask_br, a.shape)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2400,36 +2400,22 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v,
 
 
 cpdef _scatter_op_mask_single(ndarray a, ndarray mask, v, int axis, op):
-    cdef ndarray mask_scanned, mask_br, mask_br_scanned
-    cdef int n_true
-    cdef tuple lshape, rshape, v_shape
+    cdef ndarray mask_scanned
+    cdef tuple masked_shape
+
+    mask, mask_scanned, masked_shape = _prepare_mask_indexing_single(
+        a, mask, axis)
 
     if not isinstance(v, ndarray):
         v = array(v, dtype=a.dtype)
     v = v.astype(a.dtype)
-
     # broadcast v to shape determined by the mask
-    if mask.size <= 2 ** 31 - 1:
-        mask_type = numpy.int32
-    else:
-        mask_type = numpy.int64
-    mask_scanned = scan(mask.astype(mask_type).ravel())  # starts with 1
-    n_true = int(mask_scanned[-1])
-    lshape = a.shape[:axis]
-    rshape = a.shape[axis + mask.ndim:]
-    v_shape = lshape + (n_true,) + rshape
-    v = broadcast_to(v, v_shape)
-
-    mask_br = mask._reshape(
-        axis * (1,) + mask.shape + (a.ndim - axis - mask.ndim) * (1,))
-    mask_br = broadcast_to(mask_br, a.shape)
-    mask_br_scanned = scan(mask_br.astype(numpy.int32).ravel())
-    mask_br_scanned = mask_br_scanned._reshape(mask_br._shape)
+    v = broadcast_to(v, masked_shape)
 
     if op == 'update':
-        _scatter_update_mask_kernel(v, mask_br, mask_br_scanned, a)
+        _scatter_update_mask_kernel(v, mask, mask_scanned, a)
     elif op == 'add':
-        _scatter_add_mask_kernel(v, mask_br, mask_br_scanned, a)
+        _scatter_add_mask_kernel(v, mask, mask_scanned, a)
     else:
         raise ValueError('provided op is not supported')
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1145,7 +1145,7 @@ cdef class ndarray:
                         mask_i = i
             if n_not_slice_none != 1:
                 raise ValueError('currently, CuPy only supports slices that '
-                                'consist of one boolean array.')
+                                 'consist of one boolean array.')
             return _getitem_mask_single(self, slices[mask_i], mask_i)
 
         if advanced:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1073,6 +1073,13 @@ cdef class ndarray:
     def __getitem__(self, slices):
         """x.__getitem__(y) <==> x[y]
 
+        Supports both basic and advanced indexing.
+
+        .. note::
+
+            Currently, it does not support ``slices`` that consists of more
+            than one boolean arrays
+
         .. note::
 
            CuPy handles out-of-bounds indices differently from NumPy.

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -116,6 +116,14 @@ class TestArrayAdvancedIndexingGetitemCupyIndices(unittest.TestCase):
         b_cpu = a.get()[(slice(None), index.get())]
         testing.assert_array_equal(b, b_cpu)
 
+    def test_adv_getitem_cupy_indices3(self):
+        shape = (2, 3, 4)
+        a = cupy.zeros(shape)
+        index = cupy.array([True, False])
+        b = a[index]
+        b_cpu = a.get()[index.get()]
+        testing.assert_array_equal(b, b_cpu)
+
 
 @testing.parameterize(
     {'shape': (), 'indexes': ([1],)},

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -51,6 +51,19 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': numpy.array([1, 0])},
     {'shape': (2, 3, 4), 'indexes': [1, -1]},
     {'shape': (2, 3, 4), 'indexes': ([0, 1], slice(None), [[2, 1], [3, 1]])},
+    # mask
+    {'shape': (10,), 'indexes': (numpy.random.choice([False, True], (10,)),)},
+    {'shape': (2, 3, 4),
+     'indexes': (numpy.random.choice([False, True], (2, 3, 4)),)},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), numpy.array([True, False, True]))},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), slice(None),
+                 numpy.array([True, False, False, True]))},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), numpy.random.choice([False, True], (3, 4)))},
+    {'shape': (2, 3, 4),
+     'indexes': numpy.random.choice([False, True], (2, 3))},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):
@@ -83,9 +96,6 @@ class TestArrayAdvancedIndexingGetitemParametrizedTransp(unittest.TestCase):
 @testing.parameterize(
     {'shape': (2, 3, 4), 'indexes': (slice(None),)},
     {'shape': (2, 3, 4), 'indexes': (numpy.array([1, 0],))},
-    {'shape': (2, 3, 4),
-     'indexes': (numpy.random.choice([False, True], (2, 3, 4)),)},
-    {'shape': (10,), 'indexes': (numpy.random.choice([False, True], (10,)),)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemArrayClass(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -98,20 +98,23 @@ class TestArrayAdvancedIndexingGetitemParametrizedTransp(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': (numpy.array([1, 0],))},
 )
 @testing.gpu
-class TestArrayAdvancedIndexingGetitemArrayClass(unittest.TestCase):
+class TestArrayAdvancedIndexingGetitemCupyIndices(unittest.TestCase):
 
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_adv_getitem(self, xp, dtype):
-        indexes = list(self.indexes)
-        a = testing.shaped_arange(self.shape, xp, dtype)
+    def test_adv_getitem_cupy_indices1(self):
+        shape = (2, 3, 4)
+        a = cupy.zeros(shape)
+        index = cupy.array([1, 0])
+        b = a[index]
+        b_cpu = a.get()[index.get()]
+        testing.assert_array_equal(b, b_cpu)
 
-        if xp is numpy:
-            for i, s in enumerate(indexes):
-                if isinstance(s, cupy.ndarray):
-                    indexes[i] = s.get()
-
-        return a[tuple(indexes)]
+    def test_adv_getitem_cupy_indices2(self):
+        shape = (2, 3, 4)
+        a = cupy.zeros(shape)
+        index = cupy.array([1, 0])
+        b = a[(slice(None), index)]
+        b_cpu = a.get()[(slice(None), index.get())]
+        testing.assert_array_equal(b, b_cpu)
 
 
 @testing.parameterize(


### PR DESCRIPTION
This PR adds support for `cupy.ndarray.__getitem__` to handle a boolean mask array even when the mask's shape and array's shape differ.

Most of the implementation follows/extends that of `_scatter_op_mask_single`.

Note: In addition to that, here are some other things that are added.
+ consistency among names of the masking function for getitem and setitem
+ add tests for cupy.__getitem__ that uses `cupy.ndarray` indices. I restored tests that were removed in #1912.