### PR TITLE
Use extend method to show understandable error message

### DIFF
--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -63,7 +63,7 @@ class SerialIterator(iterator.Iterator):
                     numpy.random.shuffle(self._order)
                 if rest > 0:
                     if self._order is None:
-                        batch.extend(list(self.dataset[:rest]))
+                        batch.extend(self.dataset[:rest])
                     else:
                         batch.extend([self.dataset[index]
                                       for index in self._order[:rest]])

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -63,10 +63,10 @@ class SerialIterator(iterator.Iterator):
                     numpy.random.shuffle(self._order)
                 if rest > 0:
                     if self._order is None:
-                        batch += list(self.dataset[:rest])
+                        batch.extend(list(self.dataset[:rest]))
                     else:
-                        batch += [self.dataset[index]
-                                  for index in self._order[:rest]]
+                        batch.extend([self.dataset[index]
+                                      for index in self._order[:rest]])
                 self.current_position = rest
             else:
                 self.current_position = N


### PR DESCRIPTION
When a user uses `numpy.ndarray` as dataset, `SerialIterator` makes corrupted batch here. 
fixes #2160