### PR TITLE
fix epoch_detail

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -201,9 +201,9 @@ class MultiprocessIterator(iterator.Iterator):
             if i >= n:
                 self.epoch += 1
                 self.is_new_epoch = True
+                i = 0
                 if not self._repeat:
                     break
-                i = 0
         self.current_position = i
         # Eventually overwrite the (possibly shuffled) order.
         self._order = self._prefetch_order

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -69,7 +69,7 @@ class SerialIterator(iterator.Iterator):
                                       for index in self._order[:rest]])
                 self.current_position = rest
             else:
-                self.current_position = N
+                self.current_position = 0
 
             self.epoch += 1
             self.is_new_epoch = True

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import copy
 import unittest
 

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -25,25 +25,30 @@ class TestMultiprocessIterator(unittest.TestCase):
         it = iterators.MultiprocessIterator(dataset, 2, **self.options)
         for i in range(3):
             self.assertEqual(it.epoch, i)
+            self.assertAlmostEqual(it.epoch_detail, i + 0 / 6)
             batch1 = it.next()
             self.assertEqual(len(batch1), 2)
             self.assertIsInstance(batch1, list)
             self.assertFalse(it.is_new_epoch)
+            self.assertAlmostEqual(it.epoch_detail, i + 2 / 6)
             batch2 = it.next()
             self.assertEqual(len(batch2), 2)
             self.assertIsInstance(batch2, list)
             self.assertFalse(it.is_new_epoch)
+            self.assertAlmostEqual(it.epoch_detail, i + 4 / 6)
             batch3 = it.next()
             self.assertEqual(len(batch3), 2)
             self.assertIsInstance(batch3, list)
             self.assertTrue(it.is_new_epoch)
             self.assertEqual(sorted(batch1 + batch2 + batch3), dataset)
+            self.assertAlmostEqual(it.epoch_detail, i + 6 / 6)
 
     def test_iterator_list_type(self):
         dataset = [[i, numpy.zeros((10,)) + i] for i in range(6)]
         it = iterators.MultiprocessIterator(dataset, 2, **self.options)
         for i in range(3):
             self.assertEqual(it.epoch, i)
+            self.assertAlmostEqual(it.epoch_detail, i)
             batches = {}
             for j in range(3):
                 batch = it.next()
@@ -52,6 +57,8 @@ class TestMultiprocessIterator(unittest.TestCase):
                     self.assertFalse(it.is_new_epoch)
                 else:
                     self.assertTrue(it.is_new_epoch)
+                self.assertAlmostEqual(
+                    it.epoch_detail, (3 * i + j + 1) * 2 / 6)
                 for x in batch:
                     self.assertIsInstance(x, list)
                     self.assertIsInstance(x[1], numpy.ndarray)
@@ -66,6 +73,7 @@ class TestMultiprocessIterator(unittest.TestCase):
         it = iterators.MultiprocessIterator(dataset, 2, **self.options)
         for i in range(3):
             self.assertEqual(it.epoch, i)
+            self.assertAlmostEqual(it.epoch_detail, i)
             batches = {}
             for j in range(3):
                 batch = it.next()
@@ -74,6 +82,8 @@ class TestMultiprocessIterator(unittest.TestCase):
                     self.assertFalse(it.is_new_epoch)
                 else:
                     self.assertTrue(it.is_new_epoch)
+                self.assertAlmostEqual(
+                    it.epoch_detail, (3 * i + j + 1) * 2 / 6)
                 for x in batch:
                     self.assertIsInstance(x, tuple)
                     self.assertIsInstance(x[1], numpy.ndarray)
@@ -88,6 +98,7 @@ class TestMultiprocessIterator(unittest.TestCase):
         it = iterators.MultiprocessIterator(dataset, 2, **self.options)
         for i in range(3):
             self.assertEqual(it.epoch, i)
+            self.assertAlmostEqual(it.epoch_detail, i)
             batches = {}
             for j in range(3):
                 batch = it.next()
@@ -96,6 +107,8 @@ class TestMultiprocessIterator(unittest.TestCase):
                     self.assertFalse(it.is_new_epoch)
                 else:
                     self.assertTrue(it.is_new_epoch)
+                self.assertAlmostEqual(
+                    it.epoch_detail, (3 * i + j + 1) * 2 / 6)
                 for x in batch:
                     self.assertIsInstance(x, dict)
                     k = tuple(x)[0]
@@ -130,9 +143,13 @@ class TestMultiprocessIterator(unittest.TestCase):
         it = iterators.MultiprocessIterator(
             dataset, 2, repeat=False, **self.options)
 
+        self.assertAlmostEqual(it.epoch_detail, 0 / 5)
         batch1 = it.next()
+        self.assertAlmostEqual(it.epoch_detail, 2 / 5)
         batch2 = it.next()
+        self.assertAlmostEqual(it.epoch_detail, 4 / 5)
         batch3 = it.next()
+        self.assertAlmostEqual(it.epoch_detail, 5 / 5)
         self.assertRaises(StopIteration, it.next)
 
         self.assertEqual(len(batch3), 1)

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -11,41 +11,55 @@ class TestSerialIterator(unittest.TestCase):
         it = iterators.SerialIterator(dataset, 2, shuffle=False)
         for i in range(3):
             self.assertEqual(it.epoch, i)
+            self.assertAlmostEqual(it.epoch_detail, i + 0 / 6)
             self.assertEqual(it.next(), [1, 2])
             self.assertFalse(it.is_new_epoch)
+            self.assertAlmostEqual(it.epoch_detail, i + 2 / 6)
             self.assertEqual(it.next(), [3, 4])
             self.assertFalse(it.is_new_epoch)
