### PR TITLE
Stop copying iterators for efficiency

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -45,22 +45,16 @@ class MultiprocessIterator(iterator.Iterator):
         self.dataset = dataset
         self.batch_size = batch_size
         self._repeat = repeat
-        if shuffle:
-            self._order = numpy.random.permutation(len(dataset))
-        else:
-            self._order = None
+        self._shuffle = shuffle
         self._prefetch_order = None  # used at the end of each epoch
-
-        self.current_position = 0
-        self.epoch = 0
-        self.is_new_epoch = False
-        self._pushed_position = None  # initialized at the first iteration
 
         self.n_processes = n_processes or multiprocessing.cpu_count()
         self.n_prefetch = max(n_prefetch, 1)
         self._shared_mem_size = shared_mem
 
         self._finalized = None
+
+        self.reset()
 
     def __del__(self):
         self.finalize()
@@ -208,6 +202,35 @@ class MultiprocessIterator(iterator.Iterator):
         # Eventually overwrite the (possibly shuffled) order.
         self._order = self._prefetch_order
         return batch
+
+    def reset(self):
+        if getattr(self, 'current_position', 0) != 0:
+            raise NotImplementedError(
+                'Reset of MultiProcessIterator in the middle of a epoch is '
+                'currently not supported.')
+        if getattr(self, 'epoch', 0) != 0 and self._repeat:
+            raise NotImplementedError(
+                'Reset of repeating MultiProcessIterator is currently not '
+                'supported.')
+        if getattr(self, '_finalized', None) is not None and \
+                self._finalized.is_set():
+            raise NotImplementedError(
+                'Reset of finalized MultiProcessIterator is currently not '
+                'supported.')
+
+        self.current_position = 0
+        self.epoch = 0
+        self.is_new_epoch = False
+        self._pushed_position = None  # initialized at the first iteration
+
+        if self._shuffle:
+            self._order = numpy.random.permutation(len(self.dataset))
+        else:
+            self._order = None
+
+        if self._finalized is not None:
+            for _ in six.moves.range(self.n_prefetch):
+                self._invoke_prefetch()
 
 
 def _get_data_loop(data_queue, ordered_data_queue, mem_list,

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -34,14 +34,9 @@ class SerialIterator(iterator.Iterator):
         self.dataset = dataset
         self.batch_size = batch_size
         self._repeat = repeat
-        if shuffle:
-            self._order = numpy.random.permutation(len(dataset))
-        else:
-            self._order = None
+        self._shuffle = shuffle
 
-        self.current_position = 0
-        self.epoch = 0
-        self.is_new_epoch = False
+        self.reset()
 
     def __next__(self):
         if not self._repeat and self.epoch > 0:
@@ -92,3 +87,13 @@ class SerialIterator(iterator.Iterator):
         self.is_new_epoch = serializer('is_new_epoch', self.is_new_epoch)
         if self._order is not None:
             serializer('_order', self._order)
+
+    def reset(self):
+        if self._shuffle:
+            self._order = numpy.random.permutation(len(self.dataset))
+        else:
+            self._order = None
+
+        self.current_position = 0
+        self.epoch = 0
+        self.is_new_epoch = False

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -156,7 +156,13 @@ class Evaluator(extension.Extension):
 
         if self.eval_hook:
             self.eval_hook(self)
-        it = copy.copy(iterator)
+
+        if hasattr(iterator, 'reset'):
+            iterator.reset()
+            it = iterator
+        else:
+            it = copy.copy(iterator)
+
         summary = reporter_module.DictSummary()
 
         for batch in it:

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -185,4 +185,16 @@ class TestMultiprocessIterator(unittest.TestCase):
         for _ in range(2):
             self.assertRaises(StopIteration, copy_it.next)
 
+    def test_reset(self):
+        dataset = [1, 2, 3, 4, 5]
+        it = iterators.MultiprocessIterator(
+            dataset, 2, repeat=False, **self.options)
+
+        for trial in range(4):
+            batches = sum([it.next() for _ in range(3)], [])
+            self.assertEqual(sorted(batches), dataset)
+            for _ in range(2):
+                self.assertRaises(StopIteration, it.next)
+            it.reset()
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -227,6 +227,30 @@ class TestMultiprocessIterator(unittest.TestCase):
                 self.assertRaises(StopIteration, it.next)
             it.reset()
 
+    def test_unsupported_reset_middle(self):
+        dataset = [1, 2, 3, 4, 5]
+        it = iterators.MultiprocessIterator(
+            dataset, 2, repeat=False, **self.options)
+        it.next()
+        self.assertRaises(NotImplementedError, it.reset)
+
+    def test_unsupported_reset_repeat(self):
+        dataset = [1, 2, 3, 4]
+        it = iterators.MultiprocessIterator(
+            dataset, 2, repeat=True, **self.options)
+        it.next()
+        it.next()
+        self.assertRaises(NotImplementedError, it.reset)
+
+    def test_unsupported_reset_finalized(self):
+        dataset = [1, 2, 3, 4]
+        it = iterators.MultiprocessIterator(
+            dataset, 2, repeat=False, **self.options)
+        it.next()
+        it.next()
+        it.finalize()
+        self.assertRaises(NotImplementedError, it.reset)
+
 
 @testing.parameterize(*testing.product({
     'n_prefetch': [1, 2],

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -146,5 +146,15 @@ class TestSerialIteratorShuffled(unittest.TestCase):
         out = sum([it.next() for _ in range(7)], [])
         self.assertNotEqual(out[0:10], out[10:20])
 
+    def test_reset(self):
+        dataset = [1, 2, 3, 4, 5]
+        it = iterators.SerialIterator(dataset, 2, repeat=False)
+
+        for trial in range(4):
+            batches = sum([it.next() for _ in range(3)], [])
+            self.assertEqual(sorted(batches), dataset)
+            for _ in range(2):
+                self.assertRaises(StopIteration, it.next)
+            it.reset()
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -189,6 +189,7 @@ class TestSerialIteratorShuffled(unittest.TestCase):
                 self.assertRaises(StopIteration, it.next)
             it.reset()
 
+
 class TestSerialIteratorSerialize(unittest.TestCase):
 
     def test_iterator_serialize(self):


### PR DESCRIPTION
This PR aims to improve the performance of common use cases with ChainerMN by reducing the frequency of process spawn.

In `Evaluator`, currently iterators are copied for every evaluation time. For most cases, this is not very time consuming. However, we found that this is very slow when we are using `MultiProcessIterator` with `forkserver` or `spawn` modes (c.f., https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods). Therefore, to avoid spawning new processes for each evaluation time, this PR proposes to introduce `reset` method to iterators and use it in `Evaluator`.
