### PR TITLE
Set dtype option for cupy.random in initializer

### DIFF
--- a/chainer/initializers/normal.py
+++ b/chainer/initializers/normal.py
@@ -27,8 +27,13 @@ class Normal(initializer.Initializer):
 
     def __call__(self, array):
         xp = cuda.get_array_module(array)
-        array[...] = xp.random.normal(
-            loc=0.0, scale=self.scale, size=array.shape)
+        args = {'loc': 0.0, 'scale': self.scale, 'size': array.shape}
+        if xp is not numpy:
+            # Only CuPy supports dtype option
+            if self.dtype == numpy.float32 or self.dtype == numpy.float16:
+                # float16 is not supported in cuRAND
+                args['dtype'] = numpy.float32
+        array[...] = xp.random.normal(**args)
 
 
 class GlorotNormal(initializer.Initializer):


### PR DESCRIPTION
`cupy.random` supports `dtype` argument because cuRAND has float32 version of API. I fixed initializer to use lower precision API.
related to #2290 