+            self.assertAlmostEqual(it.epoch_detail, i + 4 / 6)
             self.assertEqual(it.next(), [5, 6])
             self.assertTrue(it.is_new_epoch)
+            self.assertAlmostEqual(it.epoch_detail, i + 6 / 6)
 
     def test_iterator_repeat_not_even(self):
         dataset = [1, 2, 3, 4, 5]
         it = iterators.SerialIterator(dataset, 2, shuffle=False)
 
         self.assertEqual(it.epoch, 0)
+        self.assertAlmostEqual(it.epoch_detail, 0 / 5)
         self.assertEqual(it.next(), [1, 2])
         self.assertFalse(it.is_new_epoch)
+        self.assertAlmostEqual(it.epoch_detail, 2 / 5)
         self.assertEqual(it.next(), [3, 4])
         self.assertFalse(it.is_new_epoch)
+        self.assertAlmostEqual(it.epoch_detail, 4 / 5)
         self.assertEqual(it.next(), [5, 1])
         self.assertTrue(it.is_new_epoch)
         self.assertEqual(it.epoch, 1)
+        self.assertAlmostEqual(it.epoch_detail, 6 / 5)
 
         self.assertEqual(it.next(), [2, 3])
         self.assertFalse(it.is_new_epoch)
+        self.assertAlmostEqual(it.epoch_detail, 8 / 5)
         self.assertEqual(it.next(), [4, 5])
         self.assertTrue(it.is_new_epoch)
         self.assertEqual(it.epoch, 2)
+        self.assertAlmostEqual(it.epoch_detail, 10 / 5)
 
     def test_iterator_not_repeat(self):
         dataset = [1, 2, 3, 4, 5, 6]
         it = iterators.SerialIterator(dataset, 2, repeat=False, shuffle=False)
 
+        self.assertAlmostEqual(it.epoch_detail, 0 / 6)
         self.assertEqual(it.next(), [1, 2])
+        self.assertAlmostEqual(it.epoch_detail, 2 / 6)
         self.assertEqual(it.next(), [3, 4])
+        self.assertAlmostEqual(it.epoch_detail, 4 / 6)
         self.assertEqual(it.next(), [5, 6])
         self.assertTrue(it.is_new_epoch)
         self.assertEqual(it.epoch, 1)
+        self.assertAlmostEqual(it.epoch_detail, 6 / 6)
         for i in range(2):
             self.assertRaises(StopIteration, it.next)
 
@@ -53,11 +67,15 @@ class TestSerialIterator(unittest.TestCase):
         dataset = [1, 2, 3, 4, 5]
         it = iterators.SerialIterator(dataset, 2, repeat=False, shuffle=False)
 
+        self.assertAlmostEqual(it.epoch_detail, 0 / 5)
         self.assertEqual(it.next(), [1, 2])
+        self.assertAlmostEqual(it.epoch_detail, 2 / 5)
         self.assertEqual(it.next(), [3, 4])
+        self.assertAlmostEqual(it.epoch_detail, 4 / 5)
         self.assertEqual(it.next(), [5])
         self.assertTrue(it.is_new_epoch)
         self.assertEqual(it.epoch, 1)
+        self.assertAlmostEqual(it.epoch_detail, 5 / 5)
         self.assertRaises(StopIteration, it.next)
 
 
@@ -68,16 +86,20 @@ class TestSerialIteratorShuffled(unittest.TestCase):
         it = iterators.SerialIterator(dataset, 2)
         for i in range(3):
             self.assertEqual(it.epoch, i)
+            self.assertAlmostEqual(it.epoch_detail, i + 0 / 6)
             batch1 = it.next()
             self.assertEqual(len(batch1), 2)
             self.assertFalse(it.is_new_epoch)
+            self.assertAlmostEqual(it.epoch_detail, i + 2 / 6)
             batch2 = it.next()
             self.assertEqual(len(batch2), 2)
             self.assertFalse(it.is_new_epoch)
+            self.assertAlmostEqual(it.epoch_detail, i + 4 / 6)
             batch3 = it.next()
             self.assertEqual(len(batch3), 2)
             self.assertTrue(it.is_new_epoch)
             self.assertEqual(sorted(batch1 + batch2 + batch3), dataset)
+            self.assertAlmostEqual(it.epoch_detail, i + 6 / 6)
 
     def test_iterator_repeat_not_even(self):
         dataset = [1, 2, 3, 4, 5]
@@ -100,9 +122,13 @@ class TestSerialIteratorShuffled(unittest.TestCase):
         dataset = [1, 2, 3, 4, 5]
         it = iterators.SerialIterator(dataset, 2, repeat=False)
 
+        self.assertAlmostEqual(it.epoch_detail, 0 / 5)
         batch1 = it.next()
+        self.assertAlmostEqual(it.epoch_detail, 2 / 5)
         batch2 = it.next()
+        self.assertAlmostEqual(it.epoch_detail, 4 / 5)
         batch3 = it.next()
+        self.assertAlmostEqual(it.epoch_detail, 5 / 5)
         self.assertRaises(StopIteration, it.next)
 
         self.assertEqual(len(batch3), 1)

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import unittest
 
 from chainer import iterators


### PR DESCRIPTION
`epoch_detail` takes wrong value if the iterator is not repeated.
Here is an example.
```
dataset = [1, 2, 3]
it = chainer.iterators.SerialIterator(dataset, 2, repeat=False)
it.next() # [3, 1]
it.next() # [2]
it.epoch # 1
it.epoch_detail # 2.0
```
I think `epoch_detail` should be 1.0 in this case.