### PR TITLE
Documentation of configuration

### DIFF
--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -61,7 +61,8 @@ class LocalConfig(object):
 
         .. admonition:: Example
 
-           You can easily print the list of configurations used in the current thread.
+           You can easily print the list of configurations used in
+           the current thread.
 
               >>> chainer.config.show()
               debug           False

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -82,8 +82,10 @@ class LocalConfig(object):
 
 
 def _print_attrs(obj, keys, file):
+    max_len = max(len(key) for key in keys)
     for key in keys:
-        print(u'{}:\t{}'.format(key, getattr(obj, key)), file=file)
+        spacer = ' ' * (max_len - len(key))
+        print(u'{} {}{}'.format(key, spacer, getattr(obj, key)), file=file)
 
 
 global_config = GlobalConfig()

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -4,33 +4,14 @@ import sys
 import threading
 
 
-"""Global and thread-local configuration of Chainer.
-
-TODO(beam2d): After adding more entries, move this document to sphinx rst and
-add references to the related features.
-
-Chainer provides some global settings that affect the behavior of some
-
-There are two objects that users mainly deal with: :data:`chainer.config` and
-:data:`chainer.global_config`. The ``config`` object configures the thread-
-local configuration, while the ``global_config`` object configures the global
-configuration shared among all threads.
-
-Each entry of the global configuration is initialized by its default value,
-which can be overridden by a value set to the corresponding environment
-variable. There is a naming rule of the environment variable: an entry of the
-name ``foo_var`` can be configured by the environment variable
-``CHAINER_FOO_VAR``.
-
-"""
-
-
 class GlobalConfig(object):
 
     """The plain object that represents the global configuration of Chainer."""
 
     def show(self, file=sys.stdout):
-        """Prints the global config entries.
+        """show(file=sys.stdout)
+
+        Prints the global config entries.
 
         The entries are sorted in the lexicographical order of the entry name.
 
@@ -69,12 +50,24 @@ class LocalConfig(object):
         setattr(self._local, name, value)
 
     def show(self, file=sys.stdout):
-        """Prints the config entries.
+        """show(file=sys.stdout)
+
+        Prints the config entries.
 
         The entries are sorted in the lexicographical order of the entry names.
 
         Args:
             file: Output file-like object.
+
+        .. admonition:: Example
+
+           You can easily print the list of configurations used in the current thread.
+
+              >>> chainer.config.show()
+              debug           False
+              enable_backprop True
+              train           True
+              type_check      True
 
         """
         keys = sorted(set(self._global.__dict__) | set(self._local.__dict__))
@@ -89,18 +82,33 @@ def _print_attrs(obj, keys, file):
 
 
 global_config = GlobalConfig()
+'''Global configuration of Chainer.
+
+It is an instance of :class:`chainer.configuration.GlobalConfig`.
+See :ref:`configuration` for details.
+'''
+
+
 config = LocalConfig(global_config)
+'''Thread-local configuration of Chainer.
+
+It is an instance of :class:`chainer.configuration.LocalConfig`, and is
+referring to :data:`~chainer.global_config` as its default configuration.
+See :ref:`configuration` for details.
+'''
 
 
 @contextlib.contextmanager
 def using_config(name, value, config=config):
-    """Context manager to temporarily change the thread-local configuration.
+    """using_config(name, value, config=chainer.config)
+
+    Context manager to temporarily change the thread-local configuration.
 
     Args:
         name (str): Name of the configuration to change.
         value: Temporary value of the configuration entry.
-        config (~chainer.config.LocalConfig): Configuration object. Chainer's
-            thread-local configuration is used by default.
+        config (~chainer.configuration.LocalConfig): Configuration object.
+            Chainer's thread-local configuration is used by default.
 
     """
     if hasattr(config._local, name):

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -15,3 +15,4 @@ Core functionalities
    core/dataset
    core/training
    core/debug
