### PR TITLE
Fix count_nonzero to allow its axis option

### DIFF
--- a/cupy/sorting/count.py
+++ b/cupy/sorting/count.py
@@ -1,14 +1,14 @@
 from cupy import core
 
 
-def count_nonzero(x, axis=None):
+def count_nonzero(a, axis=None):
     """Counts the number of non-zero values in the array.
 
     Args:
-        x (cupy.ndarray): The array for which to count non-zeros.
-        axis (int or tuple): optionalAxis or tuple of axes along which to count
-            non-zeros. Default is None, meaning that non-zeros will be counted
-            along a flattened version of ``a``
+        a (cupy.ndarray): The array for which to count non-zeros.
+        axis (int or tuple, optional): Axis or tuple of axes along which to
+            count non-zeros. Default is None, meaning that non-zeros will be
+            counted along a flattened version of ``a``
     Returns:
         int or cupy.ndarray of int: Number of non-zero values in the array
             along a given axis. Otherwise, the total number of non-zero values
@@ -16,9 +16,9 @@ def count_nonzero(x, axis=None):
     """
 
     if axis is None:
-        return int(_count_nonzero(x))
+        return int(_count_nonzero(a))
     else:
-        return _count_nonzero(x, axis=axis)
+        return _count_nonzero(a, axis=axis)
 
 
 _count_nonzero = core.create_reduction_func(

--- a/cupy/sorting/count.py
+++ b/cupy/sorting/count.py
@@ -6,16 +6,20 @@ def count_nonzero(x, axis=None):
 
     Args:
         x (cupy.ndarray): The array for which to count non-zeros.
-
+        axis (int or tuple): optionalAxis or tuple of axes along which to count
+            non-zeros. Default is None, meaning that non-zeros will be counted
+            along a flattened version of ``a``
     Returns:
-        int: Number of non-zero values in the array.
-
+        int or cupy.ndarray of int: Number of non-zero values in the array
+            along a given axis. Otherwise, the total number of non-zero values
+            in the array is returned.
     """
 
     if axis is None:
         return int(_count_nonzero(x))
     else:
         return _count_nonzero(x, axis=axis)
+
 
 _count_nonzero = core.create_reduction_func(
     'cupy_count_nonzero',

--- a/cupy/sorting/count.py
+++ b/cupy/sorting/count.py
@@ -1,7 +1,7 @@
 from cupy import core
 
 
-def count_nonzero(x):
+def count_nonzero(x, axis=None):
     """Counts the number of non-zero values in the array.
 
     Args:
@@ -12,7 +12,10 @@ def count_nonzero(x):
 
     """
 
-    return int(_count_nonzero(x))
+    if axis is None:
+        return int(_count_nonzero(x))
+    else:
+        return _count_nonzero(x, axis=axis)
 
 _count_nonzero = core.create_reduction_func(
     'cupy_count_nonzero',

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -31,7 +31,7 @@ class TestCount(unittest.TestCase):
         self.assertEqual(func(numpy), func(cupy))
 
     @testing.for_all_dtypes()
-    def test_count_nonzero_zero_axis(self, dtype=numpy.float32):
+    def test_count_nonzero_int_axis(self, dtype):
         for ax in range(3):
             def func(xp):
                 m = testing.shaped_random((2, 3, 4), xp, xp.bool_)
@@ -39,3 +39,17 @@ class TestCount(unittest.TestCase):
                 c = xp.count_nonzero(a, axis=ax)
                 return c
             testing.assert_allclose(func(numpy), func(cupy))
+
+    @testing.for_all_dtypes()
+    def test_count_nonzero_tuple_axis(self, dtype):
+        for ax in range(3):
+            for ay in range(3):
+                if ax == ay:
+                    continue
+
+                def func(xp):
+                    m = testing.shaped_random((2, 3, 4), xp, xp.bool_)
+                    a = testing.shaped_random((2, 3, 4), xp, dtype) * m
+                    c = xp.count_nonzero(a, axis=(ax, ay))
+                    return c
+                testing.assert_allclose(func(numpy), func(cupy))

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -5,6 +5,8 @@ import numpy
 import cupy
 from cupy import testing
 
+from six.moves import range
+
 
 @testing.gpu
 class TestCount(unittest.TestCase):

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -29,3 +29,13 @@ class TestCount(unittest.TestCase):
             self.assertIsInstance(c, int)
             return c
         self.assertEqual(func(numpy), func(cupy))
+
+    @testing.for_all_dtypes()
+    def test_count_nonzero_zero_axis(self, dtype=numpy.float32):
+        for ax in range(3):
+            def func(xp):
+                m = testing.shaped_random((2, 3, 4), xp, xp.bool_)
+                a = testing.shaped_random((2, 3, 4), xp, dtype) * m
+                c = xp.count_nonzero(a, axis=ax)
+                return c
+            testing.assert_allclose(func(numpy), func(cupy))


### PR DESCRIPTION
It's minor-fix. `cupy.count_nonzero` should be the same as `numpy.count_nonzero`.