### PR TITLE
Improved doc of crelu, elu, tanh, broadcast, broadcast_to, concat

### DIFF
--- a/chainer/functions/activation/crelu.py
+++ b/chainer/functions/activation/crelu.py
@@ -46,17 +46,39 @@ class CReLU(function.Function):
 def crelu(x, axis=1):
     """Concatenated Rectified Linear Unit function.
 
-    This function is expressed as :math:`f(x) = (\\max(0, x), \\max(0, -x))`,
-    where two output values are concatenated along an axis.
+    This function is expressed as follows
+
+     .. math:: f(x) = (\\max(0, x), \\max(0, -x)).
+
+    Here, two output values are concatenated along an axis.
 
     See: https://arxiv.org/abs/1603.05201
 
     Args:
-        x (~chainer.Variable): Input variable.
-        axis (int): Axis that the output values are concatenated along
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+        axis (int): Axis that the output values are concatenated along.
+            Default is 1.
 
     Returns:
-        ~chainer.Variable: Output variable.
+        ~chainer.Variable: Output variable of concatenated array.
+        If the axis is 1, A :math:`(s_1, s_2 \\times 2, ..., s_n)`-shaped float
+        array.
+
+    .. admonition:: Example
+
+        >>> x = np.random.uniform(-10, 10, (3, 2)).astype('f')
+        >>> x
+        array([[ 0.97627008,  4.30378723],
+               [ 2.05526757,  0.89766365],
+               [-1.52690399,  2.9178822 ]], dtype=float32)
+        >>> y = F.crelu(x, axis=1)
+        >>> y.data
+        array([[ 0.97627008,  4.30378723,  0.        ,  0.        ],
+               [ 2.05526757,  0.89766365,  0.        ,  0.        ],
+               [ 0.        ,  2.9178822 ,  1.52690399,  0.        ]], \
+dtype=float32)
 
     """
     return CReLU(axis=axis)(x)

--- a/chainer/functions/activation/elu.py
+++ b/chainer/functions/activation/elu.py
@@ -50,7 +50,7 @@ class ELU(function.Function):
 def elu(x, alpha=1.0):
     """Exponential Linear Unit function.
 
-    This function is expressed as
+    For a parameter :math:`\\alpha`, it is expressed as
 
     .. math::
         f(x) = \\left \\{ \\begin{array}{ll}
@@ -58,15 +58,30 @@ def elu(x, alpha=1.0):
         \\alpha (\\exp(x) - 1) & {\\rm if}~ x < 0,
         \\end{array} \\right.
 
-    where :math:`\\alpha` is a parameter.
     See: https://arxiv.org/abs/1511.07289
 
     Args:
-        x (~chainer.Variable): Input variable.
-        alpha (float): Parameter :math:`\\alpha`.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+        alpha (float): Parameter :math:`\\alpha`. Default is 1.0.
 
     Returns:
-        ~chainer.Variable: Output variable.
+        ~chainer.Variable: Output variable. A
+        :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+
+    .. admonition:: Example
+
+        >>> x = np.random.randint(-10, 10, (3, 2)).astype('f')
+        >>> x
+        array([[  2.,   5.],
+               [-10.,  -7.],
+               [ -7.,  -3.]], dtype=float32)
+        >>> y = F.elu(x, alpha=1.)
+        >>> y.data
+        array([[ 2.        ,  5.        ],
+               [-0.99995458, -0.99908811],
+               [-0.99908811, -0.95021296]], dtype=float32)
 
     """
     return ELU(alpha=alpha)(x)

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -75,7 +75,7 @@ def sigmoid(x, use_cudnn=True):
         :math:`(s_1, s_2, ..., s_N)`-shaped float array.
 
     .. admonition:: Example