+   core/configuration

--- a/docs/source/reference/core/configuration.rst
+++ b/docs/source/reference/core/configuration.rst
@@ -10,18 +10,20 @@ Such settings can be configured using the *unified configuration system*.
 The system provides a transparent way to manage the configuration for each process and for each thread.
 
 The configuration is managed by two global objects: :data:`chainer.global_config` and :data:`chainer.config`.
-The :data:`global_config` object maintains the configuration shared in the Python process.
-This is an instance of the :class:`~chainer.configuration.GlobalConfig` class.
-It can be used just as a plain object, and users can freely set any attributes to it.
-The :data:`config` object, on the other hand, maintains the configuration for the current thread.
-It behaves like a thread-local object, and any attribute modifications are only visible to the current thread.
-If no value is set to this thread-local configuration for a given key, the global configuration is transparently referred.
-Thanks to this transparent lookup, users can always use the ``config`` object to read any configuration so that the thread-local configuration is used if available and otherwise the default global setting is used.
-The ``config`` object is an instance of the :class:`~chainer.configuration.LocalConfig` class.
+
+- The :data:`global_config` object maintains the configuration shared in the Python process.
+  This is an instance of the :class:`~chainer.configuration.GlobalConfig` class.
+  It can be used just as a plain object, and users can freely set any attributes on it.
+- The :data:`config` object, on the other hand, maintains the configuration for the current thread.
+  This is an instance of the :class:`~chainer.configuration.LocalConfig` class.
+  It behaves like a thread-local object, and any attribute modifications are only visible to the current thread.
+
+If no value is set to :data:`config` for a given key, :data:`global_config` is transparently referred.
+Thanks to this transparent lookup, users can always use :data:`config` to read any configuration so that the thread-local configuration is used if available and otherwise the default global setting is used.
 
 The following entries of the configuration are currently provided by Chainer.
 Some entries support environment variables to set the default values.
-Note that the default values are set to the global config.
+Note that the default values are set in the global config.
 
 ``chainer.config.debug``
    Debug mode flag.
@@ -30,8 +32,8 @@ Note that the default values are set to the global config.
    The default value is given by ``CHAINER_DEBUG`` environment variable (set to 0 or 1) if available, otherwise uses ``False``.
 ``chainer.config.enable_backprop``
    Flag to enable backpropagation support.
-   If it is ``True``, the default behavior of :class:`Function` application to :class:`Variable` is non-volatile if all inputs has ``AUTO`` volatile flag.
-   Otherwise, the default behavior is set to volatile mode.
+   If it is ``True``, the default behavior of :class:`Function` application to :class:`Variable` is non-volatile if all inputs have ``AUTO`` volatile flag.
+   Otherwise, the default behavior is set to volatile mode that doesn't keep track of any function appplications to all :class:`Variable` s.
    The default value is ``True``.
 ``chainer.config.train``
    Training mode flag.
@@ -77,18 +79,27 @@ There are two ways:
 
    We often want to temporarily modify the configuration for the current thread.
    It can be done by using :func:`using_config`.
-   For example, if you want to enable the debug mode only to a fragment of codes, write as follows.
+   For example, if you only want to enable debug mode in a fragment of code, write as follows.
 
       >>> with chainer.using_config('debug', True):
       ...     ...  # code running in the debug mode
 
    We often want to switch to the test mode for an evaluation.
-   This is also done by the same way.
+   This is also done in the same way.
 
       >>> with chainer.using_config('train', False):
       ...     ...  # code running in the test mode
 
    Note that :class:`~chainer.training.extensions.Evaluator` automatically switches to the test mode, and thus you do not need to manually switch in the loss function for the evaluation.
+
+   You can also make your own code behave differently in training and test modes as follows.
+
+   .. code-block:: python
+
+      if chainer.config.train:
+          ...  # code only running in the training mode
+      else:
+          ...  # code only running in the test mode
 
 
 .. autodata:: global_config

