### PR TITLE
Use OrderedDict for known_grad, that is only supported in theano>=0.9

### DIFF
--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -84,7 +84,7 @@ Please install theano to activate theano function.
 
         gs = tuple(
             o.type('g_{}'.format(i)) for i, o in enumerate(outputs))
-        known_grads = dict(zip(outputs, gs))
+        known_grads = collections.OrderedDict(zip(outputs, gs))
         grad = theano.tensor.grad(
             cost=None, wrt=inputs, known_grads=known_grads,
             disconnected_inputs='ignore')


### PR DESCRIPTION
As @deepali-c commented, TheanoFunction does not work with theano>=0.9 since it only supports `collections.OrderedDict` as `know_grad` argument.
https://github.com/pfnet/chainer/pull/1103#issuecomment-285270297