### PR TITLE
cupy.cumsum:  implement its axis option

### DIFF
--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -75,11 +75,12 @@ def _cumsum_batch(out):
         int b = i % batch;
         int j = i / batch;
         if (j & pos) {
-          x[(A){b, j}] += x[(A){b, j ^ pos | (pos - 1)}];
+          const int dst_index[] = {b, j};
+          const int src_index[] = {b, j ^ pos | (pos - 1)};
+          x[dst_index] += x[src_index];
         }
         ''',
-        'cumsum_batch_kernel',
-        preamble="typedef const int A[2];"
+        'cumsum_batch_kernel'
     )
 
     pos = 1
@@ -108,6 +109,8 @@ def cumsum(a, axis=None, dtype=None, out=None):
 
     if axis is None:
         out = out.ravel()
+    elif not (-a.ndim <= axis < a.ndim):
+        raise ValueError("axis(={}) out of bounds".format(axis))
     else:
         return _proc_as_batch(_cumsum_batch, out, axis=axis)
 

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -51,12 +51,48 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False):
 # TODO(okuta): Implement cumprod
 
 
-def cumsum(a, axis=None, dtype=None, out=None):
-    if axis is None:
-        a = a.ravel()
-    else:
-        raise ValueError("'axis' option is not supported")
+def _axis_to_first(x, axis):
+    if axis < 0:
+        axis = x.ndim + axis
+    trans = [axis] + [a for a in range(x.ndim) if a != axis]
+    revert = list(range(1, axis + 1)) + [0] + list(range(axis + 1, x.ndim))
+    return trans, revert
 
+
+def _proc_as_batch(proc, x, axis):
+    trans, revert = _axis_to_first(x, axis)
+    t = x.transpose(trans)
+    s = t.shape
+    r = t.reshape(x.shape[axis], -1).T
+    result = proc(r)
+    return result.T.reshape(s).transpose(revert)
+
+
+def _cumsum_batch(out):
+    if out.ndim != 2:
+        raise ValueError("only 2-D array (Batch, N) is supported")
+
+    kern = core.ElementwiseKernel(
+        'int32 pos, int32 batch', 'raw T x',
+        '''
+        int b = i % batch;
+        int j = i / batch;
+        if (j & pos) {
+          x[(A){b, j}] += x[(A){b, j ^ pos | (pos - 1)}];
+        }
+        ''',
+        'cumsum_batch_kernel',
+        preamble="typedef const int A[2];"
+    )
+
+    pos = 1
+    while pos < out.size:
+        kern(pos, out.shape[0], out, size=out.size)
+        pos <<= 1
+    return out
+
+
+def cumsum(a, axis=None, dtype=None, out=None):
     if out is None:
         if dtype is None:
             kind = a.dtype.kind
@@ -73,6 +109,11 @@ def cumsum(a, axis=None, dtype=None, out=None):
     else:
         out[...] = a
 
+    if axis is None:
+        a = a.ravel()
+    else:
+        return _proc_as_batch(_cumsum_batch, out, axis=axis)
+
     kern = core.ElementwiseKernel(
         'int32 pos', 'raw T x',
         '''
@@ -87,7 +128,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     while pos < out.size:
         kern(pos, out, size=out.size)
         pos <<= 1
-    return out
+    return out.reshape(a.shape)
 
 
 # TODO(okuta): Implement diff

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -1,8 +1,7 @@
 import numpy
+import six
 
 from cupy import core
-
-import six
 
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -2,6 +2,8 @@ import numpy
 
 from cupy import core
 
