### PR TITLE
Enable deterministic mode on cuDNN v3

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -10,7 +10,7 @@ if cuda.cudnn_enabled:
     libcudnn = cuda.cudnn.cudnn
     _cudnn_version = libcudnn.getVersion()
     _fwd_pref = libcudnn.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT
-    if _cudnn_version >= 4000:
+    if _cudnn_version >= 3000:
         _bwd_filter_pref = \
             libcudnn.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT
         _bwd_data_pref = \
@@ -183,7 +183,7 @@ class Convolution2DFunction(function.Function):
             zero = numpy.array(0, dtype=oz_dtype).ctypes
             gx = cuda.cupy.empty_like(x)
 
-            if _cudnn_version >= 4000:
+            if _cudnn_version >= 3000:
                 workspace_size = cuda.get_max_workspace_size()
                 workspace = cuda.cupy.empty((workspace_size,), dtype='b')
 
@@ -217,7 +217,7 @@ class Convolution2DFunction(function.Function):
             else:
                 if self.deterministic:
                     raise ValueError("'deterministic' option not available "
-                                     "for cuDNN versions < v4")
+                                     "for cuDNN versions < v3")
                 libcudnn.convolutionBackwardFilter_v2(
                     handle, one.data, x_desc.value, x.data.ptr,
                     gy_desc.value, gy.data.ptr, self.conv_desc.value,
@@ -287,7 +287,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
             non-deterministic when it uses cuDNN.
             If this option is ``True``, then it forces cuDNN to use
             a deterministic algorithm. This option is only available for
-            cuDNN version >= v4.
+            cuDNN version >= v3.
 
 
     Returns:

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -11,7 +11,7 @@ if cuda.cudnn_enabled:
     libcudnn = cuda.cudnn.cudnn
     _cudnn_version = libcudnn.getVersion()
     _fwd_pref = libcudnn.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT
-    if _cudnn_version >= 4000:
+    if _cudnn_version >= 3000:
         _bwd_filter_pref = \
             libcudnn.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT
         _bwd_data_pref = \
@@ -131,7 +131,7 @@ class Deconvolution2DFunction(function.Function):
             one = numpy.array(1, dtype=oz_dtype).ctypes
             zero = numpy.array(0, dtype=oz_dtype).ctypes
 
-            if _cudnn_version >= 4000:
+            if _cudnn_version >= 3000:
                 workspace_size = cuda.get_max_workspace_size()
                 workspace = cuda.cupy.empty((workspace_size,), dtype='b')
                 if not self.deterministic:
@@ -234,7 +234,7 @@ class Deconvolution2DFunction(function.Function):
                     zero.data, self.bias_desc.value, gb.data.ptr)
             gW = cuda.cupy.empty_like(W)
             # filter backward
-            if _cudnn_version >= 4000:
+            if _cudnn_version >= 3000:
                 if not self.deterministic:
                     algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
                         handle, gy_desc.value, gx_desc.value,
@@ -251,7 +251,7 @@ class Deconvolution2DFunction(function.Function):
             else:
                 if self.deterministic:
                     raise ValueError("'deterministic' option not available "
-                                     "for cuDNN versions < v4")
+                                     "for cuDNN versions < v3")
                 libcudnn.convolutionBackwardFilter_v2(
                     handle, one.data, gy_desc.value, gy.data.ptr,
                     gx_desc.value, x.data.ptr, self.conv_desc.value,
@@ -304,7 +304,7 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
             non-deterministic when it uses cuDNN.
             If this option is ``True``, then it forces cuDNN to use
             a deterministic algorithm. This option is only available for
-            cuDNN version >= v4.
+            cuDNN version >= v3.
 
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -181,7 +181,7 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
     def test_call_cudnn_backward(self):
         y = self.forward()
         y.grad = self.gy
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
+        if cuda.cudnn.cudnn.getVersion() >= 3000:
             name = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
         else:
             name = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
@@ -224,12 +224,12 @@ class TestConvolution2DFunctionDeterministic(unittest.TestCase):
         with mock.patch(
                 'chainer.functions.connection.convolution_2d.libcudnn',
                 autospec=True) as mlibcudnn:
-            if self.cudnn_version < 4000:
+            if self.cudnn_version < 3000:
                 with self.assertRaises(ValueError):
                     x, W, b, y = self._run()
                 return
 
-            # cuDNN version >= v4 supports `deterministic` option
+            # cuDNN version >= v3 supports `deterministic` option
             x, W, b, y = self._run()
 
             # in Convolution2DFunction.backward_gpu()
@@ -243,7 +243,7 @@ class TestConvolution2DFunctionDeterministic(unittest.TestCase):
                 mlibcudnn.convolutionBackwardData_v3.call_count, 1)
 
     def test_deterministic(self):
-        if self.cudnn_version < 4000:
+        if self.cudnn_version < 3000:
             # `deterministic` option is not supported
             return
 

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -175,7 +175,7 @@ class TestDeconvolution2DCudnnCall(unittest.TestCase):
             x, W, None, stride=1, pad=1, use_cudnn=self.use_cudnn)
 
     def test_call_cudnn_forward(self):
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
+        if cuda.cudnn.cudnn.getVersion() >= 3000:
             name = 'cupy.cudnn.cudnn.convolutionBackwardData_v3'
         else:
             name = 'cupy.cudnn.cudnn.convolutionBackwardData_v2'
@@ -225,12 +225,12 @@ class TestDeconvolution2DFunctionDeterministic(unittest.TestCase):
         with mock.patch(
                 'chainer.functions.connection.deconvolution_2d.libcudnn'
         ) as mlibcudnn:
-            if cuda.cudnn.cudnn.getVersion() < 4000:
+            if cuda.cudnn.cudnn.getVersion() < 3000:
                 with self.assertRaises(ValueError):
                     x, W, b, y = self._run()
                 return
 
-            # cuDNN version >= v4 supports `deterministic` option
+            # cuDNN version >= v3 supports `deterministic` option
             x, W, b, y = self._run()
 
             # in Deconvolution2DFunction.forward_gpu()
@@ -242,7 +242,7 @@ class TestDeconvolution2DFunctionDeterministic(unittest.TestCase):
                 mlibcudnn.getConvolutionBackwardFilterAlgorithm.called)
 
     def test_deterministic(self):
-        if self.cudnn_version < 4000:
+        if self.cudnn_version < 3000:
             # `deterministic` option is not supported
             return
 


### PR DESCRIPTION
Enable deterministic mode on cuDNN v3.

This PR also fixes test cases around https://github.com/pfnet/chainer/blob/db7aa37fa2e0fe95a3a3f6f06b2cefcb6441fcb5/tests/chainer_tests/links_tests/connection_tests/test_mlp_convolution_2d.py#L85.