### PR TITLE
Optimize dot method for two vectors

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3158,6 +3158,12 @@ cpdef ndarray tensordot_core(
         if out.dtype != dtype:
             out = ndarray(ret_shape, dtype)
 
+    if m == 1 and n == 1:
+        (a.ravel() * b.ravel()).sum(out=out.reshape(()))
+        if out is not ret:
+            elementwise_copy(out, ret)
+        return ret
+
     # It copies the operands if needed
     if a._shape.size() != 2 or a._shape[0] != k or a._shape[1] != n:
         shape.clear()


### PR DESCRIPTION
sgemm is slow to calculate inner product between two vectors. Instead I used prod and sum. In my test, this patch is 10 times faster than the original. @soskek reported this problem.