### PR TITLE
Static-type CUDA kernel argument pointers

### DIFF
--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -11,7 +11,7 @@ cdef struct _CArray:
     int shape_and_strides[MAX_NDIM * 2]
 
 
-cdef class CArray(cupy.cuda.function.CPointer):
+cdef class CArray(CPointer):
 
     cdef:
         _CArray val
@@ -31,7 +31,7 @@ cdef struct _CIndexer:
     int shape_and_index[MAX_NDIM * 2]
 
 
-cdef class CIndexer(cupy.cuda.function.CPointer):
+cdef class CIndexer(CPointer):
     cdef:
         _CIndexer val
 
@@ -49,10 +49,6 @@ cpdef inline CIndexer to_cindexer(Py_ssize_t size, tuple shape):
 
 
 cdef class Indexer:
-    cdef:
-        public Py_ssize_t size
-        public tuple shape
-
     def __init__(self, tuple shape):
         cdef Py_ssize_t size = 1
         for s in shape:
@@ -66,6 +62,9 @@ cdef class Indexer:
 
     @property
     def cstruct(self):
+        return to_cindexer(self.size, self.shape)
+
+    cdef CPointer get_pointer(self):
         return to_cindexer(self.size, self.shape)
 
 

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -1,4 +1,3 @@
-from libc cimport stdint
 from libcpp cimport vector
 from cupy.cuda cimport memory
 

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -1,0 +1,73 @@
+from libc cimport stdint
+from libcpp cimport vector
+from cupy.cuda cimport memory
+
+from cupy.cuda.function cimport CPointer
+
+
+cdef class ndarray:
+    cdef:
+        readonly Py_ssize_t size
+        public vector.vector[Py_ssize_t] _shape
+        public vector.vector[Py_ssize_t] _strides
+        readonly bint _c_contiguous
+        readonly bint _f_contiguous
+        readonly object dtype
+        readonly memory.MemoryPointer data
+        readonly ndarray base
+
+    cpdef tolist(self)
+    cpdef tofile(self, fid, sep=*, format=*)
+    cpdef dump(self, file)
+    cpdef dumps(self)
+    cpdef ndarray astype(self, dtype, copy=*)
+    cpdef ndarray copy(self, order=*)
+    cpdef ndarray view(self, dtype=*)
+    cpdef fill(self, value)
+    cpdef ndarray _reshape(self, vector.vector[Py_ssize_t] shape)
+    cpdef ndarray _transpose(self, vector.vector[Py_ssize_t] axes)
+    cpdef ndarray swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
+    cpdef ndarray flatten(self)
+    cpdef ndarray ravel(self)
+    cpdef ndarray squeeze(self, axis=*)
+    cpdef ndarray take(self, indices, axis=*, out=*)
+    cpdef repeat(self, repeats, axis=*)
+    cpdef choose(self, choices, out=*, mode=*)
+    cpdef ndarray diagonal(self, offset=*, axis1=*, axis2=*)
+    cpdef ndarray max(self, axis=*, out=*, dtype=*, keepdims=*)
+    cpdef ndarray argmax(self, axis=*, out=*, dtype=*,
+                         keepdims=*)
+    cpdef ndarray min(self, axis=*, out=*, dtype=*, keepdims=*)
+    cpdef ndarray argmin(self, axis=*, out=*, dtype=*,
+                         keepdims=*)
+    cpdef ndarray clip(self, a_min, a_max, out=*)
+
+    cpdef ndarray trace(self, offset=*, axis1=*, axis2=*, dtype=*,
+                        out=*)
+    cpdef ndarray sum(self, axis=*, dtype=*, out=*, keepdims=*)
+
+    cpdef ndarray mean(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef ndarray var(self, axis=*, dtype=*, out=*, ddof=*,
+                      keepdims=*)
+    cpdef ndarray std(self, axis=*, dtype=*, out=*, ddof=*,
+                      keepdims=*)
+    cpdef ndarray prod(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef ndarray all(self, axis=*, out=*, keepdims=*)
+    cpdef ndarray any(self, axis=*, out=*, keepdims=*)
+    cpdef get(self, stream=*)
+    cpdef set(self, arr, stream=*)
+    cpdef ndarray reduced_view(self, dtype=*)
+    cpdef _update_c_contiguity(self)
+    cpdef _update_f_contiguity(self)
+    cpdef _update_contiguity(self)
+    cpdef _set_shape_and_strides(self, vector.vector[Py_ssize_t]& shape,
+                                 vector.vector[Py_ssize_t]& strides,
+                                 bint update_c_contiguity=*)
+    cdef CPointer get_pointer(self)
+
+
+cdef class Indexer:
+    cdef:
+        public Py_ssize_t size
+        public tuple shape
+    cdef CPointer get_pointer(self)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -17,10 +17,9 @@ from libcpp cimport vector
 
 from cupy.core cimport internal
 from cupy.cuda cimport cublas
+from cupy.cuda cimport function
 from cupy.cuda cimport runtime
 from cupy.cuda cimport memory
-
-from cupy.cuda.function cimport CPointer
 
 DEF MAX_NDIM = 25
 
@@ -1466,7 +1465,7 @@ cdef class ndarray:
         else:
             self._update_f_contiguity()
 
-    cdef CPointer get_pointer(self):
+    cdef function.CPointer get_pointer(self):
         return CArray(self)
 
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -20,6 +20,7 @@ from cupy.cuda cimport cublas
 from cupy.cuda cimport runtime
 from cupy.cuda cimport memory
 
+from cupy.cuda.function cimport CPointer
 
 DEF MAX_NDIM = 25
 
@@ -64,16 +65,6 @@ cdef class ndarray:
 
 
     """
-
-    cdef:
-        readonly Py_ssize_t size
-        public vector.vector[Py_ssize_t] _shape
-        public vector.vector[Py_ssize_t] _strides
-        readonly bint _c_contiguous
-        readonly bint _f_contiguous
-        readonly object dtype
-        readonly memory.MemoryPointer data
-        readonly ndarray base
 
     def __init__(self, shape, dtype=float, memptr=None, order='C'):
         cdef Py_ssize_t x
@@ -1474,6 +1465,9 @@ cdef class ndarray:
             self._update_contiguity()
         else:
             self._update_f_contiguity()
+
+    cdef CPointer get_pointer(self):
+        return CArray(self)
 
 
 cdef object newaxis = numpy.newaxis  # == None

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -7,9 +7,7 @@ cimport cpython
 from libcpp cimport vector
 
 from cupy.cuda cimport driver
-cimport cupy.core
-from cupy.core.core cimport ndarray
-from cupy.core.core cimport Indexer
+from cupy.core cimport core
 
 
 cdef extern from "cupy_stdint.h" nogil:
@@ -67,10 +65,10 @@ cdef inline CPointer _pointer(x):
     cdef Py_ssize_t itemsize
     if x is None:
         return CPointer()
-    if isinstance(x, ndarray):
-        return (<ndarray>x).get_pointer()
-    if isinstance(x, Indexer):
-        return (<Indexer>x).get_pointer()
+    if isinstance(x, core.ndarray):
+        return (<core.ndarray>x).get_pointer()
+    if isinstance(x, core.Indexer):
+        return (<core.Indexer>x).get_pointer()
 
     if type(x) not in _pointer_numpy_types:
         if isinstance(x, six.integer_types):

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -7,6 +7,9 @@ cimport cpython
 from libcpp cimport vector
 
 from cupy.cuda cimport driver
+cimport cupy.core
+from cupy.core.core cimport ndarray
+from cupy.core.core cimport Indexer
 
 
 cdef extern from "cupy_stdint.h" nogil:
@@ -64,8 +67,10 @@ cdef inline CPointer _pointer(x):
     cdef Py_ssize_t itemsize
     if x is None:
         return CPointer()
-    if hasattr(x, 'cstruct'):
-        return x.cstruct
+    if isinstance(x, ndarray):
+        return (<ndarray>x).get_pointer()
+    if isinstance(x, Indexer):
+        return (<Indexer>x).get_pointer()
 
     if type(x) not in _pointer_numpy_types:
         if isinstance(x, six.integer_types):
@@ -98,6 +103,7 @@ cdef void _launch(size_t func, int grid0, int grid1, int grid2,
                   args, int shared_mem, size_t stream) except *:
     cdef list pargs = []
     cdef vector.vector[void*] kargs
+    cdef CPointer cp
     kargs.reserve(len(args))
     for a in args:
         cp = _pointer(a)


### PR DESCRIPTION
This PR improves performance of linear_launch() by static-typing kernel argument pointers.

One concern is that dependency from function.pyx to core.pyx is introduced,
because core.ndarray and core.Indexer must be visible to function.pyx in order to do static-typing.

In my benchmark, linear_launch() is sped up by about 30%.
