### PR TITLE
follow autopep8-1.3.0

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -78,6 +78,7 @@ def get_function_hooks():
         thread_local.function_hooks = collections.OrderedDict()
     return thread_local.function_hooks
 
+
 _debug = False
 
 
@@ -126,6 +127,7 @@ class DebugMode(object):
 
     def __exit__(self, *_):
         set_debug(self._old)
+
 
 basic_math.install_variable_arithmetics()
 array.get_item.install_variable_get_item()

--- a/chainer/utils/conv_nd_kernel.py
+++ b/chainer/utils/conv_nd_kernel.py
@@ -165,6 +165,7 @@ class Im2colNDKernel(object):
     def generate(ndim):
         return _im2col_nd_kernel._generate(ndim)
 
+
 _im2col_nd_kernel = Im2colNDKernel()
 
 
@@ -288,5 +289,6 @@ class Col2imNDKernel(object):
     @chainer.cuda.memoize()
     def generate(ndim):
         return _col2im_nd_kernel._generate(ndim)
+
 
 _col2im_nd_kernel = Col2imNDKernel()

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -486,4 +486,5 @@ def expect(*bool_exprs):
         assert isinstance(expr, Testable)
         expr.expect()
 
+
 prod = Variable(numpy.prod, 'prod')

--- a/cupy/sorting/count.py
+++ b/cupy/sorting/count.py
@@ -14,6 +14,7 @@ def count_nonzero(x):
 
     return int(_count_nonzero(x))
 