--- a/docs/source/reference/core/configuration.rst
+++ b/docs/source/reference/core/configuration.rst
@@ -26,6 +26,7 @@ Note that the default values are set to the global config.
 ``chainer.config.debug``
    Debug mode flag.
    If it is ``True``, Chainer runs in the debug mode.
+   See :ref:`debug` for more information of the debug mode.
    The default value is given by ``CHAINER_DEBUG`` environment variable (set to 0 or 1) if available, otherwise uses ``False``.
 ``chainer.config.enable_backprop``
    Flag to enable backpropagation support.

--- a/docs/source/reference/core/configuration.rst
+++ b/docs/source/reference/core/configuration.rst
@@ -1,0 +1,101 @@
+.. _configuration:
+
+Configuring Chainer
+===================
+
+..  currentmodule:: chainer
+
+Chainer provides some global settings that affect the behavior of some functionalities.
+Such settings can be configured using the *unified configuration system*.
+The system provides a transparent way to manage the configuration for each process and for each thread.
+
+The configuration is managed by two global objects: :data:`chainer.global_config` and :data:`chainer.config`.
+The :data:`global_config` object maintains the configuration shared in the Python process.
+This is an instance of the :class:`~chainer.configuration.GlobalConfig` class.
+It can be used just as a plain object, and users can freely set any attributes to it.
+The :data:`config` object, on the other hand, maintains the configuration for the current thread.
+It behaves like a thread-local object, and any attribute modifications are only visible to the current thread.
+If no value is set to this thread-local configuration for a given key, the global configuration is transparently referred.
+Thanks to this transparent lookup, users can always use the ``config`` object to read any configuration so that the thread-local configuration is used if available and otherwise the default global setting is used.
+The ``config`` object is an instance of the :class:`~chainer.configuration.LocalConfig` class.
+
+The following entries of the configuration are currently provided by Chainer.
+Some entries support environment variables to set the default values.
+Note that the default values are set to the global config.
+
+``chainer.config.debug``
+   Debug mode flag.
+   If it is ``True``, Chainer runs in the debug mode.
+   The default value is given by ``CHAINER_DEBUG`` environment variable (set to 0 or 1) if available, otherwise uses ``False``.
+``chainer.config.enable_backprop``
+   Flag to enable backpropagation support.
+   If it is ``True``, the default behavior of :class:`Function` application to :class:`Variable` is non-volatile if all inputs has ``AUTO`` volatile flag.
+   Otherwise, the default behavior is set to volatile mode.
+   The default value is ``True``.
+``chainer.config.train``
+   Training mode flag.
+   If it is ``True``, Chainer runs in the training mode.
+   Otherwise, it runs in the testing (evaluation) mode.
+   The default value is ``True``.
+``chainer.config.type_check``
+   Type checking mode flag.
+   If it is ``True``, Chainer checks the types (data types and shapes) of inputs on :class:`Function` applications.
+   Otherwise, it skips type checking.
+   The default value is given by ``CHAINER_TYPE_CHECK`` environment variable (set to 0 or 1) if available, otherwise uses ``True``.
+
+Users can also define their own configurations.
+There are two ways:
+
+1. Use Chainer's configuration objects.
+   In this case, **it is strongly recommended to prefix the name by "user_"** to avoid name conflicts with configurations introduced to Chainer in the future.
+2. Use your own configuration objects.
+   Users can define their own configuration objects using :class:`chainer.configuration.GlobalConfig` and :class:`chainer.configuration.LocalConfig`.
+   In this case, there is no need to take care of the name conflicts.
+
+
+.. admonition:: Example
+
+   If you want to share a setting within the process, set an attribute to the global configuration.
+
+   .. doctest::
+
+      >>> chainer.global_config.user_my_setting = 123
+
+   This value is automatically extracted by referring to the local config.
+
+   .. doctest::
+
+      >>> chainer.config.user_my_setting
+      123
+
+   If you set an attribute to the local configuration, the value is only visible to the current thread.
+
+   .. doctest::
+
+      >>> chainer.config.user_my_setting = 123
+
+   We often want to temporarily modify the configuration for the current thread.
+   It can be done by using :func:`using_config`.
+   For example, if you want to enable the debug mode only to a fragment of codes, write as follows.
+
+      >>> with chainer.using_config('debug', True):
+      ...     ...  # code running in the debug mode
+
+   We often want to switch to the test mode for an evaluation.
+   This is also done by the same way.
+
+      >>> with chainer.using_config('train', False):
+      ...     ...  # code running in the test mode
+
+   Note that :class:`~chainer.training.extensions.Evaluator` automatically switches to the test mode, and thus you do not need to manually switch in the loss function for the evaluation.
+
+
+.. autodata:: global_config
+.. autodata:: config
+.. autofunction:: using_config
+
+.. autoclass:: chainer.configuration.GlobalConfig
+   :members:
+
+.. autoclass:: chainer.configuration.LocalConfig
+   :members:

