### PR TITLE
Fix BN function channel size support

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -104,19 +104,19 @@ class BatchNormalizationFunction(function.Function):
         # into a 2-dim array with channels as second dim and m=<product
         # of all dimensions except the 2nd dimension> as the first
         # dimension.
-        self.cudnn_dim_ok = x.ndim == 2 or x.ndim == 4
+        self.cudnn_dim_ok = x.ndim == 2 or (x.ndim == 4 and head_ndim == 2)
 
         cudnn_updated_running_stats = False
         if xp is not numpy and cuda.cudnn_enabled and self.use_cudnn and \
                 self.cudnn_dim_ok and _cudnn_version >= 5000:
-            if x.ndim == 4:
+            x = cuda.cupy.ascontiguousarray(x)
+            if x.ndim == 4 and head_ndim == 2:
                 # for convolutional layer
                 self.mode = libcudnn.CUDNN_BATCHNORM_SPATIAL
             else:
                 # for linear layer
                 self.mode = libcudnn.CUDNN_BATCHNORM_PER_ACTIVATION
 
-            x = cuda.cupy.ascontiguousarray(x)
             gamma = cuda.cupy.ascontiguousarray(gamma)
             beta = cuda.cupy.ascontiguousarray(beta)
             dtype = x.dtype
@@ -273,12 +273,25 @@ def batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None,
     """Batch normalization function.
 
     It takes the input variable ``x`` and two parameter variables ``gamma`` and
-    ``beta``. The input must have the batch size and the features (or channels)
-    as the first two dimensions of its shape. The input can have more than two
-    dimensions, where the remaining dimensions are considered as spatial
-    dimensions, which are considered as a part of the batch size. That is,
+    ``beta``. The parameter variables must both have the same dimensionality,
+    which is referred to as the channel shape. This channel shape corresponds
+    to the dimensions in the input which are not averaged over. Since the
+    first dimension of the input corresponds to the batch size, the second
+    dimension of `x` will correspond to the first dimension of the channel
+    shape, the third dimension of `x` will correspond to the second channel
+    dimension (if it exists) and so on. Therefore, the dimensionality of the
+    input must be at least one plus the number of channel dimensions. The
+    total effective "batch size" will then be considered to be the product of
+    all dimensions in `x` except for the channel dimensions.
+
+    As an example, if the input is four dimensional and the parameter
+    variables are one dimensional, then it is assumed that the first
+    dimension of the input is the batch size, the second dimension is the
+    channel size, and the remaining two dimensions are considered
+    to be spatial dimensions that will be averaged over along with the
+    batch size in the batch normalization computations. That is,
     the total batch size will be considered to be the product of all
-    dimensions except the second dimension.
+    input dimensions except the second dimension.
 
     Note: If this function is called, it will not be possible to access the
     updated running mean and variance statistics, because they are members

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -22,6 +22,7 @@ def _batch_normalization(expander, gamma, beta, x, mean, var):
 
 
 @testing.parameterize(*testing.product({
+    'param_shape': [(3,), (3, 4), (3, 4, 5)],
     'ndim': [0, 1, 2, 3],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
@@ -29,27 +30,29 @@ class TestBatchNormalization(unittest.TestCase):
 
     def setUp(self):
         self.expander = (None, Ellipsis) + (None,) * self.ndim
-        self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
         self.eps = 2e-5
         self.decay = 0.9
 
-        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(self.dtype)
-        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
-
-        shape = (5, 3) + (2,) * self.ndim
+        self.gamma = numpy.random.uniform(.5, 1,
+                                          self.param_shape).astype(self.dtype)
+        self.beta = numpy.random.uniform(-1, 1,
+                                         self.param_shape).astype(self.dtype)
+        head_ndim = self.gamma.ndim + 1
+        shape = (5,) + self.param_shape + (2,) * self.ndim
         self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
 
         self.args = [self.x, self.gamma, self.beta]
+        self.aggr_axes = (0,) + tuple(six.moves.range(head_ndim, self.x.ndim))
         self.mean = self.x.mean(axis=self.aggr_axes)
         self.var = self.x.var(axis=self.aggr_axes) + self.eps
         self.train = True
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
         self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
             self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, args, use_cudnn=True):
         y = functions.batch_normalization(
@@ -97,34 +100,37 @@ class TestBatchNormalization(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
+    'param_shape': [(3,), (3, 4), (3, 4, 5)],
     'ndim': [0, 1, 2, 3],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestFixedBatchNormalization(unittest.TestCase):
 
     def setUp(self):
-        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(self.dtype)
-        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
+        self.gamma = numpy.random.uniform(.5, 1,
+                                          self.param_shape).astype(self.dtype)
+        self.beta = numpy.random.uniform(-1, 1,
+                                         self.param_shape).astype(self.dtype)
         self.expander = (None, Ellipsis) + (None,) * self.ndim
-
-        shape = (5, 3) + (2,) * self.ndim
+        shape = (5,) + self.param_shape + (2,) * self.ndim
         self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.eps = 2e-5
         self.decay = 0.0
-        self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
-
-        self.mean = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
+        head_ndim = self.gamma.ndim + 1
+        self.aggr_axes = (0,) + tuple(six.moves.range(head_ndim, self.x.ndim))
+        self.mean = numpy.random.uniform(-1, 1,
+                                         self.param_shape).astype(self.dtype)
         self.var = numpy.random.uniform(
-            0.5, 1, (3,)).astype(self.dtype)
+            0.5, 1, self.param_shape).astype(self.dtype)
         self.args = [self.x, self.gamma, self.beta, self.mean, self.var]
         self.train = False
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
         self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
             self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, args, use_cudnn=True):
         y = functions.fixed_batch_normalization(
@@ -180,18 +186,27 @@ class TestBatchNormalizationCudnnCall(unittest.TestCase):
 
     def setUp(self):
         ndim = 0
-        self.gamma = cuda.cupy.random.uniform(.5, 1, (3,)).astype(self.dtype)
-        self.beta = cuda.cupy.random.uniform(-1, 1, (3,)).astype(self.dtype)
+        param_shape = (3,)
+        self.gamma = cuda.cupy.random.uniform(.5, 1,
+                                              param_shape).astype(self.dtype)
+        self.beta = cuda.cupy.random.uniform(-1, 1,
+                                             param_shape).astype(self.dtype)
         self.eps = 2e-5
-        shape = (7, 3) + (2,) * ndim
+        shape = (7,) + param_shape + (2,) * ndim
+        print('za shape: ', shape)
         self.x = cuda.cupy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.args = [self.x, self.gamma, self.beta]
-        self.aggr_axes = (0,) + tuple(six.moves.range(2, ndim + 2))
+        head_ndim = self.gamma.ndim + 1
+        print('head_ndim: ', head_ndim)
+        self.aggr_axes = (0,) + tuple(six.moves.range(head_ndim, self.x.ndim))
+        print('self.aggr_axes: ', self.aggr_axes)
         self.mean = self.x.mean(axis=self.aggr_axes)
+        print('setUp, self.mean.shape: ', self.mean.shape)
         self.var = self.x.var(axis=self.aggr_axes) + self.eps
         self.expect = self.use_cudnn and (
             cuda.cudnn.cudnn.getVersion() >= 5000)
+        print('self.expect: ', self.expect)
 
     def forward(self):
         return functions.batch_normalization(


### PR DESCRIPTION
Fix batch normalization function to handle multi-dimensional parameters correctly and update documentation of the function to be consistent with how it is documented in the corresponding batch normalization link. Previously, the function assumed that the second dimension of the input was always the only channel dimension.