### PR TITLE
Use memory view in concat

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2121,6 +2121,7 @@ cpdef ndarray concatenate(tup, axis, shape, dtype):
                 ndim = tup[0].ndim
                 x_strides = numpy.ndarray((len(tup), ndim), numpy.int32)
                 cum_sizes = numpy.ndarray(len(tup), numpy.int32)
+                cum = 0
                 for i, a in enumerate(tup):
                     for j in range(ndim):
                         x_strides[i, j] = a._strides[j]

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -13,6 +13,7 @@ from cupy import util
 
 cimport cpython
 cimport cython
+from libc cimport stdint
 from libcpp cimport vector
 
 from cupy.core cimport internal
@@ -2092,8 +2093,8 @@ cpdef ndarray concatenate(tup, axis, shape, dtype):
     cdef int i, j, base, cum, ndim
     cdef bint all_same_type, all_one_and_contiguous
     cdef Py_ssize_t[:] ptrs
-    cdef int[:] cum_sizes
-    cdef int[:, :] x_strides
+    cdef stdint.int32_t[:] cum_sizes
+    cdef stdint.int32_t[:, :] x_strides
 
     ret = ndarray(shape, dtype=dtype)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2089,8 +2089,11 @@ cpdef ndarray concatenate_method(tup, int axis):
 
 cpdef ndarray concatenate(tup, axis, shape, dtype):
     cdef ndarray a, x, ret
-    cdef int i, base, cum
+    cdef int i, j, base, cum, ndim
     cdef bint all_same_type, all_one_and_contiguous
+    cdef Py_ssize_t[:] ptrs
+    cdef int[:] cum_sizes
+    cdef int[:, :] x_strides
 
     ret = ndarray(shape, dtype=dtype)
 
@@ -2105,21 +2108,27 @@ cpdef ndarray concatenate(tup, axis, shape, dtype):
                 a._shape[axis] == 1)
 
         if all_same_type:
-            x = array([a.data.ptr for a in tup])
+            ptrs = numpy.ndarray(len(tup), numpy.int64)
+            for i, a in enumerate(tup):
+                ptrs[i] = a.data.ptr
+            x = array(ptrs)
+
             if all_one_and_contiguous:
                 base = internal.prod_ssize_t(shape[axis + 1:])
                 _concatenate_kernel_one(x, base, ret)
             else:
-                x_strides = array([a.strides for a in tup], 'i')
-                cum = 0
-                cum_sizes = numpy.empty(len(tup), 'i')
+                ndim = tup[0].ndim
+                x_strides = numpy.ndarray((len(tup), ndim), numpy.int32)
+                cum_sizes = numpy.ndarray(len(tup), numpy.int32)
                 for i, a in enumerate(tup):
+                    for j in range(ndim):
+                        x_strides[i, j] = a._strides[j]
                     cum_sizes[i] = cum
                     cum += a._shape[axis]
-                cum_sizes = array(cum_sizes)
 
                 _concatenate_kernel(
-                    x, axis, len(shape), cum_sizes, x_strides, ret)
+                    x, axis, len(shape), array(cum_sizes), array(x_strides),
+                    ret)
             return ret
 
     skip = (slice(None),) * axis

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -55,11 +55,31 @@ class TestJoin(unittest.TestCase):
 
     @testing.for_all_dtypes(name='dtype')
     @testing.numpy_cupy_array_equal()
+    def test_concatenate_large_2(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        b = testing.shaped_reverse_arange((2, 3, 2), xp, dtype)
+        c = testing.shaped_arange((2, 3, 3), xp, dtype)
+        d = testing.shaped_arange((2, 3, 5), xp, dtype)
+        e = testing.shaped_arange((2, 3, 2), xp, dtype)
+        return xp.concatenate((a, b, c, d, e), axis=-1)
+
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
     def test_concatenate_f_contiguous(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_arange((2, 3, 2), xp, dtype).T
         c = testing.shaped_arange((2, 3, 3), xp, dtype)
         return xp.concatenate((a, b, c), axis=-1)
+
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_large_f_contiguous(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        b = testing.shaped_arange((2, 3, 2), xp, dtype).T
+        c = testing.shaped_arange((2, 3, 3), xp, dtype)
+        d = testing.shaped_arange((2, 3, 2), xp, dtype).T
+        e = testing.shaped_arange((2, 3, 2), xp, dtype)
+        return xp.concatenate((a, b, c, d, e), axis=-1)
 
     def test_concatenate_wrong_ndim(self):
         a = cupy.empty((2, 3))


### PR DESCRIPTION
I fixed concat method to use memory-view. It is faster than list and vector.vector. In my small profile result, transpose_sequence is 25% faster than the original.