### PR TITLE
Support advanced indexing for chainer.Variable.__getitem__

### DIFF
--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -56,11 +56,11 @@ def get_item(x, slices):
 
     Args:
         x (~chainer.Variable): A variable to be sliced.
-        slices (int, slice, Ellipsis, None, integer array-like or tuple of\
-        them):
-            It is integer, slices, ellipsis,
-            numpy.newaxis, integer array-like, boolean array-like or tuple of
-            them.
+        slices (int, slice, Ellipsis, None, integer array-like, boolean\
+        array-like or tuple of them):
+            It is an integer, a slice, an ellipsis,
+            a numpy.newaxis, an integer array-like, a boolean array-like
+            or tuple of them.
 
     Returns:
         Variable: :class:`~chainer.Variable` object

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -50,7 +50,7 @@ def get_item(x, slices):
     """Extract elements from array with specified shape, axes and offsets.
 
     Args:
-        x (tuple of Variables): Variable to be sliced.
+        x (tuple of Variables): A variable to be sliced.
         slices (int, slice, None or Ellipsis or tuple of them): Basic slicing
             to slice a variable. It supports ``int``, ``slice``, ``newaxis``
             (equivalent to ``None``) and ``Ellipsis``.
@@ -58,6 +58,12 @@ def get_item(x, slices):
     Returns:
         Variable: :class:`~chainer.Variable` object
             which contains sliced array of ``x``.
+
+    .. note::
+        It only supports types that are supported by CUDA's atomicAdd when
+        an integer array is included in ``slices``.
+        The supported types are ``numpy.float32``, ``numpy.int32``,
+        ``numpy.uint32``, ``numpy.uint64`` and ``numpy.ulonglong``.
 
     .. note::
 

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -13,7 +13,11 @@ class GetItem(function.Function):
     """Function that slices array and extract elements."""
 
     def __init__(self, slices):
-        if not isinstance(slices, tuple):
+        if isinstance(slices, list):
+            if all([isinstance(s, int) for s in slices]):
+                slices = slices,
+            slices = tuple(slices)
+        elif not isinstance(slices, tuple):
             slices = slices,
 
         if chainer.is_debug():

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -51,19 +51,24 @@ def get_item(x, slices):
 
     Args:
         x (tuple of Variables): A variable to be sliced.
-        slices (int, slice, None or Ellipsis or tuple of them): Basic slicing
-            to slice a variable. It supports ``int``, ``slice``, ``newaxis``
-            (equivalent to ``None``) and ``Ellipsis``.
+        slices (array_like or tuple): It is integer, slices, ellipsis,
+            numpy.newaxis, integer array-like, boolean array-like or tuple of
+            them.
 
     Returns:
         Variable: :class:`~chainer.Variable` object
             which contains sliced array of ``x``.
 
     .. note::
+
         It only supports types that are supported by CUDA's atomicAdd when
         an integer array is included in ``slices``.
         The supported types are ``numpy.float32``, ``numpy.int32``,
         ``numpy.uint32``, ``numpy.uint64`` and ``numpy.ulonglong``.
+
+    .. note::
+
+        It does not support ``slices`` that contains multiple boolean arrays.
 
     .. note::
 

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -51,8 +51,10 @@ def get_item(x, slices):
     """Extract elements from array with specified shape, axes and offsets.
 
     Args:
