### PR TITLE
1. Improve getitem performance 2. Add one dimensional integer array indexing support

### DIFF
--- a/chainer/dataset/dataset_mixin.py
+++ b/chainer/dataset/dataset_mixin.py
@@ -1,3 +1,6 @@
+import array
+
+import numpy
 import six
 
 
@@ -28,7 +31,7 @@ class DatasetMixin(object):
             current, stop, step = index.indices(len(self))
             return [self.get_example(i) for i in
                     six.moves.range(current, stop, step)]
-        elif isinstance(index, list):
+        elif isinstance(index, list) or isinstance(index, numpy.ndarray):
             return [self.get_example(i) for i in index]
         else:
             return self.get_example(index)

--- a/chainer/dataset/dataset_mixin.py
+++ b/chainer/dataset/dataset_mixin.py
@@ -34,6 +34,7 @@ class DatasetMixin(object):
             returns a list of examples created by `get_example`.
 
         .. admonition:: Example
+
            >>> import numpy
            >>> from chainer import dataset
            >>> class SimpleDataset(dataset.DatasetMixin):

--- a/chainer/dataset/dataset_mixin.py
+++ b/chainer/dataset/dataset_mixin.py
@@ -1,3 +1,6 @@
+import six
+
+
 class DatasetMixin(object):
 
     """Default implementation of dataset indexing.
@@ -15,18 +18,18 @@ class DatasetMixin(object):
     def __getitem__(self, index):
         """Returns an example or a sequence of examples.
 
-        It implements the standard Python indexing. It uses the
-        :meth:`get_example` method by default, but it may be overridden by the
-        implementation to, for example, improve the slicing performance.
+        It implements the standard Python indexing and numpy like advanced
+        indexing. It uses the :meth:`get_example` method by default, but it may
+        be overridden by the implementation to, for example, improve the
+        slicing performance.
 
         """
         if isinstance(index, slice):
             current, stop, step = index.indices(len(self))
-            ret = []
-            while current < stop and step > 0 or current > stop and step < 0:
-                ret.append(self.get_example(current))
-                current += step
-            return ret
+            return [self.get_example(i) for i in
+                    six.moves.range(current, stop, step)]
+        elif isinstance(index, list):
+            return [self.get_example(i) for i in index]
         else:
             return self.get_example(index)
 

--- a/chainer/dataset/dataset_mixin.py
+++ b/chainer/dataset/dataset_mixin.py
@@ -19,10 +19,40 @@ class DatasetMixin(object):
     def __getitem__(self, index):
         """Returns an example or a sequence of examples.
 
-        It implements the standard Python indexing and numpy like advanced
-        indexing. It uses the :meth:`get_example` method by default, but it may
-        be overridden by the implementation to, for example, improve the
+        It implements the standard Python indexing and one-dimensional integer
+        array indexing. It uses the :meth:`get_example` method by default, but
+        it may be overridden by the implementation to, for example, improve the
         slicing performance.
