### PR TITLE
Improve docs of clipped_relu and relu, minor change on sigmoid and linear

### DIFF
--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -52,15 +52,33 @@ class ClippedReLU(function.Function):
 def clipped_relu(x, z=20.0):
     """Clipped Rectifier Unit function.
 
-    This function is expressed as :math:`ClippedReLU(x, z)
-    = \\min(\\max(0, x), z)`, where :math:`z(>0)` is a clipping value.
+    For a clipping value :math:`z(>0)`, it computes
+
+     .. math::`ClippedReLU(x, z) = \\min(\\max(0, x), z)`.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
         z (float): Clipping value. (default = 20.0)
 
     Returns:
-        ~chainer.Variable: Output variable.
+        ~chainer.Variable: Output variable. A
+        :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+
+    .. admonition:: Example
+
+        >>> x = np.random.uniform(-100, 100, (10, 20)).astype('f')
+        >>> z = 10.0
+        >>> np.any(x < 0)
+        True
+        >>> np.any(x > z)
+        True
+        >>> y = F.clipped_relu(x, z=z)
+        >>> np.any(y.data < 0)
+        False
+        >>> np.any(y.data > z)
+        False
 
     """
     return ClippedReLU(z)(x)

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -57,15 +57,31 @@ class ReLU(function.Function):
 
 
 def relu(x, use_cudnn=True):
-    """Rectified Linear Unit function :math:`f(x)=\\max(0, x)`.
+    """Rectified Linear Unit function.
+
+     .. math::`f(x)=\\max(0, x)`.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 
     Returns:
-        ~chainer.Variable: Output variable.
+        ~chainer.Variable: Output variable. A
+        :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+
+    .. admonition:: Example
+
+        >>> x = np.random.uniform(-1, 1, (3, 4, 5)).astype('f')
+        >>> np.any(x < 0)
+        True
+        >>> y = F.relu(x)
+        >>> np.any(y.data < 0)
+        False
+        >>> y.shape
+        (3, 4, 5)
 
     """
     return ReLU(use_cudnn)(x)

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -63,13 +63,6 @@ def sigmoid(x, use_cudnn=True):
 
      .. math:: f(x)=(1 + \\exp(-x))^{-1}.
 
-    Example::
-
-        >>> x = np.random.uniform(0, 1, (3, 4)).astype('f')
-        >>> y = F.sigmoid(x)
-        >>> y.shape
-        (3, 4)
-
     Args:
         x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`):
@@ -80,6 +73,13 @@ def sigmoid(x, use_cudnn=True):
     Returns:
         ~chainer.Variable: Output variable. A
         :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+
+    .. admonition:: Example
+
+        >>> x = np.random.uniform(0, 1, (3, 4)).astype('f')
+        >>> y = F.sigmoid(x)
+        >>> y.shape
+        (3, 4)
 
     """
     return Sigmoid(use_cudnn)(x)

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -60,15 +60,6 @@ def linear(x, W, b=None):
     matrix ``W``, and optionally a bias vector ``b``. It computes
      .. math:: Y = xW^\\top + b.
 
-    .. admonition:: Example
-
-        >>> x = np.random.uniform(0, 1, (3, 4)).astype('f')
-        >>> W = np.random.uniform(0, 1, (5, 4)).astype('f')
-        >>> b = np.random.uniform(0, 1, (5,)).astype('f')
-        >>> y = F.linear(x, W, b)
-        >>> y.shape
-        (3, 5)
-
     Args:
         x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`): Input variable, which is a :math:`(s_B, s_1, \
@@ -88,6 +79,15 @@ def linear(x, W, b=None):
         of :math:`(s_B, M)`.
 
     .. seealso:: :class:`~chainer.links.Linear`
+
+    .. admonition:: Example
+
+        >>> x = np.random.uniform(0, 1, (3, 4)).astype('f')
+        >>> W = np.random.uniform(0, 1, (5, 4)).astype('f')
+        >>> b = np.random.uniform(0, 1, (5,)).astype('f')
+        >>> y = F.linear(x, W, b)
+        >>> y.shape
+        (3, 5)
 
     """
     if b is None:


### PR DESCRIPTION
This is PR for improving docs of functions/links. Related issue: #2182

Modified functions/links:
 - functions/activation/relu
 - functions/activation/clipped_relu

Changed the order or the examples to the bottom of the docstrings:
 - functions/activation/sigmoid
 - functions/connection/linear