### PR TITLE
Ignore cudaErrorNoDevice on making device backup

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -353,7 +353,11 @@ Actual: {0}'''.format(type(data))
             return
         initial_device = None
         if cuda.available:
-            initial_device = cuda.Device()
+            try:
+                initial_device = cuda.Device()
+            except cuda.cupy.cuda.runtime.CUDARuntimeError as e:
+                if e.status != 38:  # cudaErrorNoDevice
+                    raise
 
         is_debug = chainer.is_debug()
 


### PR DESCRIPTION
Even if CUDA is available, cudaGetDevice() can return
cudaErrorNoDevice when CUDA_VISIBLE_DEVICE is set to -1.

In such case, this has resulted in CUDARuntimeError.