### PR TITLE
Raise a correct exception when attempting to import broken CuPy

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -15,7 +15,7 @@ except ImportError:
            '--no-cache-dir -vvvv`.\n\n'
            'original error: {}'.format(exc_info[1]))
 
-    six.reraise(RuntimeError, RuntimeError(msg), exc_info[2])
+    six.reraise(ImportError, ImportError(msg), exc_info[2])
 
 from cupy import binary  # NOQA
 from cupy import creation  # NOQA


### PR DESCRIPTION
Fix a test introduced in #2291 when cupy is not installed.

Ref: #2306
