### PR TITLE
ignore .idea directory for pycharm users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _readthedocs_build
 chainer.egg-info/
 dist/
 htmlcov/
+.idea/


### PR DESCRIPTION
.idea is config files directory which pycharm automatically creates
This PR is to ignore .idea directory from git commit.