### PR TITLE
Add axis option to l2_normalization

### DIFF
--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -56,10 +56,12 @@ def normalize(x, eps=1e-5, axis=1):
     vector :math:`y` by the following equation:
 
     .. math::
-       y_i = {x_i \\over \\| x_i \\|_2}
+       y_i = {x_i \\over \\| x_i \\|_2 + \epsilon}
 
-    :math:`eps` is used to avoid division by zero when norm of :math:`x` along
+    :obj:`eps` is used to avoid division by zero when norm of :math:`x` along
     the given axis is zero.
+
+    The default value of :obj:`axis` is determined for backward compatibility.
 
     Args:
         x (~chainer.Variable): Two dimensional output variable. The first

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -2,7 +2,6 @@ import numpy
 
 from chainer import cuda
 from chainer import function
-from chainer.utils import array
 from chainer.utils import type_check
 
 
@@ -10,8 +9,9 @@ class NormalizeL2(function.Function):
 
     """L2 normalization"""
 
-    def __init__(self, eps=1e-5):
+    def __init__(self, eps=1e-5, axis=1):
         self.eps = eps
+        self.axis = axis
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -19,96 +19,57 @@ class NormalizeL2(function.Function):
 
         type_check.expect(
             x_type.dtype == numpy.float32,
-            x_type.ndim == 2,
         )
 
-    def forward_cpu(self, inputs):
-        x = array.as_mat(inputs[0])
-        norm = numpy.linalg.norm(x, axis=1) + self.eps
-        return x / norm[:, numpy.newaxis],
-
-    def forward_gpu(self, inputs):
-        x = array.as_mat(inputs[0])
-        l2norm_kernel = cuda.cupy.ReductionKernel(
-            'T x, float32 eps',
-            'T y',
-            'x * x',
-            'a + b',
-            'y = sqrt(a) + eps',
-            '0',
-            'l2norm'
-        )
-        norm = cuda.cupy.broadcast_to(
-            l2norm_kernel(x, self.eps, axis=1).reshape(-1, 1),
-            x.shape
-        )
-
+    def forward(self, inputs):
+        x, = inputs
+        xp = cuda.get_array_module(x)
+        norm = xp.linalg.norm(x, axis=self.axis) + self.eps
+        norm = xp.expand_dims(norm, self.axis)
         return x / norm,
 
-    def backward_cpu(self, inputs, gy):
+    def backward(self, inputs, gy):
         x = inputs[0]
         gy = gy[0]
+        xp = cuda.get_array_module(x)
 
-        norm = numpy.linalg.norm(x, axis=1) + self.eps
-        norm = norm[:, numpy.newaxis]
+        norm = xp.linalg.norm(x, axis=self.axis) + self.eps
+        norm = xp.expand_dims(norm, self.axis)
 
-        gx = gy * norm - (x * gy).sum(axis=1)[:, numpy.newaxis] * x / norm
+        x_gy_reduced = (x * gy).sum(axis=self.axis)
+        x_gy_reduced = xp.expand_dims(x_gy_reduced, self.axis)
+        gx = gy * norm - x_gy_reduced * x / norm
         gx = gx / norm ** 2
 
         return gx,
 
-    def backward_gpu(self, inputs, gy):
-        x = inputs[0]
-        gy = gy[0]
 
-        l2norm_kernel = cuda.cupy.ReductionKernel(
-            'T x, float32 eps',
-            'T y',
-            'x * x',
-            'a + b',
-            'y = sqrt(a) + eps',
-            '0',
-            'l2norm'
-        )
-        norm = cuda.cupy.broadcast_to(
-            l2norm_kernel(x, self.eps, axis=1).reshape(-1, 1),
-            x.shape
-        )
-        x_gy = cuda.cupy.broadcast_to(
-            (x * gy).sum(axis=1, keepdims=True),
-            x.shape
-        )
-        gx = cuda.elementwise(
-            'T gy, T x, T x_gy, T norm',
-            'T gx',
-            'gx = (gy * norm - x_gy * x / norm) / (norm * norm)',
-            'l2_bwd')(gy, x, x_gy, norm)
-
-        return gx,
-
-
-def normalize(x, eps=1e-5):
+def normalize(x, eps=1e-5, axis=1):
     """L2 norm squared (a.k.a. Euclidean norm).
 
-    This function implements L2 normalization on a 1D vector. No reduction
-    is done along batch axis.  Let :math:`x` be an input vector of dimension
+    This function implements L2 normalization on a vector along the given axis.
+    No reduction is done along the normalization axis.
+
+    In the case when :obj:`axis=1` and :math:`x` is a vector of dimension
     :math:`(N, K)`, where :math:`N` and :math:`K` denote mini-batch size and
-    the dimension of the input variable. Then, this function computes an output
+    the dimension of the input variable, this function computes an output
     vector :math:`y` by the following equation:
 
     .. math::
        y_i = {x_i \\over \\| x_i \\|_2}
 
-    :math:`eps` is used to avoid division by zero when :math:`x_i=0`
+    :math:`eps` is used to avoid division by zero when norm of :math:`x` along
+    the given axis is zero.
 
     Args:
         x (~chainer.Variable): Two dimensional output variable. The first
             dimension is assumed to be the mini-batch dimension.
         eps (float): Epsilon value for numerical stability.
+        axis (int): Axis along which to normalize.
 
     Returns:
-        ~chainer.Variable: Two dimensional output variable, the same shape
-            as :math:`x`.
+        ~chainer.Variable: The output variable which has the same shape
+        as :math:`x`.
 
     """
