### PR TITLE
Check code snippet using doctest

### DIFF
--- a/docs/source/cupy-reference/difference.rst
+++ b/docs/source/cupy-reference/difference.rst
@@ -11,14 +11,14 @@ Cast behavior from float to integer
 Some casting behaviors from float to integer are not defined in C++ specification.
 The casting from a negative float to unsigned integer and infinity to integer is one of such eamples.
 The behavior of NumPy depends on your CPU architecture.
-This is Intel CPU result::
+This is Intel CPU result.
 
-  >>> numpy.array([-1], dtype='f').astype('I')
+  >>> np.array([-1], dtype='f').astype('I')
   array([4294967295], dtype=uint32)
   >>> cupy.array([-1], dtype='f').astype('I')
   array([0], dtype=uint32)
 
-  >>> numpy.array([float('inf')], dtype='f').astype('i')
+  >>> np.array([float('inf')], dtype='f').astype('i')
   array([-2147483648], dtype=int32)
   >>> cupy.array([float('inf')], dtype='f').astype('i')
   array([2147483647], dtype=int32)
@@ -32,9 +32,9 @@ Because the result of the multiplication of boolean values is boolean, ``True **
 However, when you use power operator with other arguments, it returns int values.
 If we aligned the behavior of the squared boolean values of CuPy to that of NumPy, we would have to check their values in advance of the calculation.
 But it would be slow because it would force CPUs to wait until the calculation on GPUs end.
-So we decided not to check its value::
+So we decided not to check its value.
 
-  >>> numpy.array([True]) ** 2
+  >>> np.array([True]) ** 2
   array([ True], dtype=bool)
   >>> cupy.array([True]) ** 2
   array([1])
@@ -44,13 +44,13 @@ Random methods support dtype argument
 -------------------------------------
 
 NumPy's random value generator does not support dtype option and it always resturns a ``float32`` value.
-We support the option in CuPy because cuRAND, which is used in CuPy, supports any types of float values::
+We support the option in CuPy because cuRAND, which is used in CuPy, supports any types of float values.
 
-  >>> numpy.random.randn(dtype='f')
+  >>> np.random.randn(dtype='f')
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
   TypeError: randn() got an unexpected keyword argument 'dtype'
-  >>> cupy.random.randn(dtype='f')
+  >>> cupy.random.randn(dtype='f')    # doctest: +SKIP
   array(0.10689262300729752, dtype=float32)
 
 
@@ -58,9 +58,9 @@ Out-of-bounds indices
 ---------------------
 CuPy handles out-of-bounds indices differently by default from NumPy when
 using integer array indexing.
-NumPy handles them by raising an error, but CuPy wraps around them::
+NumPy handles them by raising an error, but CuPy wraps around them.
 
-  >>> x = numpy.array([0, 1, 2])
+  >>> x = np.array([0, 1, 2])
   >>> x[[1, 3]] = 10
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
@@ -68,7 +68,7 @@ NumPy handles them by raising an error, but CuPy wraps around them::
   >>> x = cupy.array([0, 1, 2])
   >>> x[[1, 3]] = 10
   >>> x
-  array([10, 10, 2])
+  array([10, 10,  2])
 
 
 Duplicate values in indices
@@ -76,21 +76,21 @@ Duplicate values in indices
 CuPy's ``__setitem__`` behaves differently from NumPy when integer arrays
 reference the same location multiple times.
 In that case, the value that is actually stored is undefined.
-Here is an example of CuPy::
+Here is an example of CuPy.
 
   >>> a = cupy.zeros((2,))
   >>> i = cupy.arange(10000) % 2
-  >>> v = cupy.arange(10000).astype(numpy.float)
+  >>> v = cupy.arange(10000).astype(np.float)
   >>> a[i] = v
-  >>> a
-  array([9150., 9151.])
+  >>> a  # doctest: +SKIP
+  array([ 9150.,  9151.])
 
 NumPy stores the value corresponding to the
-last element among elements referencing duplicate locations::
+last element among elements referencing duplicate locations.
 
-  >>> a_cpu = numpy.zeros((2,))
-  >>> i_cpu = numpy.arange(10000) % 2
-  >>> v_cpu = numpy.arange(10000).astype(numpy.float)
+  >>> a_cpu = np.zeros((2,))
+  >>> i_cpu = np.arange(10000) % 2
+  >>> v_cpu = np.arange(10000).astype(np.float)
   >>> a_cpu[i_cpu] = v_cpu
   >>> a_cpu
-  array([9998., 9999.])
+  array([ 9998.,  9999.])


### PR DESCRIPTION
doctest does not check `::` snippets. I replaced them with doctest format and fixed the code.