### PR TITLE
Add chainer.functions.resize_images

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -30,6 +30,7 @@ from chainer.functions.array import hstack  # NOQA
 from chainer.functions.array import pad  # NOQA
 from chainer.functions.array import permutate  # NOQA
 from chainer.functions.array import reshape  # NOQA
+from chainer.functions.array import resize_images  # NOQA
 from chainer.functions.array import rollaxis  # NOQA
 from chainer.functions.array import select_item  # NOQA
 from chainer.functions.array import separate  # NOQA
@@ -175,6 +176,8 @@ from chainer.functions.array.permutate import permutate  # NOQA
 from chainer.functions.array.permutate import Permutate  # NOQA
 from chainer.functions.array.reshape import reshape  # NOQA
 from chainer.functions.array.reshape import Reshape  # NOQA
+from chainer.functions.array.resize_images import resize_images  # NOQA
+from chainer.functions.array.resize_images import ResizeImages  # NOQA
 from chainer.functions.array.rollaxis import rollaxis  # NOQA
 from chainer.functions.array.rollaxis import Rollaxis  # NOQA
 from chainer.functions.array.select_item import select_item  # NOQA

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -124,7 +124,8 @@ def resize_images(x, output_shape):
     Args:
         x (~chainer.Variable):  Input variable of shape :math:`(n, c_I, h, w)`.
         output_shape (tuple): This is a tuple of length 2 whose values are
-            :obj:`(h_O, w_O)`.
+            :obj:`(h_O, w_O)`. Note that the order of height and width is
+            opposite of the one in OpenCV.
 
     Returns:
         ~chainer.Variable: Resized image whose shape is \

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -1,0 +1,147 @@
+import numpy
+
+from chainer import cuda
+from chainer import function
+from chainer.utils import type_check
+
+
+class ResizeImages(function.Function):
+
+    def __init__(self, output_shape):
+        self.out_H = output_shape[0]
+        self.out_W = output_shape[1]
+
+    def check_type_forward(self, in_types):
+        n_in = in_types.size()
+        type_check.expect(n_in == 1)
+
+        x_type = in_types[0]
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            x_type.ndim == 4
+        )
+
+    def forward(self, inputs):
+        x, = inputs
+        xp = cuda.get_array_module(x)
+
+        B, C, H, W = x.shape
+
+        u_1d = xp.linspace(0, W - 1, num=self.out_W)
+        v_1d = xp.linspace(0, H - 1, num=self.out_H)
+        grid = xp.meshgrid(u_1d, v_1d)
+        # u, v are of shape (out_H * out_W,)
+        u = grid[0].ravel()
+        v = grid[1].ravel()
+
+        # indices of the 2x2 pixel neighborhood surrounding the coordinates
+        u0 = xp.floor(u).astype(numpy.int32)
+        u0 = u0.clip(0, W - 2)
+        u1 = u0 + 1
+        v0 = xp.floor(v).astype(numpy.int32)
+        v0 = v0.clip(0, H - 2)
+        v1 = v0 + 1
+
+        # weights
+        w1 = (u1 - u) * (v1 - v)
+        w2 = (u - u0) * (v1 - v)
+        w3 = (u1 - u) * (v - v0)
+        w4 = (u - u0) * (v - v0)
+        w1 = w1.astype(x.dtype)
+        w2 = w2.astype(x.dtype)
+        w3 = w3.astype(x.dtype)
+        w4 = w4.astype(x.dtype)
+
+        ys = []
+        for b in range(B):
+            elem = (w1[:, None] * x[b, :, v0, u0] +
+                    w2[:, None] * x[b, :, v0, u1] +
+                    w3[:, None] * x[b, :, v1, u0] +
+                    w4[:, None] * x[b, :, v1, u1])
+            elem = elem.reshape(self.out_H, self.out_W, C)
+            elem = elem.transpose(2, 0, 1)
+            ys.append(elem)
+        y = xp.concatenate([xp.expand_dims(y, axis=0) for y in ys], axis=0)
+        return y,
+
+    def backward(self, inputs, grad_outputs):
+        x, = inputs
+        xp = cuda.get_array_module(x)
+        gy, = grad_outputs
+
+        B, C, H, W = x.shape
+
+        u_1d = xp.linspace(0, W - 1, num=self.out_W)
+        v_1d = xp.linspace(0, H - 1, num=self.out_H)
+        grid = xp.meshgrid(u_1d, v_1d)
+        # u, v are of shape (out_H * out_W,)
+        u = grid[0].ravel()
+        v = grid[1].ravel()
+
+        # indices of the 2x2 pixel neighborhood surrounding the coordinates
+        u0 = xp.floor(u).astype(numpy.int32)
+        u0 = u0.clip(0, W - 2)
+        u1 = u0 + 1
+        v0 = xp.floor(v).astype(numpy.int32)
+        v0 = v0.clip(0, H - 2)
+        v1 = v0 + 1
+
+        # weights
+        wu0 = u - u0
+        wu1 = u1 - u
+        wv0 = v - v0
+        wv1 = v1 - v
+        wu0 = wu0.astype(gy.dtype)
+        wu1 = wu1.astype(gy.dtype)
+        wv0 = wv0.astype(gy.dtype)
+        wv1 = wv1.astype(gy.dtype)
+
+        # --- gx
+        gxs = []
+        samples_arange = xp.arange(
+            self.out_H * self.out_W, dtype=numpy.int32)
+        for b in range(B):
+            dydx = xp.zeros((H, W, self.out_H * self.out_W), dtype=gy.dtype)
+            if xp is numpy:
+                scatter_add = numpy.add.at
+            else:
+                scatter_add = xp.scatter_add
+            scatter_add(dydx, (v0, u0, samples_arange), wu1 * wv1)
+            scatter_add(dydx, (v0, u1, samples_arange), wu0 * wv1)
+            scatter_add(dydx, (v1, u0, samples_arange), wu1 * wv0)
+            scatter_add(dydx, (v1, u1, samples_arange), wu0 * wv0)
+
+            gy_elem = gy[b].reshape(C, -1)
+            gy_elem = gy_elem.transpose(1, 0)
+            gx = dydx.dot(gy_elem)
+            gxs.append(gx.transpose(2, 0, 1))
+        gx = xp.concatenate([xp.expand_dims(g, axis=0) for g in gxs], axis=0)
+        return gx,
+
+
+def resize_images(x, output_shape):
+    """Resize images to the given shape.
+
+    This function resizes 2D data to :obj:`output_shape`.
+    Currently, only bilinear interpolation is supported as the sampling method.
+
+    Notatition: here is a notation for dimensionalities.
+
+    - :math:`n` is the batch size.
+    - :math:`c_I` is the number of the input channels.
+    - :math:`h` and :math:`w` are the height and width of the input image,
+      respectively.
+    - :math:`h_O` and :math:`w_O` are the height and width of the output
+      image.
+
+    Args:
+        x (~chainer.Variable):  Input variable of shape :math:`(n, c_I, h, w)`.
+        output_shape (tuple): This is a tuple of length 2 whose values are
+            :obj:`(h_O, w_O)`.
+
+    Returns:
+        ~chainer.Variable: Resized image whose shape is \
+            :math:`(n, c_I, h_O, w_O)`.
+
+    """
+    return ResizeImages(output_shape)(x)

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -52,16 +52,11 @@ class ResizeImages(function.Function):
         w3 = w3.astype(x.dtype)
         w4 = w4.astype(x.dtype)
 
