### PR TITLE
Add cupy.meshgrid

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -135,6 +135,7 @@ from cupy.creation.from_data import copy  # NOQA
 from cupy.creation.ranges import arange  # NOQA
 from cupy.creation.ranges import linspace  # NOQA
 from cupy.creation.ranges import logspace  # NOQA
+from cupy.creation.ranges import meshgrid  # NOQA
 
 from cupy.creation.matrix import diag  # NOQA
 from cupy.creation.matrix import diagflat  # NOQA

--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -132,9 +132,10 @@ def meshgrid(*xi, **kwargs):
     Given one-dimensional coordinate arrays x1, x2, ..., xn, this function
     makes N-D grids.
 
-    For ndarrays x1, x2, ..., xn with lengths ``Ni = len(xi)``, return
-    ``(N1, N2, N3, ..., Nn)`` shaped arrays if indexing='ij' or
-    ``(N2, N1, N3, ..., Nn)`` shaped arrays if indexing='xy'.
+    For one-dimensional arrays x1, x2, ..., xn with lengths ``Ni = len(xi)``,
+    this function returns ``(N1, N2, N3, ..., Nn)`` shaped arrays
+    if indexing='ij' or ``(N2, N1, N3, ..., Nn)`` shaped arrays
+    if indexing='xy'.
 
     Unlike NumPy, CuPy currently only supports 1-D arrays as inputs.
     Also, CuPy does not support ``sparse`` option yet.

--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -160,7 +160,7 @@ def meshgrid(*xi, **kwargs):
     if kwargs:
         raise TypeError(
             'meshgrid() got an unexpected keyword argument \'{}\''.format(
-                        list(kwargs)[0]))
+                list(kwargs)[0]))
     if indexing not in ['xy', 'ij']:
         raise ValueError('Valid values for `indexing` are \'xy\' and \'ij\'.')
 

--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -126,7 +126,66 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
     return core.power(base, y).astype(dtype)
 
 
-# TODO(okuta): Implement meshgrid
+def meshgrid(*xi, **kwargs):
+    """Return coordinate matrices from coordinate vectors.
+
+    Given one-dimensional coordinate arrays x1, x2, ..., xn, this function
+    makes N-D grids.
+
+    For ndarrays x1, x2, ..., xn with lengths ``Ni = len(xi)``, return
+    ``(N1, N2, N3, ..., Nn)`` shaped arrays if indexing='ij' or
+    ``(N2, N1, N3, ..., Nn)`` shaped arrays if indexing='xy'.
+
+    Unlike NumPy, CuPy currently only supports 1-D arrays as inputs.
+    Also, CuPy does not support ``sparse`` option yet.
+
+    Args:
+        xi (tuple of ndarrays): 1-D arrays representing the coordinates
+            of a grid.
+        indexing ({'xy', 'ij'}, optional): Cartesian ('xy', default) or
+            matrix ('ij') indexing of output.
+        copy (bool, optional): If ``False``, a view
+            into the original arrays are returned. Default is True.
+
+    Returns:
+        list of cupy.ndarray
+
+    .. seealso:: :func:`numpy.meshgrid`
+
+    """
+
+    indexing = kwargs.pop('indexing', 'xy')
+    copy = bool(kwargs.pop('copy', True))
+    if indexing not in ['xy', 'ij']:
+        raise ValueError('Valid values for `indexing` are \'xy\' and \'ij\'.')
+
+    for x in xi:
+        if x.ndim != 1:
+            raise ValueError('input has to be 1d')
+        if not isinstance(x, cupy.ndarray):
+            raise ValueError('input has to be cupy.ndarray')
+    if len(xi) <= 1:
+        return list(xi)
+
+    meshes = []
+    for i, x in enumerate(xi):
+        if indexing == 'xy' and i == 0:
+            left_none = 1
+        elif indexing == 'xy' and i == 1:
+            left_none = 0
+        else:
+            left_none = i
+
+        expand_slices = ((None,) * left_none +
+                         (slice(None),) +
+                         (None,) * (len(xi) - (left_none + 1)))
+        meshes.append(x[expand_slices])
+    meshes_br = list(cupy.broadcast_arrays(*meshes))
+
+    if copy:
+        for i in range(len(meshes_br)):
+            meshes_br[i] = meshes_br[i].copy()
+    return meshes_br
 
 
 # mgrid

--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -157,6 +157,10 @@ def meshgrid(*xi, **kwargs):
 
     indexing = kwargs.pop('indexing', 'xy')
     copy = bool(kwargs.pop('copy', True))
+    if kwargs:
+        raise TypeError(
+            'meshgrid() got an unexpected keyword argument \'{}\''.format(
+                        list(kwargs)[0]))
     if indexing not in ['xy', 'ij']:
         raise ValueError('Valid values for `indexing` are \'xy\' and \'ij\'.')
 

--- a/docs/source/cupy-reference/creation.rst
+++ b/docs/source/cupy-reference/creation.rst
@@ -32,6 +32,7 @@ Numerical ranges
 .. autofunction:: cupy.arange
 .. autofunction:: cupy.linspace
 .. autofunction:: cupy.logspace
+.. autofunction:: cupy.meshgrid
 
 
 Matrix creation

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -2,6 +2,7 @@ import math
 import sys
 import unittest
 
+import cupy
 from cupy import testing
 
 
@@ -168,3 +169,39 @@ class TestRanges(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_logspace_base(self, xp, dtype):
         return xp.logspace(0, 2, 5, base=2.0, dtype=dtype)
+
+
+@testing.parameterize(
+    *testing.product({
+        'indexing': ['xy', 'ij'],
+        'copy': [False, True]
+    })
+)
+@testing.gpu
+class TestMeshgrid(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    def test_meshgrid0(self, dtype):
+        out = cupy.meshgrid(indexing=self.indexing, copy=self.copy)
+        assert(out == [])
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_meshgrid1(self, xp, dtype):
+        x = xp.arange(2).astype(dtype)
+        return xp.meshgrid(x, indexing=self.indexing, copy=self.copy)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_meshgrid2(self, xp, dtype):
+        x = xp.arange(2).astype(dtype)
+        y = xp.arange(3).astype(dtype)
+        return xp.meshgrid(x, y, indexing=self.indexing, copy=self.copy)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_meshgrid3(self, xp, dtype):
+        x = xp.arange(2).astype(dtype)
+        y = xp.arange(3).astype(dtype)
+        z = xp.arange(4).astype(dtype)
+        return xp.meshgrid(x, y, z, indexing=self.indexing, copy=self.copy)


### PR DESCRIPTION
This PR adds cupy.meshgrid.
*sparse* option is not supported in this PR.