-    
+
         It maps the input values into the range of :math:`[0, 1]`.
         >>> x = np.arange(-2, 3, 2).astype('f')
         >>> x

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -66,13 +66,13 @@ def sigmoid(x, use_cudnn=True):
     Args:
         x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`):
-            Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+            Input variable. A :math:`(s_1, s_2, ..., s_N)`-shaped float array.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 
     Returns:
         ~chainer.Variable: Output variable. A
-        :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+        :math:`(s_1, s_2, ..., s_N)`-shaped float array.
 
     .. admonition:: Example
 

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -57,13 +57,25 @@ class Tanh(function.Function):
 def tanh(x, use_cudnn=True):
     """Elementwise hyperbolic tangent function.
 
+     .. math:: f(x)=\\tanh(x).
+
     Args:
-        x (~chainer.Variable): Input variable.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable. A :math:`(s_1, s_2, ..., s_n)`-shaped float array.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 
     Returns:
-        ~chainer.Variable: Output variable.
+        ~chainer.Variable: Output variable. A
+        :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+
+    .. admonition:: Example
+
+        >>> x = np.random.uniform(0, 1, (3, 4)).astype('f')
+        >>> y = F.tanh(x)
+        >>> y.shape
+        (3, 4)
 
     """
     return Tanh(use_cudnn)(x)

--- a/chainer/functions/array/broadcast.py
+++ b/chainer/functions/array/broadcast.py
@@ -54,11 +54,27 @@ def broadcast(*args):
     """Broadcast given variables.
 
     Args:
-        args (Variables): Variables to be broadcasted.
+        args (:class:`~chainer.Variable` or :class:`numpy.ndarray` \
+        or :class:`cupy.ndarray`):
+            Input variables to be broadcasted. Each dimension of the shapes \
+            of the input variables must have the same size.
 
     Returns:
-        tuple: Tuple of :class:`~chainer.Variable` objects which are
-        broadcasted from given arguments.
+        ~chainer.Variable: :class:`~chainer.Variable` or tuple of \
+            :class:`~chainer.Variable` objects which are broadcasted \
+            from given arguments.
+
+    .. admonition:: Example
+
+        >>> x = np.random.uniform(0, 1, (3, 2)).astype('f')
+        >>> y = F.broadcast(x)
+        >>> np.all(x == y.data)
+        True
+        >>> z = np.random.uniform(0, 1, (3, 2)).astype('f')
+        >>> y, w = F.broadcast(x, z)
+        >>> np.all(x == y.data) & np.all(z == w.data)
+        True
+
     """
     return Broadcast()(*args)
 
@@ -106,10 +122,26 @@ def broadcast_to(x, shape):
     """Broadcast a given variable to a given shape.
 
     Args:
-        x (~chainer.Variable): Variable to be broadcasted.
-        shape (tuple of int): The shape of the output variable.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable be broadcasted. A \
+            :math:`(s_1, s_2, ..., s_n)`-shaped float array.
+        shape (tuple): Tuple of :class:`int` of the shape of the \
+            output variable.
 
     Returns:
         ~chainer.Variable: Output variable broadcasted to the given shape.
+
+    .. admonition:: Example
+
+        >>> x = np.arange(0, 3)
+        >>> x
+        array([0, 1, 2])
+        >>> y = F.broadcast_to(x, (3, 3))
+        >>> y.data
+        array([[0, 1, 2],
+               [0, 1, 2],
+               [0, 1, 2]])
+
     """
     return BroadcastTo(shape)(x)

--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -55,11 +55,33 @@ def concat(xs, axis=1):
     """Concatenates given variables along an axis.
 
     Args:
-        xs (tuple of Variables): Variables to be concatenated.
-        axis (int): Axis that the input arrays are concatenated along.
+        xs (tuple of :class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variables to be concatenated. The variables must have the \
+            same shape, except in the dimension corresponding to axis.
+        axis (int): The axis along which the arrays will be joined. Default \
+            is 1.
 
     Returns:
-        ~chainer.Variable: Output variable.
+        ~chainer.Variable: The concatenated variable.
+
+    .. admonition:: Example
+
+        >>> x = np.arange(0, 12).reshape(3, 4)
+        >>> x
+        array([[ 0,  1,  2,  3],
+               [ 4,  5,  6,  7],
+               [ 8,  9, 10, 11]])
+        >>> y = np.arange(0, 3).reshape(3, 1)
+        >>> y
+        array([[0],
+               [1],
+               [2]])
+        >>> z = F.concat((x, y), axis=1)
+        >>> z.data
+        array([[ 0,  1,  2,  3,  0],
+               [ 4,  5,  6,  7,  1],
+               [ 8,  9, 10, 11,  2]])
 
     """
     return Concat(axis=axis)(*xs)


### PR DESCRIPTION
This is PR for improving docs of functions/links. Related issue: #2182

Modified functions/links:
 - functions/activation/crelu
 - functions/activation/elu
 - functions/activation/tanh
 - functions/array/broadcast (including broadcast_to)
 - functions/array/concat

I am not sure that this example for elu is good or not. We need a figure in the future.

Minor change on:
 - functions/activation/sigmoid

I found the shape description of this is small letter (s_n).