### PR TITLE
Implement flip and rot90

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -179,9 +179,9 @@ from cupy.manipulation.split import vsplit  # NOQA
 from cupy.manipulation.tiling import repeat  # NOQA
 from cupy.manipulation.tiling import tile  # NOQA
 
+from cupy.manipulation.rearrange import flip  # NOQA
 from cupy.manipulation.rearrange import fliplr  # NOQA
 from cupy.manipulation.rearrange import flipud  # NOQA
-from cupy.manipulation.rearrange import flip  # NOQA
 from cupy.manipulation.rearrange import roll  # NOQA
 from cupy.manipulation.rearrange import rot90  # NOQA
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -181,7 +181,9 @@ from cupy.manipulation.tiling import tile  # NOQA
 
 from cupy.manipulation.rearrange import fliplr  # NOQA
 from cupy.manipulation.rearrange import flipud  # NOQA
+from cupy.manipulation.rearrange import flip  # NOQA
 from cupy.manipulation.rearrange import roll  # NOQA
+from cupy.manipulation.rearrange import rot90  # NOQA
 
 # -----------------------------------------------------------------------------
 # Binary operations

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -22,10 +22,7 @@ def flip(a, axis):
     if not -a_ndim <= axis < a_ndim:
         raise ValueError('axis must be >= %d and < %d' % (-a_ndim, a_ndim))
 
-    indexer = [slice(None)] * a_ndim
-    indexer[axis] = slice(None, None, -1)
-
-    return a[tuple(indexer)]
+    return _flip(a, axis)
 
 
 def fliplr(a):
@@ -150,12 +147,20 @@ def rot90(a, k=1, axes=(0, 1)):
     if k == 0:
         return a[:]
     if k == 2:
-        return flip(flip(a, axes[0]), axes[1])
+        return _flip(_flip(a, axes[0]), axes[1])
 
-    axes_t = list(range(0, a.ndim))
+    axes_t = list(range(0, a_ndim))
     axes_t[axes[0]], axes_t[axes[1]] = axes_t[axes[1]], axes_t[axes[0]]
 
     if k == 1:
-        return cupy.transpose(flip(a, axes[1]), axes_t)
+        return cupy.transpose(_flip(a, axes[1]), axes_t)
     else:
-        return flip(cupy.transpose(a, axes_t), axes[1])
+        return _flip(cupy.transpose(a, axes_t), axes[1])
+
+
+def _flip(a, axis):
+    # This function flips array without checking args.
+    indexer = [slice(None)] * a.ndim
+    indexer[axis] = slice(None, None, -1)
+
+    return a[tuple(indexer)]

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -4,7 +4,7 @@ import cupy
 def flip(a, axis):
     """Reverse the order of elements in an array along the given axis.
 
-    Note that ``flip`` function has been introduced since NumPy v1.12. 
+    Note that ``flip`` function has been introduced since NumPy v1.12.
     The contents of this document is the same as the original one.
 
     Args:
@@ -122,7 +122,7 @@ def roll(a, shift, axis=None):
 def rot90(a, k=1, axes=(0, 1)):
     """Rotate an array by 90 degrees in the plane specified by axes.
 
-    Note that ``axes`` argument has been introduced since NumPy v1.12. 
+    Note that ``axes`` argument has been introduced since NumPy v1.12.
     The contents of this document is the same as the original one.
 
     Args:

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -4,6 +4,9 @@ import cupy
 def flip(a, axis):
     """Reverse the order of elements in an array along the given axis.
 
+    This function was introduced since NumPy 1.12. This document is altered
+    from the original one.
+
     Args:
         a (~cupy.ndarray): Input array.
         axis (int): Axis in array, which entries are reversed.
@@ -119,6 +122,9 @@ def roll(a, shift, axis=None):
 def rot90(a, k=1, axes=(0, 1)):
     """Rotate an array by 90 degrees in the plane specified by axes.
 
+    ``axes`` argument was introduced since NumPy 1.12. This document is
+    altered from the original one.
+
     Args:
         a (~cupy.ndarray): Array of two or more dimensions.
         k (int): Number of times the array is rotated by 90 degrees.
@@ -129,6 +135,7 @@ def rot90(a, k=1, axes=(0, 1)):
         ~cupy.ndarray: Output array.
 
     .. seealso:: :func:`numpy.rot90`