-        ys = []
-        for b in range(B):
-            elem = (w1[:, None] * x[b, :, v0, u0] +
-                    w2[:, None] * x[b, :, v0, u1] +
-                    w3[:, None] * x[b, :, v1, u0] +
-                    w4[:, None] * x[b, :, v1, u1])
-            elem = elem.reshape(self.out_H, self.out_W, C)
-            elem = elem.transpose(2, 0, 1)
-            ys.append(elem)
-        y = xp.concatenate([xp.expand_dims(y, axis=0) for y in ys], axis=0)
+        y = (w1[None, None, :] * x[:, :, v0, u0] +
+             w2[None, None, :] * x[:, :, v0, u1] +
+             w3[None, None, :] * x[:, :, v1, u0] +
+             w4[None, None, :] * x[:, :, v1, u1])
+        y = y.reshape(B, C, self.out_H, self.out_W)
         return y,
 
     def backward(self, inputs, grad_outputs):

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -17,7 +17,7 @@ class ResizeImages(function.Function):
 
         x_type = in_types[0]
         type_check.expect(
-            x_type.dtype.kind == 'f',
+            x_type.dtype.char == 'f',
             x_type.ndim == 4
         )
 

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -92,21 +92,17 @@ class ResizeImages(function.Function):
         wv1 = wv1.astype(gy.dtype)
 
         # --- gx
-        samples_arange = xp.arange(
-            self.out_H * self.out_W, dtype=numpy.int32)
         if xp is numpy:
             scatter_add = numpy.add.at
         else:
             scatter_add = xp.scatter_add
 
-        dydx = xp.zeros((H, W, self.out_H * self.out_W), dtype=gy.dtype)
-        scatter_add(dydx, (v0, u0, samples_arange), wu1 * wv1)
-        scatter_add(dydx, (v0, u1, samples_arange), wu0 * wv1)
-        scatter_add(dydx, (v1, u0, samples_arange), wu1 * wv0)
-        scatter_add(dydx, (v1, u1, samples_arange), wu0 * wv0)
-        gy = gy.transpose(0, 2, 3, 1).reshape(B, self.out_H * self.out_W, C)
-        gx = dydx.dot(gy)
-        gx = gx.transpose(2, 3, 0, 1)
+        gx = xp.zeros_like(x)
+        gy = gy.reshape(B, C, -1)
+        scatter_add(gx, (slice(None), slice(None), v0, u0), gy * wu1 * wv1)
+        scatter_add(gx, (slice(None), slice(None), v0, u1), gy * wu0 * wv1)
+        scatter_add(gx, (slice(None), slice(None), v1, u0), gy * wu1 * wv0)
+        scatter_add(gx, (slice(None), slice(None), v1, u1), gy * wu0 * wv0)
         return gx,
 
 

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -155,6 +155,10 @@ reshape
 ~~~~~~~
 .. autofunction:: reshape
 
