### PR TITLE
warn when numpy and cupy are used together

### DIFF
--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -27,6 +27,10 @@ class EmbedIDFunction(function.Function):
     def forward(self, inputs):
         x, W = inputs
 
+        if(not type_check.same_types(*inputs)):
+            raise ValueError('numpy and cupy must not be used together\n'
+                             'type(W): %s, type(x): %s' % (type(W), type(x)))
+
         xp = cuda.get_array_module(*inputs)
         if chainer.is_debug():
             valid_x = xp.logical_and(0 <= x, x < len(W))
@@ -35,11 +39,6 @@ class EmbedIDFunction(function.Function):
             if not valid_x.all():
                 raise ValueError('Each not ignored `x` value need to satisfy'
                                  '`0 <= x < len(W)`')
-
-        if (issubclass(type(W), numpy.ndarray) !=
-                issubclass(type(x), numpy.ndarray)):
-            raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): %s, type(x): %s' % (type(W), type(x)))
 
         if self.ignore_label is not None:
             mask = (x == self.ignore_label)

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -36,15 +36,15 @@ class EmbedIDFunction(function.Function):
                 raise ValueError('Each not ignored `x` value need to satisfy'
                                  '`0 <= x < len(W)`')
 
-        if self.ignore_label is not None:
-            mask = (x == self.ignore_label)
-            return xp.where(
-                mask[..., None], 0, W.take(xp.where(mask, 0, x), axis=0)),
-
         if (issubclass(type(W), numpy.ndarray) !=
                 issubclass(type(x), numpy.ndarray)):
             raise ValueError('numpy and cupy must not be used together\n'
                              'type(W): %s, type(x): %s' % (type(W), type(x)))
+
+        if self.ignore_label is not None:
+            mask = (x == self.ignore_label)
+            return xp.where(
+                mask[..., None], 0, W.take(xp.where(mask, 0, x), axis=0)),
 
         return W.take(x, axis=0),
 

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -41,6 +41,10 @@ class EmbedIDFunction(function.Function):
             return xp.where(
                 mask[..., None], 0, W.take(xp.where(mask, 0, x), axis=0)),
 
+        if not issubclass(type(W), type(x)):
+            raise ValueError('numpy and cupy must not be used together\n'
+                             'type(W): %s, type(x): %s' % (type(W), type(x)))
+
         return W.take(x, axis=0),
 
     def backward(self, inputs, grad_outputs):

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -41,7 +41,8 @@ class EmbedIDFunction(function.Function):
             return xp.where(
                 mask[..., None], 0, W.take(xp.where(mask, 0, x), axis=0)),
 
-        if not issubclass(type(W), type(x)):
+        if (issubclass(type(W), numpy.ndarray) !=
+                issubclass(type(x), numpy.ndarray)):
             raise ValueError('numpy and cupy must not be used together\n'
                              'type(W): %s, type(x): %s' % (type(W), type(x)))
 

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -3,10 +3,12 @@ import operator
 import sys
 import threading
 
-import cupy
 import numpy
 
 from chainer import cuda
+
+if cuda.available:
+    import cupy
 
 
 _thread_local = threading.local()
@@ -491,9 +493,13 @@ def expect(*bool_exprs):
 def same_types(*arrays):
     are_numpy_arrays = map(lambda x: issubclass(type(x), numpy.ndarray),
                            [a for a in arrays])
-    are_cupy_arrays = map(lambda x: issubclass(type(x), cupy.ndarray),
-                          [a for a in arrays])
-    return all(are_numpy_arrays) or all(are_cupy_arrays)
+    all_numpy_arrays = all(are_numpy_arrays)
+    if cuda.available:
+        are_cupy_arrays = map(lambda x: issubclass(type(x), cupy.ndarray),
+                              [a for a in arrays])
+        return all_numpy_arrays or all(are_cupy_arrays)
+    else:
+        return all_numpy_arrays
 
 
 prod = Variable(numpy.prod, 'prod')

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -7,9 +7,6 @@ import numpy
 
 from chainer import cuda
 
-if cuda.available:
-    import cupy
-
 
 _thread_local = threading.local()
 
@@ -495,7 +492,7 @@ def same_types(*arrays):
                            arrays)
     all_numpy_arrays = all(are_numpy_arrays)
     if cuda.available:
