### PR TITLE
fix typo in test_sigmoid_cross_entropy

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -101,7 +101,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
     {'use_cudnn': False},
 )
 @attr.cudnn
-class TestSgimoidCrossEntropyCudnnCall(unittest.TestCase):
+class TestSigmoidCrossEntropyCudnnCall(unittest.TestCase):
 
     def setUp(self):
         self.x = cuda.cupy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)


### PR DESCRIPTION
I found a typo in `tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py`