### PR TITLE
[wip] Fix cuDNN test

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -114,13 +114,14 @@ class TestReLUCudnnCall(unittest.TestCase):
                 self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backward(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            patch = 'cupy.cudnn.cudnn.activationBackward_v4'
+        else:
+            patch = 'cupy.cudnn.cudnn.activationBackward_v3'
+
         with chainer.using_config('use_cudnn', self.use_cudnn):
             y = self.forward()
             y.grad = self.gy
-            if cuda.cudnn.cudnn.getVersion() >= 4000:
-                patch = 'cupy.cudnn.cudnn.activationBackward_v4'
-            else:
-                patch = 'cupy.cudnn.cudnn.activationBackward_v3'
             with mock.patch(patch) as func:
                 y.backward()
                 self.assertEqual(func.called, self.expect)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -104,8 +104,12 @@ class TestReLUCudnnCall(unittest.TestCase):
         return functions.relu(x)
 
     def test_call_cudnn_forward(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            patch = 'cupy.cudnn.cudnn.activationForward_v4'
+        else:
+            patch = 'cupy.cudnn.cudnn.activationForward_v3'
         with chainer.using_config('use_cudnn', self.use_cudnn):
-            with mock.patch('cupy.cudnn.cudnn.activationForward_v3') as func:
+            with mock.patch(patch) as func:
                 self.forward()
                 self.assertEqual(func.called, self.expect)
 
@@ -113,7 +117,11 @@ class TestReLUCudnnCall(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             y = self.forward()
             y.grad = self.gy
-            with mock.patch('cupy.cudnn.cudnn.activationBackward_v3') as func:
+            if cuda.cudnn.cudnn.getVersion() >= 4000:
+                patch = 'cupy.cudnn.cudnn.activationBackward_v4'
+            else:
+                patch = 'cupy.cudnn.cudnn.activationBackward_v3'
+            with mock.patch(patch) as func:
                 y.backward()
                 self.assertEqual(func.called, self.expect)
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -101,16 +101,25 @@ class TestSigmoidCudnnCall(unittest.TestCase):
         return functions.sigmoid(x)
 
     def test_call_cudnn_forward(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            patch = 'cupy.cudnn.cudnn.activationForward_v4'
+        else:
+            patch = 'cupy.cudnn.cudnn.activationForward_v3'
         with chainer.using_config('use_cudnn', self.use_cudnn):
-            with mock.patch('cupy.cudnn.cudnn.activationForward_v3') as func:
+            with mock.patch(patch) as func:
                 self.forward()
                 self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backward(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            patch = 'cupy.cudnn.cudnn.activationBackward_v4'
+        else:
+            patch = 'cupy.cudnn.cudnn.activationBackward_v3'
+
         with chainer.using_config('use_cudnn', self.use_cudnn):
             y = self.forward()
             y.grad = self.gy
-            with mock.patch('cupy.cudnn.cudnn.activationBackward_v3') as func:
+            with mock.patch(patch) as func:
                 y.backward()
                 self.assertEqual(func.called, self.expect)
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -97,16 +97,26 @@ class TestTanhCudnnCall(unittest.TestCase):
         return functions.tanh(x)
 
     def test_call_cudnn_forward(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            patch = 'cupy.cudnn.cudnn.activationForward_v4'
+        else:
+            patch = 'cupy.cudnn.cudnn.activationForward_v3'
+
         with chainer.using_config('use_cudnn', self.use_cudnn):
-            with mock.patch('cupy.cudnn.cudnn.activationForward_v3') as func:
+            with mock.patch(patch) as func:
                 self.forward()
                 self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backward(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            patch = 'cupy.cudnn.cudnn.activationBackward_v4'
+        else:
+            patch = 'cupy.cudnn.cudnn.activationBackward_v3'
+
         with chainer.using_config('use_cudnn', self.use_cudnn):
             y = self.forward()
             y.grad = self.gy
-            with mock.patch('cupy.cudnn.cudnn.activationBackward_v3') as func:
+            with mock.patch(patch) as func:
                 y.backward()
                 self.assertEqual(func.called, self.expect)
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -115,9 +115,14 @@ class TestSgimoidCrossEntropyCudnnCall(unittest.TestCase):
         return functions.sigmoid_cross_entropy(x, t)
 
     def test_call_cudnn_backward(self):
+        if cuda.cudnn.cudnn.getVersion() >= 4000:
+            patch = 'cupy.cudnn.cudnn.activationForward_v4'
+        else:
+            patch = 'cupy.cudnn.cudnn.activationForward_v3'
+
         with chainer.using_config('use_cudnn', self.use_cudnn):
             y = self.forward()
-            with mock.patch('cupy.cudnn.cudnn.activationForward_v3') as func:
+            with mock.patch(patch) as func:
                 y.backward()
                 self.assertEqual(func.called,
                                  chainer.should_use_cudnn('==always'))


### PR DESCRIPTION
I found an error in tests of activation functions which appear when v1.22.0 is merged.