### PR TITLE
L.Linear is preferable to F.Linear in LSTM document.

### DIFF
--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -215,8 +215,8 @@ def lstm(c_prev, x):
         >>> y = chainer.Variable(np.zeros((1, n_units), 'f'))
         >>> h = chainer.Variable(np.zeros((1, n_units), 'f'))
         >>> c = chainer.Variable(np.zeros((1, n_units), 'f'))
-        >>> model = chainer.Chain(w=F.Linear(n_units, 4 * n_units),
-        ...                       v=F.Linear(n_units, 4 * n_units),)
+        >>> model = chainer.Chain(w=L.Linear(n_units, 4 * n_units),
+        ...                       v=L.Linear(n_units, 4 * n_units),)
         >>> x = model.w(y) + model.v(h)
         >>> c, h = F.lstm(c, x)
 


### PR DESCRIPTION
I fixed the LSTM document.
`L.Linear` is preferable to `F.Linear` because it has parameters (weight and bias).
