### PR TITLE
Set dependency for CuPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,12 @@ install_requires = [
 ]
 cupy_require = 'cupy==0.0.1'
 
-cupy_pkg = pkg_resources.get_distribution('cupy')
+cupy_pkg = None
+try:
+    cupy_pkg = pkg_resources.get_distribution('cupy')
+except pkg_resources.DistributionNotFound:
+    pass
+
 if cupy_pkg is not None:
     install_requires.append(cupy_require)
     print('Use %s' % cupy_require)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import pkg_resources
+
 from setuptools import setup
 
 
@@ -11,6 +13,12 @@ install_requires = [
     'protobuf',
     'six>=1.9.0',
 ]
+cupy_require = 'cupy==0.0.1'
+
+cupy_pkg = __version__ = pkg_resources.get_distribution('cupy')
+if cupy_pkg is not None:
+    install_requires.append(cupy_require)
+    print('Use %s' % cupy_require)
 
 setup(
     name='chainer',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 ]
 cupy_require = 'cupy==0.0.1'
 
-cupy_pkg = __version__ = pkg_resources.get_distribution('cupy')
+cupy_pkg = pkg_resources.get_distribution('cupy')
 if cupy_pkg is not None:
     install_requires.append(cupy_require)
     print('Use %s' % cupy_require)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'protobuf',
     'six>=1.9.0',
 ]
-cupy_require = 'cupy==0.0.1'
+cupy_require = 'cupy==1.0.0a1'
 
 cupy_pkg = None
 try:


### PR DESCRIPTION
Chainer and CuPy are split in version 2.
This PR helps Chainer version up.
If user has installed CuPy, Chainer install corresponding CuPy automatically.