--- a/docs/source/reference/core/debug.rst
+++ b/docs/source/reference/core/debug.rst
@@ -1,3 +1,5 @@
+.. _debug:
+
 Debug mode
 ==========
 
@@ -8,6 +10,11 @@ Instead it requires additional overhead time.
 
 In debug mode, Chainer checks all results of forward and backward computation, and if it founds a NaN value, it raises :class:`RuntimeError`.
 Some functions and links also check validity of input values.
+
+As of v2.0.0, it is recommended to turn on the debug mode using ``chainer.config.debug``.
+See :ref:`configuration` for the way to use the config object.
+We leave the reference of the conventional ways as follows.
+
 
 .. currentmodule:: chainer
 

--- a/docs/source/reference/core/debug.rst
+++ b/docs/source/reference/core/debug.rst
@@ -13,7 +13,7 @@ Some functions and links also check validity of input values.
 
 As of v2.0.0, it is recommended to turn on the debug mode using ``chainer.config.debug``.
 See :ref:`configuration` for the way to use the config object.
-We leave the reference of the conventional ways as follows.
+We leave the reference of the conventional ways (which have been available since Chainer v1) as follows.
 
 
 .. currentmodule:: chainer

--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -559,6 +559,7 @@ These extensions perform the following tasks:
 
 :class:`~training.extensions.Evaluator`
    Evaluates the current model on the test dataset at the end of every epoch.
+   It automatically switches to the test mode (see :ref:`configuration` for details), and so we do not have to take care on functions that behave differently in training/test modes (e.g. :func:`~chainer.functions.dropout`, :class:`~chainer.links.BatchNormalization`).
 :class:`~training.extensions.LogReport`
    Accumulates the reported values and emits them to the log file in the output directory.
 :class:`~training.extensions.PrintReport`

--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -559,7 +559,7 @@ These extensions perform the following tasks:
 
 :class:`~training.extensions.Evaluator`
    Evaluates the current model on the test dataset at the end of every epoch.
-   It automatically switches to the test mode (see :ref:`configuration` for details), and so we do not have to take care on functions that behave differently in training/test modes (e.g. :func:`~chainer.functions.dropout`, :class:`~chainer.links.BatchNormalization`).
+   It automatically switches to the test mode (see :ref:`configuration` for details), and so we do not have to take any special function for functions that behave differently in training/test modes (e.g. :func:`~chainer.functions.dropout`, :class:`~chainer.links.BatchNormalization`).
 :class:`~training.extensions.LogReport`
    Accumulates the reported values and emits them to the log file in the output directory.
 :class:`~training.extensions.PrintReport`


### PR DESCRIPTION
This PR adds a documentation for `chainer.config` and modifies some existing docs related to any configuration entries (e.g. debug mode document, tutorial).