-        are_cupy_arrays = map(lambda x: issubclass(type(x), cupy.ndarray),
+        are_cupy_arrays = map(lambda x: issubclass(type(x), cuda.cupy.ndarray),
                               arrays)
         return all_numpy_arrays or all(are_cupy_arrays)
     else:

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -3,6 +3,7 @@ import operator
 import sys
 import threading
 
+import cupy
 import numpy
 
 from chainer import cuda
@@ -485,6 +486,14 @@ def expect(*bool_exprs):
     for expr in bool_exprs:
         assert isinstance(expr, Testable)
         expr.expect()
+
+
+def same_types(*arrays):
+    are_numpy_arrays = map(lambda x: issubclass(type(x), numpy.ndarray),
+                           [a for a in arrays])
+    are_cupy_arrays = map(lambda x: issubclass(type(x), cupy.ndarray),
+                          [a for a in arrays])
+    return all(are_numpy_arrays) or all(are_cupy_arrays)
 
 
 prod = Variable(numpy.prod, 'prod')

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -492,11 +492,11 @@ def expect(*bool_exprs):
 
 def same_types(*arrays):
     are_numpy_arrays = map(lambda x: issubclass(type(x), numpy.ndarray),
-                           [a for a in arrays])
+                           arrays)
     all_numpy_arrays = all(are_numpy_arrays)
     if cuda.available:
         are_cupy_arrays = map(lambda x: issubclass(type(x), cupy.ndarray),
-                              [a for a in arrays])
+                              arrays)
         return all_numpy_arrays or all(are_cupy_arrays)
     else:
         return all_numpy_arrays

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -56,15 +56,15 @@ class TestEmbedID(unittest.TestCase):
     @attr.gpu
     def test_forward_mixed_cpu_gpu_1(self):
         # self.link is not sent to gpu
-        with self.assertRaisesRegexp(ValueError, "numpy and cupy must not\
-                                                      be used together.*"):
+        with self.assertRaisesRegexp(ValueError, "numpy and cupy must not \
+be used together.*"):
             self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
     def test_forward_mixed_cpu_gpu_2(self):
         self.link.to_gpu()
-        with self.assertRaisesRegexp(ValueError, "numpy and cupy must not\
-                                                      be used together.*"):
+        with self.assertRaisesRegexp(ValueError, "numpy and cupy must not \
+be used together.*"):
             # self.x is not sent to gpu
             self.check_forward(self.x)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -53,6 +53,21 @@ class TestEmbedID(unittest.TestCase):
         self.link.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
 
+    @attr.gpu
+    def test_forward_mixed_cpu_gpu_1(self):
+        # self.link is not sent to gpu
+        with self.assertRaisesRegexp(ValueError, "numpy and cupy must not\
+                                                      be used together.*"):
+            self.check_forward(cuda.to_gpu(self.x))
+
+    @attr.gpu
+    def test_forward_mixed_cpu_gpu_2(self):
+        self.link.to_gpu()
+        with self.assertRaisesRegexp(ValueError, "numpy and cupy must not\
+                                                      be used together.*"):
+            # self.x is not sent to gpu
+            self.check_forward(self.x)
+
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             self.link, x_data, y_grad, self.link.W)

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -360,11 +360,16 @@ class TestProd(unittest.TestCase):
 
 class TestSameTypes(unittest.TestCase):
 
-    @attr.gpu
     def test_all_numpy_array(self):
         x = numpy.array([0])
         y = numpy.array([1])
         z = numpy.array([2])
+        self.assertTrue(T.same_types(x, y, z))
+
+    def test_all_numpy_subclasses(self):
+        x = numpy.array([0])
+        y = numpy.array([[1], [2]])
+        z = numpy.matrix("3,4; 5,6")
         self.assertTrue(T.same_types(x, y, z))
 
     @attr.gpu

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -8,9 +8,6 @@ from chainer import testing
 from chainer.testing import attr
 from chainer.utils import type_check as T
 
-if cuda.available:
-    import cupy
-
 
 class TestConstant(unittest.TestCase):
 
@@ -374,23 +371,23 @@ class TestSameTypes(unittest.TestCase):
 
     @attr.gpu
     def test_all_cupy_array(self):