+resize_images
+~~~~~~~~~~~~~
+.. autofunction:: resize_images
+
 rollaxis
 ~~~~~~~~
 .. autofunction:: rollaxis

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -31,7 +31,7 @@ class TestResizeImagesForwardIdentity(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), output_shape=self.in_shape[2:])
 
 
-class TestResizeImagesForwardScale(unittest.TestCase):
+class TestResizeImagesForwardDownScale(unittest.TestCase):
 
     in_shape = (2, 2, 4, 4)
     output_shape = (2, 2, 2, 2)
@@ -48,6 +48,38 @@ class TestResizeImagesForwardScale(unittest.TestCase):
         self.out[:, :, 1, 0] = 2
         self.out[:, :, 0, 1] = 3
         self.out[:, :, 1, 1] = 4
+
+    def check_forward(self, x, output_shape):
+        y = functions.resize_images(x, output_shape)
+        testing.assert_allclose(y.data, self.out)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, output_shape=self.output_shape[2:])
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(
+            cuda.to_gpu(self.x), output_shape=self.output_shape[2:])
+
+
+class TestResizeImagesForwardUpScale(unittest.TestCase):
+
+    in_shape = (1, 1, 2, 2)
+    output_shape = (1, 1, 3, 3)
+
+    def setUp(self):
+        self.x = numpy.zeros(self.in_shape, dtype=numpy.float32)
+        self.x[:, :, 0, 0] = 1
+        self.x[:, :, 1, 0] = 2
+        self.x[:, :, 0, 1] = 3
+        self.x[:, :, 1, 1] = 4
+
+        self.out = numpy.zeros(self.output_shape, dtype=numpy.float32)
+        self.out[0, 0, :, :] = numpy.array(
+            [[1., 2., 3.],
+             [1.5, 2.5, 3.5],
+             [2., 3., 4.]],
+            dtype=numpy.float32)
 
     def check_forward(self, x, output_shape):
         y = functions.resize_images(x, output_shape)

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -1,0 +1,94 @@
+import unittest
+
+import numpy
+
+from chainer import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+
+@testing.parameterize(*testing.product({
+    'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
+}))
+class TestResizeImagesForwardIdentity(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(
+            size=self.in_shape).astype(numpy.float32)
+
+    def check_forward(self, x, output_shape):
+        y = functions.resize_images(x, output_shape)
+        testing.assert_allclose(y.data, x)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, output_shape=self.in_shape[2:])
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x), output_shape=self.in_shape[2:])
+
+
+class TestResizeImagesForwardScale(unittest.TestCase):
+
+    in_shape = (2, 2, 4, 4)
+    output_shape = (2, 2, 2, 2)
+
+    def setUp(self):
+        self.x = numpy.zeros(self.in_shape, dtype=numpy.float32)
+        self.x[:, :, :2, :2] = 1
+        self.x[:, :, 2:, :2] = 2
+        self.x[:, :, :2, 2:] = 3
+        self.x[:, :, 2:, 2:] = 4
+
+        self.out = numpy.zeros(self.output_shape, dtype=numpy.float32)
+        self.out[:, :, 0, 0] = 1
+        self.out[:, :, 1, 0] = 2
+        self.out[:, :, 0, 1] = 3
+        self.out[:, :, 1, 1] = 4
+
+    def check_forward(self, x, output_shape):
+        y = functions.resize_images(x, output_shape)
+        testing.assert_allclose(y.data, self.out)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, output_shape=self.output_shape[2:])
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(
+            cuda.to_gpu(self.x), output_shape=self.output_shape[2:])
+
+
+@testing.parameterize(*testing.product({
+    'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
+    'output_shape': [(10, 5), (3, 4)]
+}))
+class TestResizeImagesBackward(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(
+            size=self.in_shape).astype(numpy.float32)
+        output_shape_4d = self.in_shape[:2] + self.output_shape
+        self.grads = numpy.random.uniform(
+            size=output_shape_4d).astype(numpy.float32)
+
+    def check_backward(self, x, output_shape, grads):
+        gradient_check.check_backward(
+            functions.ResizeImages(output_shape),
+            (x,), (grads,), atol=1e-2, rtol=1e-3, eps=1e-5)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.output_shape, self.grads)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), self.output_shape,
+                            cuda.to_gpu(self.grads))
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds a function that resizes image like variables.
This is similar to #2272, but `resize_images` does not backpropagate to coordinate variables and has nicer API.


### example

```python
import matplotlib.pyplot as plt
import numpy as np
from skimage.data import astronaut

from chainer.functions import resize_images

img = astronaut().astype(np.float32)
img = np.transpose(img, (2, 0, 1))

out = resize_images(img[None], (512, 256))[0].data.transpose(1, 2, 0)
plt.imshow(out.astype(np.uint8))
plt.show()
```

![figure_1-1](https://cloud.githubusercontent.com/assets/2062128/23646092/9af308ee-0352-11e7-9d71-5b7bc551bc02.png)