+from six.moves import range
+
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):
     """Returns the sum of an array along given axes.

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -69,9 +69,6 @@ def _proc_as_batch(proc, x, axis):
 
 
 def _cumsum_batch(out):
-    if out.ndim != 2:
-        raise ValueError("only 2-D array (Batch, N) is supported")
-
     kern = core.ElementwiseKernel(
         'int32 pos, int32 batch', 'raw T x',
         '''

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -2,7 +2,7 @@ import numpy
 
 from cupy import core
 
-from six.moves import range
+import six
 
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):
@@ -56,8 +56,10 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False):
 def _axis_to_first(x, axis):
     if axis < 0:
         axis = x.ndim + axis
-    trans = [axis] + [a for a in range(x.ndim) if a != axis]
-    revert = list(range(1, axis + 1)) + [0] + list(range(axis + 1, x.ndim))
+    trans = [axis] + [a for a in six.moves.range(x.ndim) if a != axis]
+    pre = list(six.moves.range(1, axis + 1))
+    succ = list(six.moves.range(axis + 1, x.ndim))
+    revert = pre + [0] + succ
     return trans, revert
 
 
@@ -112,7 +114,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     if axis is None:
         out = out.ravel()
     elif not (-a.ndim <= axis < a.ndim):
-        raise ValueError("axis(={}) out of bounds".format(axis))
+        raise ValueError('axis(={}) out of bounds'.format(axis))
     else:
         return _proc_as_batch(_cumsum_batch, out, axis=axis)
 

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -107,7 +107,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
         out[...] = a
 
     if axis is None:
-        a = a.ravel()
+        out = out.ravel()
     else:
         return _proc_as_batch(_cumsum_batch, out, axis=axis)
 
@@ -125,7 +125,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     while pos < out.size:
         kern(pos, out, size=out.size)
         pos <<= 1
-    return out.ravel()
+    return out
 
 
 # TODO(okuta): Implement diff

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -125,7 +125,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     while pos < out.size:
         kern(pos, out, size=out.size)
         pos <<= 1
-    return out.reshape(a.shape)
+    return out.ravel()
 
 
 # TODO(okuta): Implement diff

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -151,6 +151,8 @@ class TestSumprod(unittest.TestCase):
 
 
 axes = [0, 1, 2]
+
+
 @testing.gpu
 @testing.parameterize(*testing.product({"axis": axes}))
 class TestCumsum(unittest.TestCase):

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1,11 +1,10 @@
 import unittest
 
 import numpy
+import six
 
 import cupy
 from cupy import testing
-
-import six
 
 
 @testing.gpu

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -6,6 +6,9 @@ import cupy
 from cupy import testing
 
 
+from six.moves import range
+
+
 @testing.gpu
 class TestSumprod(unittest.TestCase):
 
@@ -153,8 +156,8 @@ class TestSumprod(unittest.TestCase):
 axes = [0, 1, 2]
 
 
+@testing.parameterize(*testing.product({'axis': axes}))
 @testing.gpu
-@testing.parameterize(*testing.product({"axis": axes}))
 class TestCumsum(unittest.TestCase):
 
     _multiprocess_can_split_ = True

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -5,7 +5,6 @@ import numpy
 import cupy
 from cupy import testing
 
-
 from six.moves import range
 
 

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -150,7 +150,9 @@ class TestSumprod(unittest.TestCase):
         return xp.prod(a, axis=1)
 
 
+axes = [0, 1, 2]
 @testing.gpu
+@testing.parameterize(*testing.product({"axis": axes}))
 class TestCumsum(unittest.TestCase):
 
     _multiprocess_can_split_ = True
@@ -166,3 +168,10 @@ class TestCumsum(unittest.TestCase):
     def test_cumsum_2dim(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.cumsum(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumsum_axis(self, xp, dtype):
+        n = len(axes)
+        a = testing.shaped_arange(tuple(range(4, 4 + n)), xp, dtype)
+        return xp.cumsum(a, axis=self.axis)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -5,7 +5,7 @@ import numpy
 import cupy
 from cupy import testing
 
-from six.moves import range
+import six
 
 
 @testing.gpu
@@ -177,5 +177,17 @@ class TestCumsum(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_cumsum_axis(self, xp, dtype):
         n = len(axes)
-        a = testing.shaped_arange(tuple(range(4, 4 + n)), xp, dtype)
+        a = testing.shaped_arange(tuple(six.moves.range(4, 4 + n)), xp, dtype)
         return xp.cumsum(a, axis=self.axis)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_invalid_axis_lower(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.cumsum(a, axis=-a.ndim - 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_invalid_axis_upper(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.cumsum(a, axis=a.ndim + 1)


### PR DESCRIPTION
Hi,

I implement and test `cupy.cumsum` with its axis option by extending the (axis=None) version.

