### PR TITLE
Fix Advanced indexing of Cupy's setitem and scatter_add when an index argument is a list

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2608,11 +2608,7 @@ cpdef _scatter_op(ndarray a, slices, value, op):
         slices = list(slices)
     elif isinstance(slices, list):
         slices = list(slices)  # copy list
-        single_integer_array_indexing = True
-        for s in slices:
-            if not isinstance(s, int):
-                single_integer_array_indexing = False
-        if single_integer_array_indexing:
+        if all([isinstance(s, int) for s in slices]):
             slices = [slices]
     else:
         slices = [slices]

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2604,10 +2604,18 @@ cpdef _scatter_op(ndarray a, slices, value, op):
     cdef ndarray v, x, y, a_interm, reduced_idx
     cdef int li, ri
 
-    if not isinstance(slices, tuple):
-        slices = [slices]
-    else:
+    if isinstance(slices, tuple):
         slices = list(slices)
+    elif isinstance(slices, list):
+        slices = list(slices)  # copy list
+        single_integer_array_indexing = True
+        for s in slices:
+            if not isinstance(s, int):
+                single_integer_array_indexing = False
+        if single_integer_array_indexing:
+            slices = [slices]
+    else:
+        slices = [slices]
 
     # Expand ellipsis into empty slices
     ellipsis = -1
@@ -2642,8 +2650,6 @@ cpdef _scatter_op(ndarray a, slices, value, op):
             # handle the case when s is an empty list
             if is_list and s.size == 0:
                 s = s.astype(numpy.int32)
-                if s.ndim > 1:
-                    s = s[0]
             slices[i] = s
         if isinstance(s, ndarray):
             if issubclass(s.dtype.type, numpy.integer):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -253,6 +253,14 @@ class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
      'value': 1},
     {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.bool),
      'value': numpy.random.uniform(size=(4,))},
+    # list indexes
+    {'shape': (2, 3, 4), 'indexes': [1, 0], 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': [[1]], 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': [[1, 0]], 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': [[1], [0]], 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': [[1, 0], 2], 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)], 'value': 1},
+    {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)], 'value': 1},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
@@ -306,6 +314,9 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
     {'shape': (2, 3, 4),
      'indexes': (1, slice(None), [[2, 0], [3, 1]]),
      'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
+    # list indexes
+    {'shape': (2, 3, 4), 'indexes': [1], 'value': numpy.arange(3 * 4).reshape(3, 4)},
+
 )
 @testing.gpu
 class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -315,8 +315,8 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
      'indexes': (1, slice(None), [[2, 0], [3, 1]]),
      'value': numpy.arange(2 * 2 * 3).reshape(2, 2, 3)},
     # list indexes
-    {'shape': (2, 3, 4), 'indexes': [1], 'value': numpy.arange(3 * 4).reshape(3, 4)},
-
+    {'shape': (2, 3, 4), 'indexes': [1],
+     'value': numpy.arange(3 * 4).reshape(3, 4)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -97,6 +97,16 @@ from cupy import testing
      'value': 1},
     {'shape': (2, 3, 4), 'slices': numpy.array([[]], dtype=numpy.bool),
      'value': numpy.random.uniform(size=(4,))},
+    # list indexes
+    {'shape': (2, 3, 4), 'slices': [1], 'value': 1},
+    {'shape': (2, 3, 4), 'slices': [1, 1],
+     'value': numpy.arange(2 * 3 * 4).reshape(2, 3, 4)},
+    {'shape': (2, 3, 4), 'slices': [[1]], 'value': 1},
+    {'shape': (2, 3, 4), 'slices': [[1, 1]], 'value': 1},
+    {'shape': (2, 3, 4), 'slices': [[1], [1]], 'value': 1},
+    {'shape': (2, 3, 4), 'slices': [[1, 1], 1], 'value': 1},
+    {'shape': (2, 3, 4), 'slices': [[1], slice(1, 2)], 'value': 1},
+    {'shape': (2, 3, 4), 'slices': [[[1]], slice(1, 2)], 'value': 1},
 )
 @testing.gpu
 class TestScatterAddParametrized(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a bug similar to #2418.
The solution is similar to #2419.