### PR TITLE
Add reshape method to chainer.Variable

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -441,7 +441,7 @@ Actual: {0}'''.format(type(data))
            :func:`chainer.functions.reshape` for full documentation,
 
         """
-        if len(shape) == 1 and isinstance(shape[0], tuple):
+        if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
             shape = shape[0]
         return chainer.functions.reshape(self, shape)
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -434,6 +434,17 @@ Actual: {0}'''.format(type(data))
                             x._grad += gx
             del gxs  # to reduce memory usage
 
+    def reshape(self, *shape):
+        """Returns a variable of a different shape and the same content.
+
+        .. seealso::
+           :func:`chainer.functions.reshape` for full documentation,
+
+        """
+        if len(shape) == 1 and isinstance(shape[0], tuple):
+            shape = shape[0]
+        return chainer.functions.reshape(self, shape)
+
     def unchain_backward(self):
         """Deletes references between variables and functions backward.
 

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -763,7 +763,7 @@ class TestVariableBackwardErrorTraceback(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'in_shape': [(4, 3, 2)],
-    'out_shape': [(2, 2, 6), (2, -1, 6), 24, (-1,)],
+    'out_shape': [(2, 2, 6), (2, -1, 6), 24, (-1,), [2, 12]],
     'dtype': [np.float16, np.float32, np.float64],
 }))
 class TestReshape(unittest.TestCase):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -761,4 +761,43 @@ class TestVariableBackwardErrorTraceback(unittest.TestCase):
         self.check_traceback(cuda.to_gpu(self.x))
 
 
+@testing.parameterize(*testing.product({
+    'in_shape': [(4, 3, 2)],
+    'out_shape': [(2, 2, 6), (2, -1, 6), 24, (-1,)],
+    'dtype': [np.float16, np.float32, np.float64],
+}))
+class TestReshape(unittest.TestCase):
+
+    def setUp(self):
+        self.x = np.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+
+    def check_forward(self, x_data):
+        shape = self.out_shape
+        x = chainer.Variable(x_data)
+        y = x.reshape(shape)
+        self.assertEqual(y.data.dtype, self.dtype)
+        self.assertTrue((self.x.reshape(shape) == cuda.to_cpu(y.data)).all())
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x_data):
+        x = chainer.Variable(x_data)
+        y = x.reshape(self.out_shape)
+        y.grad = y.data
+        y.backward()
+        testing.assert_allclose(x.data, x.grad, atol=0, rtol=0)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x))
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds a reshape method to `chainer.Variable`.

The interface follows that of `numpy.ndarray.reshape`.

This PR is useful in a situation when you want to declare reshape at the end of a line rather than at the beginning. A simple example to demonstrate the visual difference is as follows.

```python
import numpy
import chainer
import chainer.functions as F

x = chainer.Variable(numpy.array([1,2,3,4]))

y = F.reshape(F.tile(x, 4), (4, 4))

# an alternative way to write the same thing
y = F.tile(x, 4).reshape(4, 4)
```