### PR TITLE
Re-compute

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -33,6 +33,8 @@ from chainer.flag import ON  # NOQA
 from chainer.function import force_backprop_mode  # NOQA
 from chainer.function import Function  # NOQA
 from chainer.function import no_backprop_mode  # NOQA
+from chainer.function import use_recompute  # NOQA
+from chainer.function import no_recompute  # NOQA
 from chainer.function_set import FunctionSet  # NOQA
 from chainer.functions import array  # NOQA
 from chainer.functions import basic_math  # NOQA

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -88,7 +88,7 @@ def use_recompute(*fnames):
 
     default = copy.copy(getattr(_thread_local, 'recompute_targets', []))
     for fname in fnames:
-        if not fname in _thread_local.recompute_targets:
+        if fname not in _thread_local.recompute_targets:
             _thread_local.recompute_targets.append(fname)
     yield
     _thread_local.recompute_targets = default
@@ -100,7 +100,7 @@ def no_recompute(*fnames):
     default = copy.copy(getattr(_thread_local, 'recompute_targets', []))
     _thread_local.recompute_targets = []
     for fname in default:
-        if not fname in fnames:
+        if fname not in fnames:
             _thread_local.recompute_targets.append(fname)
     yield
     _thread_local.recompute_targets = default
@@ -476,6 +476,7 @@ class Function(object):
             y_ref = y()
             if y_ref is not None:
                 y_ref.creator = None
+                y_ref.g_creator = None
         self.inputs = None
 
     def add_hook(self, hook, name=None):

--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -16,6 +16,11 @@ class LeakyReLU(function.Function):
     def __init__(self, slope=0.2):
         self.slope = slope
 
+        _fnames = getattr(function._thread_local, 'recompute_targets', [])
+        if "RELU" in _fnames:
+            self.recompute = True
+            # print('  recompute is enabled: {}'.format(self))
+
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
         x_type, = in_types

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -21,6 +21,11 @@ class ReLU(function.Function):
     def __init__(self, use_cudnn=True):
         self.use_cudnn = use_cudnn
 