+
 _count_nonzero = core.create_reduction_func(
     'cupy_count_nonzero',
     ('?->l', 'B->l', 'h->l', 'H->l', 'i->l', 'I->l', 'l->l', 'L->l',

--- a/cupy/sorting/search.py
+++ b/cupy/sorting/search.py
@@ -118,6 +118,7 @@ def where(condition, x=None, y=None):
 
     return _where_ufunc(condition.astype('?'), x, y)
 
+
 _where_ufunc = core.create_ufunc(
     'cupy_where',
     ('???->?', '?bb->b', '?BB->B', '?hh->h', '?HH->H', '?ii->i', '?II->I',

--- a/examples/cifar/train_cifar.py
+++ b/examples/cifar/train_cifar.py
@@ -108,5 +108,6 @@ def main():
     # Run the training
     trainer.run()
 
+
 if __name__ == '__main__':
     main()

--- a/examples/dcgan/train_dcgan.py
+++ b/examples/dcgan/train_dcgan.py
@@ -111,5 +111,6 @@ def main():
     # Run the training
     trainer.run()
 
+
 if __name__ == '__main__':
     main()

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -121,5 +121,6 @@ def main():
     # Run the training
     trainer.run()
 
+
 if __name__ == '__main__':
     main()

--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -174,6 +174,7 @@ def evaluate(model, test_trees):
     print(' Root accuracy: {0:.2f} %% ({1:,d}/{2:,d})'.format(
         acc_root, result['correct_root'], result['total_root']))
 
+
 vocab = {}
 if args.test:
     max_size = 10

--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -139,6 +139,7 @@ def save_images(x, filename):
         ai.imshow(xi.reshape(28, 28))
     fig.savefig(filename)
 
+
 train_ind = [1, 3, 5, 10, 2, 0, 13, 15, 17]
 x = chainer.Variable(np.asarray(x_train[train_ind]), volatile='on')
 x1 = model(x)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -108,4 +108,5 @@ class TestLogSoftmaxCudnnCall(unittest.TestCase):
             y.backward()
             self.assertEqual(func.called, self.expect)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -90,4 +90,5 @@ class TestContrastive(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x0),
                             cuda.to_gpu(self.t))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -82,4 +82,5 @@ class TestHinge(unittest.TestCase):
     def test_backward_gpu_l2(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t), 'L2')
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_bias.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_bias.py
@@ -66,4 +66,5 @@ class TestBiasInvalidShape(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 functions.bias(x1, x2, axis)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_ceil.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_ceil.py
@@ -79,4 +79,5 @@ class TestCeil(UnaryFunctionsTestBase):
     def test_label(self):
         self.check_label(F.Ceil, 'ceil')
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_exponential_m1.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_exponential_m1.py
@@ -50,4 +50,5 @@ class Expm1FunctionTest(unittest.TestCase):
     def test_expm1(self):
         self.assertEqual(F.Expm1().label, 'expm1')
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_floor.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_floor.py
@@ -79,4 +79,5 @@ class TestFloor(UnaryFunctionsTestBase):
     def test_label(self):
         self.check_label(F.Floor, 'floor')
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_fmod.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_fmod.py
@@ -90,4 +90,5 @@ class TestFmod(UnaryFunctionsTestBase):
     def test_label(self):
         self.check_label(F.Fmod, 'fmod')
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_logsumexp.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_logsumexp.py
@@ -201,4 +201,5 @@ class TestLogSumExp(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.x.sum(axis=(1, -2))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -45,6 +45,7 @@ class _TestMatMul(unittest.TestCase):
             cuda.to_gpu(self.x1), cuda.to_gpu(self.x2),
             cuda.to_gpu(self.gy), atol=1e-2, rtol=1e-2)
 
+
 m = 2
 k = 5
 n = 10
@@ -129,6 +130,7 @@ class TestMatMulVectorVectorT(_TestMatMul):
         self.op = lambda x, y: F.matmul(x, y, transb=True)
         self.forward_answer = numpy.dot(
             self.x1.reshape(m, 1), self.x2.reshape(1, m))
+
 
 batch_size = 10
 
@@ -268,5 +270,6 @@ class TestBatchMatMulBroadcastedMatrix2(_TestMatMul):
         self.forward_answer = numpy.array([
             numpy.dot(self.x1[i], self.x2)
             for i in six.moves.range(batch_size)])
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
@@ -104,4 +104,5 @@ class TestMaximumInconsistentShapes(unittest.TestCase):
         with self.assertRaises(type_check.InvalidType):
             functions.maximum(x1, x2)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_minimum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minimum.py
@@ -104,4 +104,5 @@ class TestMinimumInconsistentShapes(unittest.TestCase):
         with self.assertRaises(type_check.InvalidType):
             functions.minimum(x1, x2)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_scale.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_scale.py
@@ -66,4 +66,5 @@ class TestScaleInvalidShape(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 functions.scale(x1, x2, axis)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sum.py
@@ -210,4 +210,5 @@ class TestSum(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.x.sum(axis=(1, -2))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_zoneout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_zoneout.py
@@ -76,4 +76,5 @@ class TestZoneout(unittest.TestCase):
                             cuda.to_gpu(self.x),
                             cuda.to_gpu(self.gy))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -212,4 +212,5 @@ class TestBatchNormalizationCudnnCall(unittest.TestCase):
             y.backward()
             self.assertEqual(func.called, self.expect)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
@@ -71,4 +71,5 @@ class TestUpsampling2D(unittest.TestCase):
         self.check_backward(cuda.to_gpu(
             self.pooled_y.data), cuda.to_gpu(self.gy))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -185,4 +185,5 @@ class TestMultiprocessIterator(unittest.TestCase):
         for _ in range(2):
             self.assertRaises(StopIteration, copy_it.next)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -216,4 +216,5 @@ class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
         self.link.to_gpu()
         self.check_pickling(cuda.to_gpu(self.x))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_dilated_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_dilated_convolution_2d.py
@@ -213,4 +213,5 @@ class TestDilatedConvolution2DParameterShapePlaceholder(unittest.TestCase):
         self.link.to_gpu()
         self.check_pickling(cuda.to_gpu(self.x))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
@@ -217,4 +217,5 @@ class TestZoneoutToCPUToGPU(unittest.TestCase):
         self.h.to_gpu()
         self.check_to_cpu_to_gpu(self.c, self.h)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -218,4 +218,5 @@ class TestVGG16Layers(unittest.TestCase):
         self.link.to_gpu()
         self.check_predict()
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_function_set.py
+++ b/tests/chainer_tests/test_function_set.py
@@ -334,4 +334,5 @@ class TestFunctionSet(TestFunctionSetBase):
     def test_gradients_setter_invalid_2_gpu(self):
         self._check_setter_invalid(self.fs, -1, cuda.cupy, 'gradients')
 
+
 testing.run_module(__name__, __file__)

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -10,6 +10,7 @@ class TestImportError(unittest.TestCase):
         except Exception as e:
             self.assertIsInstance(e, RuntimeError)
 
+
 # This is copied from chainer/testing/__init__.py, so should be replaced in
 # some way.
 if __name__ == '__main__':


### PR DESCRIPTION
As mentioned in #2362,
The travis-ci tests will not be passed, because autopep8 generates the diffs in the files.
The cause is the version of autopep8.
My build and  [PR build](https://travis-ci.org/pfnet/chainer/builds/207796476) use autopep8 of 1.3.0.
But the builds before use autopep8 of 1.2.4.
So, there are some updates from 1.2.4 to 1.3.0 and they generate some diff for other files.

Modification is automatically created by the command
```
$ autopep8 -r . --global-config .pep8 --in-place
```