+
+        Args:
+            index (int, slice, list or numpy.ndarray): An index of example
+                or indexes of examples.
+
+        Returns: If index is int, returns an example created by `get_example`.
+        If index is either slice or one-dimensional list or numpy.ndarray,
+        returns a list of examples created by `get_example`.
+
+        .. admonition:: Example
+           >>> import numpy
+           >>> from chainer import dataset
+           >>> class SimpleDataset(dataset.DatasetMixin):
+           ...     def __init__(self, values):
+           ...         self.values = values
+           ...     def __len__(self):
+           ...         return len(self.values)
+           ...     def get_example(self, i):
+           ...         return self.values[i]
+           ...
+           >>> ds = SimpleDataset([0, 1, 2, 3, 4, 5])
+           >>> ds[1]   # Access by int
+           1
+           >>> ds[1:3]  # Access by slice
+           [1, 2]
+           >>> ds[[4, 0]]  # Access by one-dimensional integer list
+           [4, 0]
+           >>> index = numpy.arange(3)
+           >>> ds[index]  # Access by one-dimensional integer numpy.ndarray
+           [0, 1, 2]
 
         """
         if isinstance(index, slice):

--- a/chainer/dataset/dataset_mixin.py
+++ b/chainer/dataset/dataset_mixin.py
@@ -1,5 +1,3 @@
-import array
-
 import numpy
 import six
 

--- a/chainer/dataset/dataset_mixin.py
+++ b/chainer/dataset/dataset_mixin.py
@@ -25,12 +25,13 @@ class DatasetMixin(object):
         slicing performance.
 
         Args:
-            index (int, slice, list or numpy.ndarray): An index of example
+            index (int, slice, list or numpy.ndarray): An index of an example
                 or indexes of examples.
 
-        Returns: If index is int, returns an example created by `get_example`.
-        If index is either slice or one-dimensional list or numpy.ndarray,
-        returns a list of examples created by `get_example`.
+        Returns:
+            If index is int, returns an example created by `get_example`.
+            If index is either slice or one-dimensional list or numpy.ndarray,
+            returns a list of examples created by `get_example`.
 
         .. admonition:: Example
            >>> import numpy

--- a/tests/chainer_tests/dataset_tests/test_dataset_mixin.py
+++ b/tests/chainer_tests/dataset_tests/test_dataset_mixin.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy
 
 from chainer import dataset
 from chainer import testing
@@ -52,6 +53,26 @@ class TestDatasetMixin(unittest.TestCase):
         self.assertEqual(ds[1:4:2], ds.values[1:4:2])
         self.assertEqual(ds[::-2], ds.values[::-2])
         self.assertEqual(ds[:10], ds.values[:10])
+
+    def test_advanced_indexing(self):
+        ds = self.ds
+        self.assertEqual(ds[[1, 2, 3]], [ds.values[1], ds.values[2], ds.values[3]])
+        self.assertEqual(ds[[1, 2, 3]], ds[1:4])
+        self.assertEqual(ds[[0, 4, 3]], [ds.values[0], ds.values[4], ds.values[3]])
+        self.assertEqual(ds[[4]], [ds.values[4]])
+        self.assertEqual(ds[[4, 1, 3, 2, 2, 1]],
+                         [ds.values[4], ds.values[1], ds.values[3], ds.values[2], ds.values[2], ds.values[1]])
+        self.assertEqual(ds[[0, -2, -1]], [ds.values[0], ds.values[-2], ds.values[-1]])
+
+    def test_large_dataset(self):
+        # Check performance of __get_item__ with large size of dataset
+        ds = SimpleDataset(list(numpy.arange(1000000)))
+        self.assertEqual(ds[3453], ds.values[3453])
+        self.assertEqual(ds[:], ds.values)
+        self.assertEqual(ds[2:987654:7], ds.values[2:987654:7])
+        self.assertEqual(ds[::-3], ds.values[::-3])
+        for i in range(100):
+            self.assertEqual(ds[i*4096:(i+1)*4096], ds.values[i*4096:(i+1)*4096])
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/dataset_tests/test_dataset_mixin.py
+++ b/tests/chainer_tests/dataset_tests/test_dataset_mixin.py
@@ -1,5 +1,5 @@
-import unittest
 import numpy
+import unittest
 
 from chainer import dataset
 from chainer import testing
@@ -56,13 +56,14 @@ class TestDatasetMixin(unittest.TestCase):
 
     def test_advanced_indexing(self):
         ds = self.ds
-        self.assertEqual(ds[[1, 2, 3]], [ds.values[1], ds.values[2], ds.values[3]])
-        self.assertEqual(ds[[1, 2, 3]], ds[1:4])
-        self.assertEqual(ds[[0, 4, 3]], [ds.values[0], ds.values[4], ds.values[3]])
+        self.assertEqual(ds[[1, 2]], [ds.values[1], ds.values[2]])
+        self.assertEqual(ds[[1, 2]], ds[1:3])
+        self.assertEqual(ds[[4, 0]], [ds.values[4], ds.values[0]])
         self.assertEqual(ds[[4]], [ds.values[4]])
         self.assertEqual(ds[[4, 1, 3, 2, 2, 1]],
-                         [ds.values[4], ds.values[1], ds.values[3], ds.values[2], ds.values[2], ds.values[1]])
-        self.assertEqual(ds[[0, -2, -1]], [ds.values[0], ds.values[-2], ds.values[-1]])
+                         [ds.values[4], ds.values[1], ds.values[3],
+                          ds.values[2], ds.values[2], ds.values[1]])
+        self.assertEqual(ds[[-2, -1]], [ds.values[-2], ds.values[-1]])
         # test ndarray
         self.assertEqual(ds[numpy.asarray([1, 2, 3])], ds[1:4])
 
@@ -74,7 +75,8 @@ class TestDatasetMixin(unittest.TestCase):
         self.assertEqual(ds[2:987654:7], ds.values[2:987654:7])
         self.assertEqual(ds[::-3], ds.values[::-3])
         for i in range(100):
-            self.assertEqual(ds[i*4096:(i+1)*4096], ds.values[i*4096:(i+1)*4096])
+            self.assertEqual(ds[i * 4096:(i + 1) * 4096],
+                             ds.values[i * 4096:(i + 1) * 4096])
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/dataset_tests/test_dataset_mixin.py
+++ b/tests/chainer_tests/dataset_tests/test_dataset_mixin.py
@@ -63,6 +63,8 @@ class TestDatasetMixin(unittest.TestCase):
         self.assertEqual(ds[[4, 1, 3, 2, 2, 1]],
                          [ds.values[4], ds.values[1], ds.values[3], ds.values[2], ds.values[2], ds.values[1]])
         self.assertEqual(ds[[0, -2, -1]], [ds.values[0], ds.values[-2], ds.values[-1]])
+        # test ndarray
+        self.assertEqual(ds[numpy.asarray([1, 2, 3])], ds[1:4])
 
     def test_large_dataset(self):
         # Check performance of __get_item__ with large size of dataset


### PR DESCRIPTION
There are 2 improvement in this PR.

1. Improve getitem performance 
Performance improvement of slice access of DatasetMixin.
(test_large_dataset took 0.4 sec -> 0.3 sec with this modification in my environment.)

2. Add advanced indexing support
Allow numpy like advanced indexing access of dataset
e.g., ds[[1, 2, 4]]