### PR TITLE
improve forget bias to 1

### DIFF
--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -16,7 +16,7 @@ class LSTMBase(link.Chain):
 
     def __init__(self, in_size, out_size,
                  lateral_init=None, upward_init=None,
-                 bias_init=0, forget_bias_init=0):
+                 bias_init=0, forget_bias_init=1):
         super(LSTMBase, self).__init__(
             upward=linear.Linear(in_size, 4 * out_size, initialW=0),
             lateral=linear.Linear(out_size, 4 * out_size,


### PR DESCRIPTION
The default forget bias will be better to set 1.

Let me introduce the following paper.

[An Empirical Exploration of Recurrent Network Architectures](http://jmlr.org/proceedings/papers/v37/jozefowicz15.pdf)

> Thus we recommend adding a bias of 1 to the forget gate of every LSTM in every application; it is easy to do often results in better performance on our tasks. This adjustment is the simple improvement over the LSTM that we set out to discover.

And TensorFlow's forget bias is set to 1.

[BasicLSTMCell implementation](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/rnn/python/ops/core_rnn_cell_impl.py#L138)