### PR TITLE
Support multiple integer array indexing for cupy.scatter_add

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2415,13 +2415,12 @@ cpdef _scatter_op_multiple(ndarray a, list slices, v, op):
     cdef ndarray a_interm, reduced_idx
     cdef int li, ri
 
-    if op != 'update':
-        raise TypeError('scatter_op_multiple does not support op other than'
-                        'update yet')
-
     a_interm, reduced_idx, li, ri =\
         _prepare_multiple_array_indexing(a, slices)
-    _scatter_op_single(a_interm, reduced_idx, v, li=li, ri=ri, op=op)
+    if op == 'update':
+        _scatter_op_single(a_interm, reduced_idx, v, li=li, ri=ri, op=op)
+    elif op == 'add':
+        _scatter_op_single(a_interm, reduced_idx, v, li=li, ri=ri, op=op)
 
 
 cpdef _scatter_op(ndarray a, slices, value, op):

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -39,6 +39,21 @@ from cupy import testing
     # broadcasting
     {'shape': (3, 4, 5), 'slices': (slice(None), [[1, 2], [0, -1]],),
      'value': numpy.arange(3 * 2 * 2 * 5).reshape(3, 2, 2, 5)},
+    # multiple integer arrays
+    {'shape': (2, 3, 4), 'slices': ([1, 0], [2, 1]),
+     'value': numpy.arange(2 * 4).reshape(2, 4)},
+    {'shape': (2, 3, 4), 'slices': ([1, 0], slice(None), [2, 1]),
+     'value': numpy.arange(2 * 3).reshape(2, 3)},
+    {'shape': (2, 3, 4), 'slices': ([1, 0], slice(None), [[2, 0], [3, 1]]),
+     'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
+    {'shape': (1, 1, 2, 3, 4),
+     'slices': (None, slice(None), 0, [1, 0], slice(0, 2, 2), [2, -1]),
+     'value': 1},
+    # multiple integer arrays duplicate
+    {'shape': (2, 3, 4), 'slices': ([1, 1], [1, 1]),
+     'value': numpy.arange(2 * 4).reshape(2, 4)},
+    {'shape': (2, 3, 4), 'slices': ([1, 1], slice(None), [[2, 2], [3, 1]]),
+     'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
     # mask
     {'shape': (3, 4, 5),
      'slices': (numpy.random.choice([False, True], (3, 4, 5)),),

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -53,7 +53,8 @@ from cupy import testing
 @testing.gpu
 class TestScatterAddParametrized(unittest.TestCase):
 
-    @testing.for_dtypes([numpy.float32, numpy.int32])
+    @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
+                         numpy.uint64, numpy.ulonglong])
     @testing.numpy_cupy_array_equal()
     def test_scatter_add(self, xp, dtype):
         a = xp.zeros(self.shape, dtype)
@@ -67,7 +68,8 @@ class TestScatterAddParametrized(unittest.TestCase):
 @testing.gpu
 class TestScatterAdd(unittest.TestCase):
 
-    @testing.for_dtypes([numpy.float32, numpy.int32])
+    @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
+                         numpy.uint64, numpy.ulonglong])
     def test_scatter_add_cupy_arguments(self, dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)
@@ -76,7 +78,8 @@ class TestScatterAdd(unittest.TestCase):
         testing.assert_array_equal(
             a, cupy.array([[0., 0., 0.], [2., 2., 2.]], dtype))
 
-    @testing.for_dtypes([numpy.float32, numpy.int32])
+    @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
+                         numpy.uint64, numpy.ulonglong])
     def test_scatter_add_cupy_arguments_mask(self, dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -54,6 +54,8 @@ from cupy import testing
      'value': numpy.arange(2 * 4).reshape(2, 4)},
     {'shape': (2, 3, 4), 'slices': ([1, 1], slice(None), [[2, 2], [3, 1]]),
      'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
+    {'shape': (2, 3, 4), 'slices': ([1, 1], 1, [[2, 2], [3, 1]]),
+     'value': numpy.arange(2 * 2).reshape(2, 2)},
     # mask
     {'shape': (3, 4, 5),
      'slices': (numpy.random.choice([False, True], (3, 4, 5)),),


### PR DESCRIPTION
Merge after #2175 and #2126.

This PR supports multiple integer array indexing for `cupy.scatter_add`.