+        _fnames = getattr(function._thread_local, 'recompute_targets', [])
+        if "RELU" in _fnames:
+            self.recompute = True
+            # print("  recompute is enabled: {}".format(self))
+
     def check_type_forward(self, in_types):
         type_check.expect(
             in_types.size() == 1,

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -24,7 +24,7 @@ class ReLU(function.Function):
         _fnames = getattr(function._thread_local, 'recompute_targets', [])
         if "RELU" in _fnames:
             self.recompute = True
-            # print("  recompute is enabled: {}".format(self))
+            # print('  recompute is enabled: {}'.format(self))
 
     def check_type_forward(self, in_types):
         type_check.expect(

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -38,6 +38,11 @@ class Convolution2DFunction(function.Function):
         self.cover_all = cover_all
         self.deterministic = deterministic
 
+        _fnames = getattr(function._thread_local, 'recompute_targets', [])
+        if "CONV" in _fnames:
+            self.recompute = True
+            # print("  recompute is enabled: {}".format(self))
+
     def check_type_forward(self, in_types):
         n_in = in_types.size()
         type_check.expect(2 <= n_in, n_in <= 3)

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -41,7 +41,7 @@ class Convolution2DFunction(function.Function):
         _fnames = getattr(function._thread_local, 'recompute_targets', [])
         if "CONV" in _fnames:
             self.recompute = True
-            # print("  recompute is enabled: {}".format(self))
+            # print('  recompute is enabled: {}'.format(self))
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -37,6 +37,11 @@ class Deconvolution2DFunction(function.Function):
         self.outh, self.outw = (None, None) if outsize is None else outsize
         self.deterministic = deterministic
 
+        _fnames = getattr(function._thread_local, 'recompute_targets', [])
+        if "CONV" in _fnames:
+            self.recompute = True
+            # print("  recompute is enabled: {}".format(self))
+
     def check_type_forward(self, in_types):
         n_in = in_types.size()
         type_check.expect(2 <= n_in, n_in <= 3)

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -51,7 +51,7 @@ class BatchNormalizationFunction(function.Function):
         _fnames = getattr(function._thread_local, 'recompute_targets', [])
         if "BN" in _fnames:
             self.recompute = True
-            # print("  recompute is enabled: {}".format(self))
+            # print('  recompute is enabled: {}'.format(self))
 
     def check_type_forward(self, in_types):
         n_in = in_types.size().eval()

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -48,6 +48,11 @@ class BatchNormalizationFunction(function.Function):
         self.mean_cache = None
         self.decay = decay
 
+        _fnames = getattr(function._thread_local, 'recompute_targets', [])
+        if "BN" in _fnames:
+            self.recompute = True
+            # print("  recompute is enabled: {}".format(self))
+
     def check_type_forward(self, in_types):
         n_in = in_types.size().eval()
         if n_in != 3 and n_in != 5:

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -56,7 +56,8 @@ cdef class SingleDeviceMemoryPool:
     cpdef free_all_blocks(self)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
-
+    cpdef size_in_use_mem(self)  # testing
+    cpdef size_free_mem(self)  # testing
 
 cdef class MemoryPool:
 
@@ -67,3 +68,5 @@ cdef class MemoryPool:
     cpdef free_all_blocks(self)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
+    cpdef size_in_use_mem(self)  # testing
+    cpdef size_free_mem(self)  # testing

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -395,6 +395,26 @@ cdef class SingleDeviceMemoryPool:
             n += len(v)
         return n
 
+    # testing
+    cpdef size_in_use_mem(self):
+        cdef Py_ssize_t size = 0
+        cdef Memory mem
+        for ptr in self._in_use:
+            mem = self._in_use[ptr]
+            size += mem.size
+        return size
+
+    # testing
+    cpdef size_free_mem(self):
+        cdef Py_ssize_t size = 0
+        cdef list free
+        cdef Memory mem
+        for s in self._free:
+            free = self._free[s]
+            for mem in free:
+                size += mem.size
+        return size
+
 
 cdef class MemoryPool(object):
 
@@ -466,3 +486,13 @@ cdef class MemoryPool(object):
         """
         dev = device.get_device_id()
         return self._pools[dev].n_free_blocks()
+
+    # testing
+    cpdef size_in_use_mem(self):
+        dev = device.get_device_id()
+        return self._pools[dev].size_in_use_mem()
+
+    # testing
+    cpdef size_free_mem(self):
+        dev = device.get_device_id()
+        return self._pools[dev].size_free_mem()

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -13,7 +13,6 @@ from cupy.cuda import runtime
 from cupy.cuda cimport device
 from cupy.cuda cimport runtime
 
-
 cdef class Memory:
 
     """Memory allocation on a CUDA device.
@@ -320,6 +319,9 @@ cdef class PooledMemory(Memory):
         buffer to the memory pool for reuse.
 
         """
+        if False:  # debug
+            print("[memory.pyx, PooledMemory, free()] size: {}, ptr: {}".format(self.size, self.ptr))
+
         pool = self.pool()
         if pool and self.ptr != 0:
             pool.free(self.ptr, self.size)
@@ -369,6 +371,8 @@ cdef class SingleDeviceMemoryPool:
 
         self._in_use[mem.ptr] = mem
         pmem = PooledMemory(mem, self._weakref)
+        if False:  # debug
+            print("[memory.ptx, SingleDeviceMemoryPool, malloc()] size: {}, ptr: {}".format(pmem.size, pmem.ptr))
         return MemoryPointer(pmem, 0)
 
     cpdef free(self, size_t ptr, Py_ssize_t size):

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -320,7 +320,8 @@ cdef class PooledMemory(Memory):
 
         """
         if False:  # debug
-            print("[memory.pyx, PooledMemory, free()] size: {}, ptr: {}".format(self.size, self.ptr))
+            print('[memory.pyx, free()] size: {}, ptr: {}'.
+                  format(self.size, self.ptr))
 
         pool = self.pool()
         if pool and self.ptr != 0:
@@ -372,7 +373,8 @@ cdef class SingleDeviceMemoryPool:
         self._in_use[mem.ptr] = mem
         pmem = PooledMemory(mem, self._weakref)
         if False:  # debug
-            print("[memory.ptx, SingleDeviceMemoryPool, malloc()] size: {}, ptr: {}".format(pmem.size, pmem.ptr))
+            print('[memory.ptx, malloc()] size: {}, ptr: {}'.
+                  format(pmem.size, pmem.ptr))
         return MemoryPointer(pmem, 0)
 
     cpdef free(self, size_t ptr, Py_ssize_t size):

--- a/examples/imagenet/resnet152.py
+++ b/examples/imagenet/resnet152.py
@@ -1,64 +1,67 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import numpy as np
-
-import math
 import chainer
 import chainer.functions as F
 import chainer.links as L
+import math
 
 
 class BottleNeckA(chainer.Chain):
+
     def __init__(self, in_size, ch, out_size, stride=2):
         w = math.sqrt(2)
         super(BottleNeckA, self).__init__(
+            bn1=L.BatchNormalization(in_size),
             conv1=L.Convolution2D(in_size, ch, 1, stride, 0, w, nobias=True),
-            bn1=L.BatchNormalization(ch),
-            conv2=L.Convolution2D(ch, ch, 3, 1, 1, w, nobias=True),
             bn2=L.BatchNormalization(ch),
+            conv2=L.Convolution2D(ch, ch, 3, 1, 1, w, nobias=True),
+            bn3=L.BatchNormalization(ch),
             conv3=L.Convolution2D(ch, out_size, 1, 1, 0, w, nobias=True),
-            bn3=L.BatchNormalization(out_size),
 
-            conv4=L.Convolution2D(in_size, out_size, 1, stride, 0, w, nobias=True),
-            bn4=L.BatchNormalization(out_size),
+            bn4=L.BatchNormalization(in_size),
+            conv4=L.Convolution2D(in_size, out_size, 1, stride, 0, w,
+                                  nobias=True),
         )
 
     def __call__(self, x, train):
-        h1 = F.relu(self.bn1(self.conv1(x), test=not train))
-        h1 = F.relu(self.bn2(self.conv2(h1), test=not train))
-        h1 = self.bn3(self.conv3(h1), test=not train)
-        h2 = self.bn4(self.conv4(x), test=not train)
+        h1 = self.conv1(F.relu(self.bn1(x, test=not train)))
+        h1 = self.conv2(F.relu(self.bn2(h1, test=not train)))
+        h1 = self.conv3(F.relu(self.bn3(h1, test=not train)))
 
-        return F.relu(h1 + h2)
+        h2 = self.conv4(F.relu(self.bn4(x, test=not train)))
+
+        return h1 + h2
 
 
 class BottleNeckB(chainer.Chain):
+
     def __init__(self, in_size, ch):
         w = math.sqrt(2)
         super(BottleNeckB, self).__init__(
+            bn1=L.BatchNormalization(in_size),
             conv1=L.Convolution2D(in_size, ch, 1, 1, 0, w, nobias=True),
-            bn1=L.BatchNormalization(ch),
-            conv2=L.Convolution2D(ch, ch, 3, 1, 1, w, nobias=True),
             bn2=L.BatchNormalization(ch),
+            conv2=L.Convolution2D(ch, ch, 3, 1, 1, w, nobias=True),
+            bn3=L.BatchNormalization(ch),
             conv3=L.Convolution2D(ch, in_size, 1, 1, 0, w, nobias=True),
-            bn3=L.BatchNormalization(in_size),
         )
 
     def __call__(self, x, train):
-        h = F.relu(self.bn1(self.conv1(x), test=not train))
-        h = F.relu(self.bn2(self.conv2(h), test=not train))
-        h = self.bn3(self.conv3(h), test=not train)
+        h = self.conv1(F.relu(self.bn1(x, test=not train)))
+        h = self.conv2(F.relu(self.bn2(h, test=not train)))
+        h = self.conv3(F.relu(self.bn3(h, test=not train)))
 
-        return F.relu(h + x)
+        return h + x
 
 
 class Block(chainer.Chain):
+
     def __init__(self, layer, in_size, ch, out_size, stride=2):
         super(Block, self).__init__()
         links = [('a', BottleNeckA(in_size, ch, out_size, stride))]
-        for i in range(layer-1):
-            links += [('b{}'.format(i+1), BottleNeckB(out_size, ch))]
+        for i in range(layer - 1):
+            links += [('b{}'.format(i + 1), BottleNeckB(out_size, ch))]
 
         for l in links:
             self.add_link(*l)
@@ -106,35 +109,9 @@ class ResNet(chainer.Chain):
         return loss
 
 
-class Block_recomp(Block):
-
-    def __call__(self, x, train):
-        x.set_end_of_sub_graph()
-        for name, _ in sorted(self.forward):
-            f = getattr(self, name)
-            x = f(x, train)
-            x.set_end_of_sub_graph()
-
-        return x
-
-
 class ResNet_recomp(ResNet):
 
     insize = 224
-
-    def __init__(self):
-        w = math.sqrt(2)
-        chainer.Chain.__init__(
-            self,
-            conv1=L.Convolution2D(3, 64, 7, 2, 3, w, nobias=True),
-            bn1=L.BatchNormalization(64),
-            res2=Block_recomp(3, 64, 64, 256, 1),
-            res3=Block_recomp(8, 256, 128, 512),
-            res4=Block_recomp(36, 512, 256, 1024),
-            res5=Block_recomp(3, 1024, 512, 2048),
-            fc=L.Linear(2048, 1000),
-        )
-        self.train = True
 
     def __call__(self, x, t):
         with chainer.use_recompute("RELU", "BN"):

--- a/examples/imagenet/resnet152.py
+++ b/examples/imagenet/resnet152.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import math
+import chainer
+import chainer.functions as F
+import chainer.links as L
+
+
+class BottleNeckA(chainer.Chain):
+    def __init__(self, in_size, ch, out_size, stride=2):
+        w = math.sqrt(2)
+        super(BottleNeckA, self).__init__(
+            conv1=L.Convolution2D(in_size, ch, 1, stride, 0, w, nobias=True),
+            bn1=L.BatchNormalization(ch),
+            conv2=L.Convolution2D(ch, ch, 3, 1, 1, w, nobias=True),
+            bn2=L.BatchNormalization(ch),
+            conv3=L.Convolution2D(ch, out_size, 1, 1, 0, w, nobias=True),
+            bn3=L.BatchNormalization(out_size),
+
+            conv4=L.Convolution2D(in_size, out_size, 1, stride, 0, w, nobias=True),
+            bn4=L.BatchNormalization(out_size),
+        )
+
+    def __call__(self, x, train):
+        h1 = F.relu(self.bn1(self.conv1(x), test=not train))
+        h1 = F.relu(self.bn2(self.conv2(h1), test=not train))
+        h1 = self.bn3(self.conv3(h1), test=not train)
+        h2 = self.bn4(self.conv4(x), test=not train)
+
+        return F.relu(h1 + h2)
+
+
+class BottleNeckB(chainer.Chain):
+    def __init__(self, in_size, ch):
+        w = math.sqrt(2)
+        super(BottleNeckB, self).__init__(
+            conv1=L.Convolution2D(in_size, ch, 1, 1, 0, w, nobias=True),
+            bn1=L.BatchNormalization(ch),
+            conv2=L.Convolution2D(ch, ch, 3, 1, 1, w, nobias=True),
+            bn2=L.BatchNormalization(ch),
+            conv3=L.Convolution2D(ch, in_size, 1, 1, 0, w, nobias=True),
+            bn3=L.BatchNormalization(in_size),
+        )
+
+    def __call__(self, x, train):
+        h = F.relu(self.bn1(self.conv1(x), test=not train))
+        h = F.relu(self.bn2(self.conv2(h), test=not train))
+        h = self.bn3(self.conv3(h), test=not train)
+
+        return F.relu(h + x)
+
+
+class Block(chainer.Chain):
+    def __init__(self, layer, in_size, ch, out_size, stride=2):
+        super(Block, self).__init__()
+        links = [('a', BottleNeckA(in_size, ch, out_size, stride))]
+        for i in range(layer-1):
+            links += [('b{}'.format(i+1), BottleNeckB(out_size, ch))]
+
+        for l in links:
+            self.add_link(*l)
+        self.forward = links
+
+    def __call__(self, x, train):
+        for name, _ in sorted(self.forward):
+            f = getattr(self, name)
+            x = f(x, train)
+
+        return x
+
+
+class ResNet(chainer.Chain):
+
+    insize = 224
+
+    def __init__(self):
+        w = math.sqrt(2)
+        super(ResNet, self).__init__(
+            conv1=L.Convolution2D(3, 64, 7, 2, 3, w, nobias=True),
+            bn1=L.BatchNormalization(64),
+            res2=Block(3, 64, 64, 256, 1),
+            res3=Block(8, 256, 128, 512),
+            res4=Block(36, 512, 256, 1024),
+            res5=Block(3, 1024, 512, 2048),
+            fc=L.Linear(2048, 1000),
+        )
+        self.train = True
+
+    def __call__(self, x, t):
+        h = self.bn1(self.conv1(x), test=not self.train)
+        h = F.max_pooling_2d(F.relu(h), 3, stride=2)
+        h = self.res2(h, self.train)
+        h = self.res3(h, self.train)
+        h = self.res4(h, self.train)
+        h = self.res5(h, self.train)
+        h = F.average_pooling_2d(h, 7, stride=1)
+        h = self.fc(h)
+
+        loss = F.softmax_cross_entropy(h, t)
+        pred = F.softmax(h)
+        accuracy = F.accuracy(pred, t)
+        chainer.report({'loss': loss, 'accuracy': accuracy}, self)
+        return loss
+
+
+class Block_recomp(Block):
+
+    def __call__(self, x, train):
+        x.set_end_of_sub_graph()
+        for name, _ in sorted(self.forward):
+            f = getattr(self, name)
+            x = f(x, train)
+            x.set_end_of_sub_graph()
+
+        return x
+
+
+class ResNet_recomp(ResNet):
+
+    insize = 224
+
+    def __init__(self):
+        w = math.sqrt(2)
+        chainer.Chain.__init__(
+            self,
+            conv1=L.Convolution2D(3, 64, 7, 2, 3, w, nobias=True),
+            bn1=L.BatchNormalization(64),
+            res2=Block_recomp(3, 64, 64, 256, 1),
+            res3=Block_recomp(8, 256, 128, 512),
+            res4=Block_recomp(36, 512, 256, 1024),
+            res5=Block_recomp(3, 1024, 512, 2048),
+            fc=L.Linear(2048, 1000),
+        )
+        self.train = True
+
+    def __call__(self, x, t):
+        with chainer.use_recompute("RELU", "BN"):
+            return ResNet.__call__(self, x, t)

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -22,6 +22,7 @@ import alex
 import googlenet
 import googlenetbn
 import nin
+import resnet152
 
 
 class PreprocessedDataset(chainer.dataset.DatasetMixin):
@@ -82,7 +83,9 @@ def main():
         'googlenet': googlenet.GoogLeNet,
         'googlenetbn': googlenetbn.GoogLeNetBN,
         'googlenetbn_fp16': googlenetbn.GoogLeNetBNFp16,
-        'nin': nin.NIN
+        'nin': nin.NIN,
+        'resnet152': resnet152.ResNet,
+        'resnet152_recomp': resnet152.ResNet_recomp,
     }
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
This PR is a split from #2027 and focusing solely on re-compute features in order to reduce memory usage.

With this branch, you can specify layer types whose outputs will be forgotten during forward propagation phase and recomputed during backward propagation phase, by using **chainer.use_recompute()** as below, 

    with chainer.use_recompute("RELU", "BN"):
        loss = model(x, t)

Now, ReLU and BatchNormalization layers are supported by this branch, and "RELU" stands for ReLU, "BN" stands for BatchNormalization.

You also need to tell chainer runtime when and where are safe and good to do re-compute during backward propagation using **set_end_of_sub_graph()** method.  Please see [a example of resnet152](https://github.com/anaruse/chainer/blob/re-compute/examples/imagenet/resnet152.py) for the usage.