+
     """
     a_ndim = a.ndim
     if a_ndim < 2:

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -4,8 +4,8 @@ import cupy
 def flip(a, axis):
     """Reverse the order of elements in an array along the given axis.
 
-    This function was introduced since NumPy 1.12. This document is altered
-    from the original one.
+    Note that ``flip`` function has been introduced since NumPy v1.12. 
+    The contents of this document is the same as the original one.
 
     Args:
         a (~cupy.ndarray): Input array.
@@ -122,8 +122,8 @@ def roll(a, shift, axis=None):
 def rot90(a, k=1, axes=(0, 1)):
     """Rotate an array by 90 degrees in the plane specified by axes.
 
-    ``axes`` argument was introduced since NumPy 1.12. This document is
-    altered from the original one.
+    Note that ``axes`` argument has been introduced since NumPy v1.12. 
+    The contents of this document is the same as the original one.
 
     Args:
         a (~cupy.ndarray): Array of two or more dimensions.

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -1,6 +1,33 @@
 import cupy
 
 
+def flip(a, axis):
+    """Reverse the order of elements in an array along the given axis.
+
+    Args:
+        a (~cupy.ndarray): Input array.
+        axis (int): Axis in array, which entries are reversed.
+
+    Returns:
+        ~cupy.ndarray: Output array.
+
+    .. seealso:: :func:`numpy.flip`
+
+    """
+    a_ndim = a.ndim
+    if a_ndim < 1:
+        raise ValueError('Input must be >= 1-d')
+
+    axis = int(axis)
+    if not -a_ndim <= axis < a_ndim:
+        raise ValueError('axis must be >= %d and < %d' % (-a_ndim, a_ndim))
+
+    indexer = [slice(None)] * a_ndim
+    indexer[axis] = slice(None, None, -1)
+
+    return a[tuple(indexer)]
+
+
 def fliplr(a):
     """Flip array in the left/right direction.
 
@@ -39,33 +66,6 @@ def flipud(a):
     if a.ndim < 1:
         raise ValueError('Input must be >= 1-d')
     return cupy.take(a, cupy.arange(a.shape[0] - 1, -1, -1), axis=0)
-
-
-def flip(a, axis):
-    """Reverse the order of elements in an array along the given axis.
-
-    Args:
-        a (~cupy.ndarray): Input array.
-        axis (int): Axis in array, which entries are reversed.
-
-    Returns:
-        ~cupy.ndarray: Output array.
-
-    .. seealso:: :func:`numpy.flip`
-
-    """
-    a_ndim = a.ndim
-    if a_ndim < 1:
-        raise ValueError('Input must be >= 1-d')
-
-    axis = int(axis)
-    if not -a_ndim <= axis < a_ndim:
-        raise ValueError('axis must be >= %d and < %d' % (-a_ndim, a_ndim))
-
-    indexer = [slice(None)] * a_ndim
-    indexer[axis] = slice(None, None, -1)
-
-    return a[tuple(indexer)]
 
 
 def roll(a, shift, axis=None):

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -119,7 +119,7 @@ def roll(a, shift, axis=None):
         return res
 
 