-        x (tuple of Variables): A variable to be sliced.
-        slices (array_like or tuple): It is integer, slices, ellipsis,
+        x (~chainer.Variable): A variable to be sliced.
+        slices (int, slice, Ellipsis, None, integer array-like or tuple of\
+        them):
+            It is integer, slices, ellipsis,
             numpy.newaxis, integer array-like, boolean array-like or tuple of
             them.
 

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -28,7 +28,8 @@ class GetItem(function.Function):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
-        valid_slice = len(self.slices) - self.slices.count(None)
+        n_nones = len([item for item in self.slices if item is None])
+        valid_slice = len(self.slices) - n_nones
         type_check.expect(in_types[0].ndim >= valid_slice)
 
     def forward(self, xs):

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -79,6 +79,11 @@ class TestGetItem(unittest.TestCase):
 @testing.parameterize(*testing.product_dict(
     [
         {'slices': [], 'sliced_shape': (0, 3, 2)},
+        {'slices': [[]], 'sliced_shape': (0, 3, 2)},
+        {'slices': [[[]]], 'sliced_shape': (1, 0, 3, 2)},
+        {'slices': ([[]],), 'sliced_shape': (1, 0, 3, 2)},
+        {'slices': [1, [1]], 'sliced_shape': (1, 2)},
+        {'slices': [[1], slice(1, 2)], 'sliced_shape': (1, 1, 2)},
         {'slices': [1, 0], 'sliced_shape': (2, 3, 2)},
         {'slices': ([1, 0],), 'sliced_shape': (2, 3, 2)},
         {'slices': numpy.array([[1, 0], [2, 3]]),

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -160,6 +160,8 @@ class TestCupyIndicesGetItem(unittest.TestCase):
         for i, s in enumerate(self.slices):
             if isinstance(s, numpy.ndarray):
                 s = chainer.cuda.cupy.array(s)
+            if isinstance(s, list):
+                s = chainer.cuda.cupy.array(s, dtype=numpy.int32)
             slices.append(s)
         slices = tuple(slices)
         x = chainer.Variable(x_data)
@@ -177,6 +179,8 @@ class TestCupyIndicesGetItem(unittest.TestCase):
         for i, s in enumerate(self.slices):
             if isinstance(s, numpy.ndarray):
                 s = chainer.cuda.cupy.array(s)
+            if isinstance(s, list):
+                s = chainer.cuda.cupy.array(s, dtype=numpy.int32)
             slices.append(s)
         slices = tuple(slices)
         gradient_check.check_backward(functions.GetItem(slices),

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -82,6 +82,8 @@ class TestGetItem(unittest.TestCase):
         {'slices': [[]], 'sliced_shape': (0, 3, 2)},
         {'slices': [[[]]], 'sliced_shape': (1, 0, 3, 2)},
         {'slices': ([[]],), 'sliced_shape': (1, 0, 3, 2)},
+        {'slices': numpy.array([], dtype=numpy.bool),
+         'sliced_shape': (0, 3, 2)},
         {'slices': [1, [1]], 'sliced_shape': (1, 2)},
         {'slices': [[1], slice(1, 2)], 'sliced_shape': (1, 1, 2)},
         {'slices': [1, 0], 'sliced_shape': (2, 3, 2)},

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -86,6 +86,8 @@ class TestGetItem(unittest.TestCase):
         {'slices': ([1, 0], slice(None), [[1, 1], [1, 1]]),
          'sliced_shape': (2, 2, 3)},
         {'slices': ([1, 0], slice(1, 2), [0, 0]), 'sliced_shape': (2, 1)},
+        {'slices': ([[1, 1], [1, 0]], slice(1, 2), 1),
+         'sliced_shape': (2, 2, 1)},
         {'slices': numpy.array([True] * 18 + [False] * 6).reshape(4, 3, 2),
          'sliced_shape': (18,)},
     ],

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -78,6 +78,7 @@ class TestGetItem(unittest.TestCase):
 
 @testing.parameterize(*testing.product_dict(
     [
+        {'slices': [], 'sliced_shape': (0, 3, 2)},
         {'slices': [1, 0], 'sliced_shape': (2, 3, 2)},
         {'slices': ([1, 0],), 'sliced_shape': (2, 3, 2)},
         {'slices': numpy.array([[1, 0], [2, 3]]),

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -138,15 +138,21 @@ class TestGetitemAdvanced(unittest.TestCase):
                             cuda.to_gpu(self.gy_data))
 
 
+@parameterize(
+    {'slices': ([1, 0], [1, 1]), 'sliced_shape': (2, 2)},
+    {'slices': ([1, 0], slice(None), [[1, 1], [1, 1]]),
+     'sliced_shape': (2, 2, 3)},
+    {'slices': ([1, 0], [1, 1], [0, 0]), 'sliced_shape': (2,)},
+    {'slices': (slice(None), numpy.array([True, False, True])),
+     'sliced_shape': (4, 2, 2)},
+)
 class TestCupyIndicesGetItem(unittest.TestCase):
 
     def setUp(self):
         self.x_data = numpy.random.uniform(
             -1, 1, (4, 3, 2)).astype(numpy.float32)
-        self.sliced_shape = (2, 2, 3)
         self.gy_data = numpy.random.uniform(
             -1, 1, self.sliced_shape).astype(numpy.float32)
-        self.slices = ([1, 0], slice(None), [[1, 1], [1, 1]])
 
     def check_forward(self, x_data):
         slices = []

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -76,6 +76,62 @@ class TestGetItem(unittest.TestCase):
                             cuda.to_gpu(self.gy_data))
 
 
+@testing.parameterize(*testing.product_dict(
+    [
+        {'slices': [1, 0], 'sliced_shape': (2, 3, 2)},
+        {'slices': ([1, 0],), 'sliced_shape': (2, 3, 2)},
+        {'slices': numpy.array([[1, 0], [2, 3]]),
+         'sliced_shape': (2, 2, 3, 2)},
+        {'slices': ([1, 0], [1, 1]), 'sliced_shape': (2, 2)},
+        {'slices': ([1, 0], slice(None), [[1, 1], [1, 1]]),
+         'sliced_shape': (2, 2, 3)},
+        {'slices': ([1, 0], slice(1, 2), [0, 0]), 'sliced_shape': (2, 1)},
+        {'slices': numpy.array([True] * 18 + [False] * 6).reshape(4, 3, 2),
+         'sliced_shape': (18,)},
+    ],
+    [
+        {'dtype': numpy.float32},
+        {'dtype': numpy.int32},
+        {'dtype': numpy.uint32},
+        {'dtype': numpy.uint64},
+        {'dtype': numpy.ulonglong},
+    ]
+))
+class TestGetitemAdvanced(unittest.TestCase):
+
+    def setUp(self):
+        self.x_data = numpy.random.uniform(
+            -1, 1, (4, 3, 2)).astype(numpy.float32)
+        self.gy_data = numpy.random.uniform(
+            -1, 1, self.sliced_shape).astype(numpy.float32)
+
+    def check_forward(self, x_data):
+        x = chainer.Variable(x_data)
+        y = functions.get_item(x, self.slices)
+        self.assertEqual(y.data.dtype, numpy.float32)
+        numpy.testing.assert_equal(cuda.to_cpu(x_data)[self.slices],
+                                   cuda.to_cpu(y.data))
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x_data)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x_data))
+
+    def check_backward(self, x_data, y_grad):
+        gradient_check.check_backward(functions.GetItem(self.slices),
+                                      (x_data,), y_grad)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x_data, self.gy_data)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x_data),
+                            cuda.to_gpu(self.gy_data))
+
+
 class TestInvalidGetItem(unittest.TestCase):
 
     def setUp(self):