-    return NormalizeL2(eps)(x)
+    return NormalizeL2(eps, axis)(x)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -27,9 +27,10 @@ class TestL2Normalization(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
 
     def check_forward(self, x_data, axis):
+        eps = 1e-5
         x = chainer.Variable(x_data)
 
-        y = functions.normalize(x, axis=axis)
+        y = functions.normalize(x, eps=eps, axis=axis)
         self.assertEqual(y.data.dtype, numpy.float32)
         y_data = cuda.to_cpu(y.data)
 
@@ -43,7 +44,8 @@ class TestL2Normalization(unittest.TestCase):
                 indices.append([slice(None)])
         indices_tuple = list(itertools.product(*indices))
         for index in indices_tuple:
-            y_expect[index] = self.x[index] / numpy.linalg.norm(self.x[index])
+            numerator = numpy.linalg.norm(self.x[index]) + eps
+            y_expect[index] = self.x[index] / numerator
         testing.assert_allclose(y_expect, y_data)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -1,5 +1,6 @@
 import unittest
 
+import itertools
 import numpy
 import six
 
@@ -10,11 +11,14 @@ from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
-from chainer.utils import type_check
 
 
 @testing.parameterize(
-    {'shape': (4, 15)},
+    {'shape': (4, 15), 'axis': 1},
+    {'shape': (4, 3, 2, 5), 'axis': 0},
+    {'shape': (4, 3, 2, 5), 'axis': 1},
+    {'shape': (4, 3, 2, 5), 'axis': 2},
+    {'shape': (4, 3, 2, 5), 'axis': 3},
 )
 class TestL2Normalization(unittest.TestCase):
 
@@ -22,45 +26,54 @@ class TestL2Normalization(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
 
-    def check_forward(self, x_data):
+    def check_forward(self, x_data, axis):
         x = chainer.Variable(x_data)
 
-        y = functions.normalize(x)
+        y = functions.normalize(x, axis=axis)
         self.assertEqual(y.data.dtype, numpy.float32)
         y_data = cuda.to_cpu(y.data)
 
         y_expect = numpy.empty_like(self.x)
-        for n in six.moves.range(len(self.x)):
-            y_expect[n] = self.x[n] / numpy.linalg.norm(self.x[n])
-
+        shape = self.x.shape
+        indices = []
+        for i in six.moves.range(len(shape)):
+            if i != axis:
+                indices.append(six.moves.range(shape[i]))
+            else:
+                indices.append([slice(None)])
+        indices_tuple = list(itertools.product(*indices))
+        for index in indices_tuple:
+            y_expect[index] = self.x[index] / numpy.linalg.norm(self.x[index])
         testing.assert_allclose(y_expect, y_data)
 
     @condition.retry(3)
     def test_forward_cpu(self):
-        self.check_forward(self.x)
+        self.check_forward(self.x, self.axis)
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
+        self.check_forward(cuda.to_gpu(self.x), self.axis)
 
-    def check_backward(self, x_data, y_grad):
+    def check_backward(self, x_data, axis, y_grad):
         gradient_check.check_backward(
-            functions.NormalizeL2(), x_data, y_grad, rtol=1e-3, atol=1e-4)
+            functions.NormalizeL2(axis=axis), x_data, y_grad,
+            rtol=1e-3, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
+        self.check_backward(self.x, self.axis, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+        self.check_backward(
+            cuda.to_gpu(self.x), self.axis, cuda.to_gpu(self.gy))
 
     def check_eps(self, x_data):
         x = chainer.Variable(x_data)
 
-        y = functions.normalize(x)
+        y = functions.normalize(x, axis=self.axis)
         self.assertEqual(y.data.dtype, numpy.float32)
         y_data = cuda.to_cpu(y.data)
 
@@ -73,15 +86,6 @@ class TestL2Normalization(unittest.TestCase):
     @attr.gpu
     def test_eps_gpu(self):
         self.check_eps(cuda.to_gpu(numpy.zeros_like(self.x)))
-
-
-class TestL2NormalizationTypeError(unittest.TestCase):
-
-    def test_invalid_shape(self):
-        x = chainer.Variable(numpy.zeros((4, 3, 24), dtype=numpy.float32))
-
-        with self.assertRaises(type_check.InvalidType):
-            chainer.functions.normalize(x)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -59,15 +59,15 @@ class TestL2Normalization(unittest.TestCase):
 
     def check_backward(self, x_data, axis, y_grad):
         gradient_check.check_backward(
-            functions.NormalizeL2(axis=axis), x_data, y_grad,
+            functions.NormalizeL2(eps=1e-6, axis=axis), x_data, y_grad,
             rtol=1e-3, atol=1e-4)
 
-    @condition.retry(3)
+    @condition.retry(5)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.axis, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
+    @condition.retry(5)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), self.axis, cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -62,12 +62,12 @@ class TestL2Normalization(unittest.TestCase):
             functions.NormalizeL2(eps=1e-6, axis=axis), x_data, y_grad,
             rtol=1e-3, atol=1e-4)
 
-    @condition.retry(5)
+    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.axis, self.gy)
 
     @attr.gpu
-    @condition.retry(5)
+    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), self.axis, cuda.to_gpu(self.gy))


### PR DESCRIPTION
This PR adds `axis` option to `chainer.functions.normalization` so that it can normalize arrays along arbitrary axis.

Previously, the function only supported the case when an input array is of dimension two and normalization happens in the second axis.
The default value of `axis` is set to behave identical to the previous implementation when `axis` is not supplied by the user.