### PR TITLE
use NVTOOLSEXT_PATH to search nvToolsExt on Windows

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -67,9 +67,8 @@ MODULES = [
 
 if sys.platform == 'win32':
     mod_cuda = MODULES[0]
-    mod_cuda['file'].remove('cupy.cuda.nvtx')
-    mod_cuda['include'].remove('nvToolsExt.h')
     mod_cuda['libraries'].remove('nvToolsExt')
+    mod_cuda['libraries'].append('nvToolsExt64_1')
 
 
 def check_readthedocs_environment():

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -24,9 +24,7 @@
 #include <cuda_profiler_api.h>
 #include <cuda_runtime.h>
 #include <curand.h>
-#ifndef _WIN32
 #include <nvToolsExt.h>
-#endif
 
 extern "C" {
 

--- a/install/build.py
+++ b/install/build.py
@@ -49,6 +49,12 @@ def get_compiler_setting():
     if sys.platform == 'darwin':
         library_dirs.append('/usr/local/cuda/lib')
 
+    if sys.platform == 'win32':
+        nvtoolsext_path = os.environ.get('NVTOOLSEXT_PATH', '')
+        if os.path.exists(nvtoolsext_path):
+            include_dirs.append(os.path.join(nvtoolsext_path, 'include'))
+            library_dirs.append(os.path.join(nvtoolsext_path, 'lib', 'x64'))
+
     return {
         'include_dirs': include_dirs,
         'library_dirs': library_dirs,


### PR DESCRIPTION
fix for #1660

However, `import cupy.cuda.nvtx` fails unless `%NVTOOLSEXT_PATH%\bin\x64` is located in [Search Path Used by Windows to Locate a DLL](https://msdn.microsoft.com/en-US/library/7d83bc18.aspx).