### PR TITLE
TestHDF5Deserializer: add test_string

### DIFF
--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -144,15 +144,18 @@ class TestHDF5Deserializer(unittest.TestCase):
         self.assertEqual(ret, 10)
 
     def test_string(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
             data = 'abc'
-            path = os.path.join(tmp_dir, 'tmp.hdf5')
             with h5py.File(path, 'w') as f:
                 f.create_dataset('str', data=data)
             with h5py.File(path, 'r') as f:
                 deserializer = hdf5.HDF5Deserializer(f)
                 ret = deserializer('str', '')
                 self.assertEqual(ret, data)
+        finally:
+            os.remove(path)
 
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -152,7 +152,7 @@ class TestHDF5Deserializer(unittest.TestCase):
             with h5py.File(path, 'r') as f:
                 deserializer = hdf5.HDF5Deserializer(f)
                 ret = deserializer('str', '')
-                self.assertEqual(ret == data, (ret, data))
+                self.assertEqual(ret, data)
 
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -142,6 +142,17 @@ class TestHDF5Deserializer(unittest.TestCase):
         z = 5
         ret = self.deserializer('z', z)
         self.assertEqual(ret, 10)
+        
+    def test_string(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = 'abc'
+            path = os.path.join(tmp_dir, 'tmp.hdf5')
+            with h5py.File(path, 'w') as f:
+                f.create_dataset('str', data=data)
+            with h5py.File(path, 'r') as f:
+                deserializer = hdf5.HDF5Deserializer(f)
+                ret = deserializer('str', '')
+                assert ret == data, (ret, data)
 
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -142,7 +142,7 @@ class TestHDF5Deserializer(unittest.TestCase):
         z = 5
         ret = self.deserializer('z', z)
         self.assertEqual(ret, 10)
-        
+
     def test_string(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             data = 'abc'
@@ -152,7 +152,7 @@ class TestHDF5Deserializer(unittest.TestCase):
             with h5py.File(path, 'r') as f:
                 deserializer = hdf5.HDF5Deserializer(f)
                 ret = deserializer('str', '')
-                assert ret == data, (ret, data)
+                self.assertEqual(ret == data, (ret, data))
 
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')


### PR DESCRIPTION
This PR is a suggestion. If a maintainer thinks it's faster to self-implement it, he can do this.
The `LogReport` has the function

```python
def serialize(self, serializer: HDF5Deserializer):
    # Note that this serialization may lose some information of small
    # numerical differences.
    if isinstance(serializer, serializer_module.Serializer):
        log = json.dumps(self._log)
        serializer('_log', log)
    else:
        log = serializer('_log', '')
        import pdb; pdb.set_trace()
        self._log = json.loads(log)
```

that requires to store and load strings with the serializer. Therefore there should also be a test for that.