### PR TITLE
Fix Advanced indexing of Cupy's __getitem__ when an index argument is a list

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -4,6 +4,7 @@ from __future__ import division
 import ctypes
 import sys
 
+import copy
 import numpy
 import six
 
@@ -1098,10 +1099,18 @@ cdef class ndarray:
         cdef Py_ssize_t i, j, offset, ndim, n_newaxes, n_ellipses, ellipsis
         cdef Py_ssize_t ellipsis_sizem, s_start, s_stop, s_step, dim, ind
         cdef vector.vector[Py_ssize_t] shape, strides
-        if not isinstance(slices, tuple):
-            slices = [slices]
-        else:
+        if isinstance(slices, tuple):
             slices = list(slices)
+        elif isinstance(slices, list):
+            slices = copy.copy(slices)
+            single_integer_array_indexing = True
+            for s in slices:
+                if not isinstance(s, int):
+                    single_integer_array_indexing = False
+            if single_integer_array_indexing:
+                slices = [slices]
+        else:
+            slices = [slices]
 
         # Expand ellipsis into empty slices
         ellipsis = -1

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1102,11 +1102,7 @@ cdef class ndarray:
             slices = list(slices)
         elif isinstance(slices, list):
             slices = list(slices)  # copy list
-            single_integer_array_indexing = True
-            for s in slices:
-                if not isinstance(s, int):
-                    single_integer_array_indexing = False
-            if single_integer_array_indexing:
+            if all([isinstance(s, int) for s in slices]):
                 slices = [slices]
         else:
             slices = [slices]

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1145,8 +1145,6 @@ cdef class ndarray:
                 # handle the case when s is an empty list
                 if is_list and s.size == 0:
                     s = s.astype(numpy.int32)
-                    if s.ndim > 1:
-                        s = s[0]
                 slices[i] = s
             if isinstance(s, ndarray):
                 if issubclass(s.dtype.type, numpy.integer):

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -4,7 +4,6 @@ from __future__ import division
 import ctypes
 import sys
 
-import copy
 import numpy
 import six
 
@@ -1102,7 +1101,7 @@ cdef class ndarray:
         if isinstance(slices, tuple):
             slices = list(slices)
         elif isinstance(slices, list):
-            slices = copy.copy(slices)
+            slices = list(slices)  # copy list
             single_integer_array_indexing = True
             for s in slices:
                 if not isinstance(s, int):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -85,6 +85,7 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': [1, 1]},
     {'shape': (2, 3, 4), 'indexes': [[1]]},
     {'shape': (2, 3, 4), 'indexes': [[1, 1]]},
+    {'shape': (2, 3, 4), 'indexes': [[1], [1]]},
     {'shape': (2, 3, 4), 'indexes': [[1, 1], 1]},
     {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)]},
     {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)]},

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -75,6 +75,7 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     {'shape': (2, 3, 4, 5), 'indexes': [[[[[]]]]]},
     {'shape': (2, 3, 4), 'indexes': (slice(None), [])},
     {'shape': (2, 3, 4), 'indexes': ([], [])},
+    {'shape': (2, 3, 4), 'indexes': ([[]],)},
     {'shape': (2, 3, 4), 'indexes': numpy.array([], dtype=numpy.bool)},
     {'shape': (2, 3, 4),
      'indexes': (slice(None), numpy.array([], dtype=numpy.bool))},

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -153,6 +153,7 @@ class TestArrayAdvancedIndexingGetitemCupyIndices(unittest.TestCase):
     {'shape': (), 'indexes': ([1],)},
     {'shape': (2, 3), 'indexes': (slice(None), [1, 2], slice(None))},
     {'shape': (2, 3), 'indexes': numpy.array([], dtype=numpy.float)},
+    {'shape': (2, 3, 4), 'indexes': [1, [1, [1]]]},
 )
 @testing.gpu
 class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -79,6 +79,14 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     {'shape': (2, 3, 4),
      'indexes': (slice(None), numpy.array([], dtype=numpy.bool))},
     {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.bool)},
+    # list indexes
+    {'shape': (2, 3, 4), 'indexes': [1]},
+    {'shape': (2, 3, 4), 'indexes': [1, 1]},
+    {'shape': (2, 3, 4), 'indexes': [[1]]},
+    {'shape': (2, 3, 4), 'indexes': [[1, 1]]},
+    {'shape': (2, 3, 4), 'indexes': [[1, 1], 1]},
+    {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)]},
+    {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)]},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a bug found in #2418.