-def rot90(a, k=1, axes=(0,1)):
+def rot90(a, k=1, axes=(0, 1)):
     """Rotate an array by 90 degrees in the plane specified by axes.
 
     Args:

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -142,7 +142,7 @@ def rot90(a, k=1, axes=(0,1)):
         raise ValueError('len(axes) must be 2')
     if axes[0] == axes[1] or abs(axes[0] - axes[1]) == a_ndim:
         raise ValueError('axes must be different')
-    if not (-a_ndim <= axes[0] < a_ndim or -a_ndim <= axes[1] < a_ndim):
+    if not (-a_ndim <= axes[0] < a_ndim and -a_ndim <= axes[1] < a_ndim):
         raise ValueError('axes must be >= %d and < %d' % (-a_ndim, a_ndim))
 
     k = k % 4

--- a/docs/source/cupy-reference/manipulation.rst
+++ b/docs/source/cupy-reference/manipulation.rst
@@ -72,6 +72,8 @@ Repeating part of arrays along axis
 Rearranging elements
 ====================
 
+.. autofunction:: cupy.flip
 .. autofunction:: cupy.fliplr
 .. autofunction:: cupy.flipud
 .. autofunction:: cupy.roll
+.. autofunction:: cupy.rot90

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -136,12 +136,6 @@ class TestFlip(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_flip_3(self, xp, dtype):
-        x = testing.shaped_arange((3, 4, 2), xp, dtype)
-        return xp.flip(x, 1)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
     def test_flip_with_negative_axis(self, xp, dtype):
         x = testing.shaped_arange((3, 4, 2), xp, dtype)
         return xp.flip(x, -1)
@@ -155,8 +149,14 @@ class TestFlip(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_flip_invalid_axis(self, xp, dtype):
-        x = testing.shaped_arange((3,), xp, dtype)
-        return xp.flip(x, 1)
+        x = testing.shaped_arange((3, 4), xp, dtype)
+        return xp.flip(x, 2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_flip_invalid_negative_axis(self, xp, dtype):
+        x = testing.shaped_arange((3, 4), xp, dtype)
+        return xp.flip(x, -3)
 
 
 @testing.gpu

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -118,6 +118,7 @@ class TestFlipud(unittest.TestCase):
 
 
 @testing.gpu
+@testing.with_requires('numpy>=1.12')
 class TestFlip(unittest.TestCase):
 
     _multiprocess_can_split_ = True
@@ -182,12 +183,14 @@ class TestRot90(unittest.TestCase):
         x = testing.shaped_arange((3, 4, 2), xp, dtype)
         return xp.rot90(x, -1)
 
+    @testing.with_requires('numpy>=1.12')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_rot90_with_axes(self, xp, dtype):
         x = testing.shaped_arange((3, 4, 2), xp, dtype)
         return xp.rot90(x, 1, axes=(1, 2))
 
+    @testing.with_requires('numpy>=1.12')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_rot90_with_negative_axes(self, xp, dtype):
@@ -200,18 +203,21 @@ class TestRot90(unittest.TestCase):
         x = testing.shaped_arange((3,), xp, dtype)
         return xp.rot90(x)
 
+    @testing.with_requires('numpy>=1.12')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_rot90_too_much_axes(self, xp, dtype):
         x = testing.shaped_arange((3, 4, 2), xp, dtype)
         return xp.rot90(x, 1, axes=(0, 1, 2))
 
+    @testing.with_requires('numpy>=1.12')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_rot90_invalid_axes(self, xp, dtype):
         x = testing.shaped_arange((3, 4, 2), xp, dtype)
         return xp.rot90(x, 1, axes=(1, 3))
 
+    @testing.with_requires('numpy>=1.12')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_rot90_invalid_negative_axes(self, xp, dtype):

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -115,3 +115,105 @@ class TestFlipud(unittest.TestCase):
     def test_flipud_insufficient_ndim(self, xp, dtype):
         x = testing.shaped_arange((), xp, dtype)
         return xp.flipud(x)
+
+
+@testing.gpu
+class TestFlip(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_flip_1(self, xp, dtype):
+        x = testing.shaped_arange((3,), xp, dtype)
+        return xp.flip(x, 0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_flip_2(self, xp, dtype):
+        x = testing.shaped_arange((3, 4), xp, dtype)
+        return xp.flip(x, 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_flip_3(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.flip(x, 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_flip_with_negative_axis(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.flip(x, -1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_flip_insufficient_ndim(self, xp, dtype):
+        x = testing.shaped_arange((), xp, dtype)
+        return xp.flip(x, 0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_flip_invalid_axis(self, xp, dtype):
+        x = testing.shaped_arange((3,), xp, dtype)
+        return xp.flip(x, 1)
+
+
+@testing.gpu
+class TestRot90(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_rot90_none(self, xp, dtype):
+        x = testing.shaped_arange((3, 4), xp, dtype)
+        return xp.rot90(x, 0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_rot90_twice(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.rot90(x, 2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_rot90_negative(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.rot90(x, -1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_rot90_with_axes(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.rot90(x, 1, axes=(1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_rot90_with_negative_axes(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.rot90(x, 1, axes=(1, -1))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_rot90_insufficient_ndim(self, xp, dtype):
+        x = testing.shaped_arange((3,), xp, dtype)
+        return xp.rot90(x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_rot90_too_much_axes(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.rot90(x, 1, axes=(0, 1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_rot90_invalid_axes(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.rot90(x, 1, axes=(1, 3))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_rot90_invalid_negative_axes(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.rot90(x, 1, axes=(1, -2))


### PR DESCRIPTION
This PR implements cupy.flip and cupy.rot90 functions. Since numpy.flip is new feature of NumPy v1.12, the test code expect to run with NumPy v1.12 or later.