### PR TITLE
Stop checking that optimizer is an instance of Optimizer class

### DIFF
--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -123,7 +123,7 @@ class StandardUpdater(Updater):
             iterator = {'main': iterator}
         self._iterators = iterator
 
-        if isinstance(optimizer, optimizer_module.Optimizer):
+        if not isinstance(optimizer, dict):
             optimizer = {'main': optimizer}
         self._optimizers = optimizer
 

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -3,7 +3,6 @@ import six
 
 from chainer.dataset import convert
 from chainer.dataset import iterator as iterator_module
-from chainer import optimizer as optimizer_module
 from chainer import variable
 
 


### PR DESCRIPTION
This is necessary workaround for compatibility with ChainerMN's `MultiNodeOptimizer`.

ChainerMN's `MultiNodeOptimizer` wraps an actual optimizer. There is no good reason for `MultiNodeOptimizer` to inherit `Optimizer`, as it would not use any methods nor variables of `Optimizer`. And, for some technical reasons from ChainerMN side, it is not preferable for `MultiNodeOptimizer` to inherit `Optimizer`. Therefore, this PR proposes Chainer's `Updater` to change the way to determine whether `optimizer` argument is a `dict` or not. (This is the conclusion of discussion with @beam2d -san.)