-        x = cupy.array([0])
-        y = cupy.array([1])
-        z = cupy.array([2])
+        x = cuda.cupy.array([0])
+        y = cuda.cupy.array([1])
+        z = cuda.cupy.array([2])
         self.assertTrue(T.same_types(x, y, z))
 
     @attr.gpu
     def test_numpy_cupy_mixed_1(self):
         x = numpy.array([0])
-        y = cupy.array([1])
+        y = cuda.cupy.array([1])
         z = numpy.array([2])
         self.assertFalse(T.same_types(x, y, z))
 
     @attr.gpu
     def test_numpy_cupy_mixed_2(self):
-        x = cupy.array([0])
+        x = cuda.cupy.array([0])
         y = numpy.array([1])
-        z = cupy.array([2])
+        z = cuda.cupy.array([2])
         self.assertFalse(T.same_types(x, y, z))
 
 

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -1,11 +1,15 @@
 import sys
 import unittest
 
-import cupy
 import numpy
 
+from chainer import cuda
 from chainer import testing
+from chainer.testing import attr
 from chainer.utils import type_check as T
+
+if cuda.available:
+    import cupy
 
 
 class TestConstant(unittest.TestCase):
@@ -356,24 +360,28 @@ class TestProd(unittest.TestCase):
 
 class TestSameTypes(unittest.TestCase):
 
+    @attr.gpu
     def test_all_numpy_array(self):
         x = numpy.array([0])
         y = numpy.array([1])
         z = numpy.array([2])
         self.assertTrue(T.same_types(x, y, z))
 
+    @attr.gpu
     def test_all_cupy_array(self):
         x = cupy.array([0])
         y = cupy.array([1])
         z = cupy.array([2])
         self.assertTrue(T.same_types(x, y, z))
 
+    @attr.gpu
     def test_numpy_cupy_mixed_1(self):
         x = numpy.array([0])
         y = cupy.array([1])
         z = numpy.array([2])
         self.assertFalse(T.same_types(x, y, z))
 
+    @attr.gpu
     def test_numpy_cupy_mixed_2(self):
         x = cupy.array([0])
         y = numpy.array([1])

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -1,8 +1,8 @@
 import sys
 import unittest
 
-import numpy
 import cupy
+import numpy
 
 from chainer import testing
 from chainer.utils import type_check as T

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -368,13 +368,13 @@ class TestSameTypes(unittest.TestCase):
         z = cupy.array([2])
         self.assertTrue(T.same_types(x, y, z))
 
-    def test_all_numpy_cupy_mixed_1(self):
+    def test_numpy_cupy_mixed_1(self):
         x = numpy.array([0])
         y = cupy.array([1])
         z = numpy.array([2])
         self.assertFalse(T.same_types(x, y, z))
 
-    def test_all_numpy_cupy_mixed_2(self):
+    def test_numpy_cupy_mixed_2(self):
         x = cupy.array([0])
         y = numpy.array([1])
         z = cupy.array([2])

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 import numpy
+import cupy
 
 from chainer import testing
 from chainer.utils import type_check as T
@@ -351,6 +352,33 @@ class TestProd(unittest.TestCase):
 
     def test_value(self):
         self.assertIs(T.prod.value, numpy.prod)
+
+
+class TestSameTypes(unittest.TestCase):
+
+    def test_all_numpy_array(self):
+        x = numpy.array([0])
+        y = numpy.array([1])
+        z = numpy.array([2])
+        self.assertTrue(T.same_types(x, y, z))
+
+    def test_all_cupy_array(self):
+        x = cupy.array([0])
+        y = cupy.array([1])
+        z = cupy.array([2])
+        self.assertTrue(T.same_types(x, y, z))
+
+    def test_all_numpy_cupy_mixed_1(self):
+        x = numpy.array([0])
+        y = cupy.array([1])
+        z = numpy.array([2])
+        self.assertFalse(T.same_types(x, y, z))
+
+    def test_all_numpy_cupy_mixed_2(self):
+        x = cupy.array([0])
+        y = numpy.array([1])
+        z = cupy.array([2])
+        self.assertFalse(T.same_types(x, y, z))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR is an improvement over #2076. My apologies to making a new PR, but I mistakenly deleted the whole repository once so I cannot push to the branch used in #2076.

This version considers the case where W is a sub-class of `numpy.array` so that this case is also accepted.


