### PR TITLE
Fix error with advanced indexing when a zero length array-like is the index

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1131,7 +1131,10 @@ cdef class ndarray:
         mask_exists = False
         for i, s in enumerate(slices):
             if isinstance(s, (list, numpy.ndarray)):
-                s = array(s)
+                dtype = None
+                if isinstance(s, list) and len(s) == 0:
+                    dtype = numpy.int32
+                s = array(s, dtype=dtype)
                 slices[i] = s
             if isinstance(s, ndarray):
                 if issubclass(s.dtype.type, numpy.integer):

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1131,10 +1131,10 @@ cdef class ndarray:
         mask_exists = False
         for i, s in enumerate(slices):
             if isinstance(s, (list, numpy.ndarray)):
-                dtype = None
-                if isinstance(s, list) and len(s) == 0:
-                    dtype = numpy.int32
-                s = array(s, dtype=dtype)
+                is_list = isinstance(s, list)
+                s = array(s)
+                if is_list and s.size == 0:
+                    s = s.astype(numpy.int32).ravel()
                 slices[i] = s
             if isinstance(s, ndarray):
                 if issubclass(s.dtype.type, numpy.integer):

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1133,8 +1133,11 @@ cdef class ndarray:
             if isinstance(s, (list, numpy.ndarray)):
                 is_list = isinstance(s, list)
                 s = array(s)
+                # handle the case when s is an empty list
                 if is_list and s.size == 0:
-                    s = s.astype(numpy.int32).ravel()
+                    s = s.astype(numpy.int32)
+                    if s.ndim > 1:
+                        s = s[0]
                 slices[i] = s
             if isinstance(s, ndarray):
                 if issubclass(s.dtype.type, numpy.integer):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -67,12 +67,18 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     # empty arrays
     {'shape': (2, 3, 4), 'indexes': []},
     {'shape': (2, 3, 4), 'indexes': numpy.array([], dtype=numpy.int32)},
-    {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.int32)},
     {'shape': (2, 3, 4), 'indexes': [[]]},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.int32)},
+    {'shape': (2, 3, 4), 'indexes': [[[]]]},
+    {'shape': (2, 3, 4), 'indexes': [[[[]]]]},
+    {'shape': (2, 3, 4, 5), 'indexes': [[[[]]]]},
+    {'shape': (2, 3, 4, 5), 'indexes': [[[[[]]]]]},
+    {'shape': (2, 3, 4), 'indexes': (slice(None), [])},
     {'shape': (2, 3, 4), 'indexes': ([], [])},
     {'shape': (2, 3, 4), 'indexes': numpy.array([], dtype=numpy.bool)},
     {'shape': (2, 3, 4),
      'indexes': (slice(None), numpy.array([], dtype=numpy.bool))},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.bool)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -64,6 +64,15 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
      'indexes': (slice(None), numpy.random.choice([False, True], (3, 4)))},
     {'shape': (2, 3, 4),
      'indexes': numpy.random.choice([False, True], (2, 3))},
+    # empty arrays
+    {'shape': (2, 3, 4), 'indexes': []},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([], dtype=numpy.int32)},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.int32)},
+    {'shape': (2, 3, 4), 'indexes': [[]]},
+    {'shape': (2, 3, 4), 'indexes': ([], [])},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([], dtype=numpy.bool)},
+    {'shape': (2, 3, 4),
+     'indexes': (slice(None), numpy.array([], dtype=numpy.bool))},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):
@@ -128,6 +137,7 @@ class TestArrayAdvancedIndexingGetitemCupyIndices(unittest.TestCase):
 @testing.parameterize(
     {'shape': (), 'indexes': ([1],)},
     {'shape': (2, 3), 'indexes': (slice(None), [1, 2], slice(None))},
+    {'shape': (2, 3), 'indexes': numpy.array([], dtype=numpy.float)},
 )
 @testing.gpu
 class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):


### PR DESCRIPTION
This resolves issue #2366.

Three bugs are fixed

+ index is `[]`
+ index is `[[]]`
+ index is a boolean array of size 0