### PR TITLE
PlotReport takes non-negligible portion of time in small networks

### DIFF
--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -140,7 +140,7 @@ class PlotReport(extension.Extension):
                     self._postprocess(f, a, summary)
                 l = a.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
                 f.savefig(path.join(trainer.out, self._file_name),
-                          bbox_extra_artists=(l,), bbox_inches='tight')
+                          bbox_extra_artists=(l,))
 
             plot.close()
             self._init_summary()


### PR DESCRIPTION
When a figure is saved with `bbox_inches='tight'`, `matplotlib.backend_bases.print_method()` is called twice per each `savefig()`, as a comment in the matplotlib source says: https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/backend_bases.py#L2156_L2166

Due to this, when the network is small (like the MNIST example) and the latency of storage IO is high, `savefig()` takes non-negligible portion of the total elapsed time. For example, when the MNIST example is executed in a g2.2xlarge AWS instance with a magnetic device used as the storage, **`write_png()` function (the main part of `print_method()`) takes 5.9 seconds out of 134.7 seconds of total execution time**.

Given this, this PR deletes `bbox_inches='tight'` and reduces the number of calls to `print_method()` to only once per each `savefig()`, resulting in 2.8 seconds used for `write_png()` in the aforementioned environment (g2.2xlarge, magnetic device used as the storage). Because PlotReport uses the default font size and shape, removing `bbox_inches='tight'` does not affect the output image.
