### PR TITLE
Add transpose method to chainer.Variable

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -462,6 +462,18 @@ Actual: {0}'''.format(type(data))
             shape = shape[0]
         return chainer.functions.reshape(self, shape)
 
+    def transpose(self, *axes):
+        """Permute the dimensions of an input variable without copy.
+
+        .. seealso::
+           :func:`chainer.functions.transpose` for full documentation.
+
+        """
+        if len(axes) == 1 and (isinstance(axes[0], (tuple, list)) or
+                               axes[0] is None):
+            axes = axes[0]
+        return chainer.functions.transpose(self, axes)
+
     def unchain_backward(self):
         """Deletes references between variables and functions backward.
 

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -800,4 +800,43 @@ class TestReshape(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x))
 
 
+@testing.parameterize(*testing.product({
+    'in_shape': [(4, 3, 2)],
+    'axes': [(-1, 0, 1), None, [-1, 0, 1]],
+    'dtype': [np.float16, np.float32, np.float32],
+}))
+class TestTranspose(unittest.TestCase):
+
+    def setUp(self):
+        self.x = np.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+
+    def check_forward(self, x_data):
+        axes = self.axes
+        x = chainer.Variable(x_data)
+        y = x.transpose(axes)
+        self.assertEqual(y.data.dtype, self.dtype)
+        self.assertTrue((self.x.transpose(axes) == cuda.to_cpu(y.data)).all())
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x_data):
+        x = chainer.Variable(x_data)
+        y = x.transpose(self.axes)
+        y.grad = y.data
+        y.backward()
+        testing.assert_allclose(x.data, x.grad, atol=0, rtol=0)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x))
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
In a similar intent as #2236, this PR adds a function to `chainer.Variable` for convenience.