@@ -86,10 +142,6 @@ class TestInvalidGetItem(unittest.TestCase):
 
     def tearDown(self):
         chainer.set_debug(self.default_debug)
-
-    def test_advanced_indexing(self):
-        with self.assertRaises(ValueError):
-            functions.get_item(self.x_data, ([0, 0, 0],))
 
     def test_multiple_ellipsis(self):
         with self.assertRaises(ValueError):

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -102,6 +102,8 @@ class TestGetItem(unittest.TestCase):
          'sliced_shape': (2, 3, 2)},
         {'slices': (slice(None), numpy.array([True, False, True])),
          'sliced_shape': (4, 2, 2)},
+        {'slices': numpy.array([False, False, False, False]),
+         'sliced_shape': (0, 3, 2)},
     ],
     [
         {'dtype': numpy.float32},

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -104,7 +104,7 @@ class TestGetItem(unittest.TestCase):
         {'dtype': numpy.ulonglong},
     ]
 ))
-class TestGetitemAdvanced(unittest.TestCase):
+class TestGetItemAdvanced(unittest.TestCase):
 
     def setUp(self):
         self.x_data = numpy.random.uniform(

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -90,6 +90,10 @@ class TestGetItem(unittest.TestCase):
          'sliced_shape': (2, 2, 1)},
         {'slices': numpy.array([True] * 18 + [False] * 6).reshape(4, 3, 2),
          'sliced_shape': (18,)},
+        {'slices': numpy.array([True, False, False, True]),
+         'sliced_shape': (2, 3, 2)},
+        {'slices': (slice(None), numpy.array([True, False, True])),
+         'sliced_shape': (4, 2, 2)},
     ],
     [
         {'dtype': numpy.float32},


### PR DESCRIPTION
Related #2202 #2201, #2175, #2134, #2126, #2099, #2043, #1863, #1832.
Resolves issue #2042. 

This PR supports advanced indexing for `chainer.Variable.__getitem__`.

Here are lists of functionalities that are added.
+ support for integer arrays. This includes multiple integer arrays (e.g. `a[i1, i2]`) and combination of integer arrays and basic indexing (e.g. `a[i1, 2:10, i2]`).
+ support for boolean array indexing.

This PR does not support multiple boolean arrays as indexing.