### PR TITLE
Improve cuDNN test

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -101,22 +101,18 @@ class TestReLUCudnnCall(unittest.TestCase):
         return functions.relu(x, use_cudnn=self.use_cudnn)
 
     def test_call_cudnn_forward(self):
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
-            patch = 'cupy.cudnn.cudnn.activationForward_v4'
-        else:
-            patch = 'cupy.cudnn.cudnn.activationForward_v3'
-        with mock.patch(patch) as func:
+        default_func = cuda.cupy.cudnn.activation_forward
+        with mock.patch('cupy.cudnn.activation_forward') as func:
+            func.side_effect = default_func
             self.forward()
             self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backward(self):
         y = self.forward()
         y.grad = self.gy
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
-            patch = 'cupy.cudnn.cudnn.activationBackward_v4'
-        else:
-            patch = 'cupy.cudnn.cudnn.activationBackward_v3'
-        with mock.patch(patch) as func:
+        default_func = cuda.cupy.cudnn.activation_backward
+        with mock.patch('cupy.cudnn.activation_backward') as func:
+            func.side_effect = default_func
             y.backward()
             self.assertEqual(func.called, self.expect)
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -97,22 +97,18 @@ class TestSigmoidCudnnCall(unittest.TestCase):
         return functions.tanh(x, use_cudnn=self.use_cudnn)
 
     def test_call_cudnn_forward(self):
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
-            patch = 'cupy.cudnn.cudnn.activationForward_v4'
-        else:
-            patch = 'cupy.cudnn.cudnn.activationForward_v3'
-        with mock.patch(patch) as func:
+        default_func = cuda.cupy.cudnn.activation_forward
+        with mock.patch('cupy.cudnn.activation_forward') as func:
+            func.side_effect = default_func
             self.forward()
             self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backward(self):
         y = self.forward()
         y.grad = self.gy
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
-            patch = 'cupy.cudnn.cudnn.activationBackward_v4'
-        else:
-            patch = 'cupy.cudnn.cudnn.activationBackward_v3'
-        with mock.patch(patch) as func:
+        default_func = cuda.cupy.cudnn.activation_backward
+        with mock.patch('cupy.cudnn.activation_backward') as func:
+            func.side_effect = default_func
             y.backward()
             self.assertEqual(func.called, self.expect)
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_tanh.py
@@ -93,22 +93,18 @@ class TestTanhCudnnCall(unittest.TestCase):
         return functions.tanh(x, use_cudnn=self.use_cudnn)
 
     def test_call_cudnn_forward(self):
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
-            patch = 'cupy.cudnn.cudnn.activationForward_v4'
-        else:
-            patch = 'cupy.cudnn.cudnn.activationForward_v3'
-        with mock.patch(patch) as func:
+        default_func = cuda.cupy.cudnn.activation_forward
+        with mock.patch('cupy.cudnn.activation_forward') as func:
+            func.side_effect = default_func
             self.forward()
             self.assertEqual(func.called, self.expect)
 
     def test_call_cudnn_backward(self):
         y = self.forward()
         y.grad = self.gy
-        if cuda.cudnn.cudnn.getVersion() >= 4000:
-            patch = 'cupy.cudnn.cudnn.activationBackward_v4'
-        else:
-            patch = 'cupy.cudnn.cudnn.activationBackward_v3'
-        with mock.patch(patch) as func:
+        default_func = cuda.cupy.cudnn.activation_backward
+        with mock.patch('cupy.cudnn.activation_backward') as func:
+            func.side_effect = default_func
             y.backward()
             self.assertEqual(func.called, self.expect)
 

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -12,20 +12,20 @@ try:
         libcudnn.CUDNN_ACTIVATION_RELU,
         libcudnn.CUDNN_ACTIVATION_TANH,
     ]
+    import cupy.cudnn
 except ImportError:
     cudnn_enabled = False
     modes = []
-import cupy.cudnn
 from cupy import testing
 
 
-@unittest.skipUnless(
-    cudnn_enabled and libcudnn.getVersion() >= 3000,
-    'cuDNN >= 3.0 is supported')
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64],
     'mode': modes,
 }))
+@unittest.skipUnless(
+    cudnn_enabled and libcudnn.getVersion() >= 3000,
+    'cuDNN >= 3.0 is supported')
 class TestCudnnActivation(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -4,18 +4,27 @@ import mock
 import numpy
 
 import cupy
-import cupy.cuda.cudnn as libcudnn
+try:
+    import cupy.cuda.cudnn as libcudnn
+    cudnn_enabled = True
+    modes = [
+        libcudnn.CUDNN_ACTIVATION_SIGMOID,
+        libcudnn.CUDNN_ACTIVATION_RELU,
+        libcudnn.CUDNN_ACTIVATION_TANH,
+    ]
+except ImportError:
+    cudnn_enabled = False
+    modes = []
 import cupy.cudnn
 from cupy import testing
 
 
+@unittest.skipUnless(
+    cudnn_enabled and libcudnn.getVersion() >= 3000,
+    'cuDNN >= 3.0 is supported')
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'mode': [
-        libcudnn.CUDNN_ACTIVATION_SIGMOID,
-        libcudnn.CUDNN_ACTIVATION_RELU,
-        libcudnn.CUDNN_ACTIVATION_TANH,
-    ],
+    'dtype': [numpy.float32, numpy.float64],
+    'mode': modes,
 }))
 class TestCudnnActivation(unittest.TestCase):
 
@@ -25,23 +34,19 @@ class TestCudnnActivation(unittest.TestCase):
         self.g = testing.shaped_arange((3, 4), cupy, self.dtype)
 
     def test_activation_forward_version(self):
-        expect = libcudnn.getVersion() >= 3000 or self.dtype != numpy.float16
-
         if libcudnn.getVersion() >= 4000:
             patch = 'cupy.cuda.cudnn.activationForward_v4'
         else:
             patch = 'cupy.cuda.cudnn.activationForward_v3'
         with mock.patch(patch) as func:
             cupy.cudnn.activation_forward(self.x, self.mode)
-            self.assertEqual(func.called, expect)
+            self.assertEqual(func.called, True)
 
     def test_activation_backward_version(self):
-        expect = libcudnn.getVersion() >= 3000 or self.dtype != numpy.float16
-
         if libcudnn.getVersion() >= 4000:
             patch = 'cupy.cuda.cudnn.activationBackward_v4'
         else:
             patch = 'cupy.cuda.cudnn.activationBakward_v3'
         with mock.patch(patch) as func:
             cupy.cudnn.activation_backward(self.x, self.y, self.g, self.mode)
-            self.assertEqual(func.called, expect)
+            self.assertEqual(func.called, True)

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -1,0 +1,47 @@
+import unittest
+
+import mock
+import numpy
+
+import cupy
+import cupy.cuda.cudnn as libcudnn
+import cupy.cudnn
+from cupy import testing
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'mode': [
+        libcudnn.CUDNN_ACTIVATION_SIGMOID,
+        libcudnn.CUDNN_ACTIVATION_RELU,
+        libcudnn.CUDNN_ACTIVATION_TANH,
+    ],
+}))
+class TestCudnnActivation(unittest.TestCase):
+
+    def setUp(self):
+        self.x = testing.shaped_arange((3, 4), cupy, self.dtype)
+        self.y = testing.shaped_arange((3, 4), cupy, self.dtype)
+        self.g = testing.shaped_arange((3, 4), cupy, self.dtype)
+
+    def test_activation_forward_version(self):
+        expect = libcudnn.getVersion() >= 3000 or self.dtype != numpy.float16
+
+        if libcudnn.getVersion() >= 4000:
+            patch = 'cupy.cuda.cudnn.activationForward_v4'
+        else:
+            patch = 'cupy.cuda.cudnn.activationForward_v3'
+        with mock.patch(patch) as func:
+            cupy.cudnn.activation_forward(self.x, self.mode)
+            self.assertEqual(func.called, expect)
+
+    def test_activation_backward_version(self):
+        expect = libcudnn.getVersion() >= 3000 or self.dtype != numpy.float16
+
+        if libcudnn.getVersion() >= 4000:
+            patch = 'cupy.cuda.cudnn.activationBackward_v4'
+        else:
+            patch = 'cupy.cuda.cudnn.activationBakward_v3'
+        with mock.patch(patch) as func:
+            cupy.cudnn.activation_backward(self.x, self.y, self.g, self.mode)
+            self.assertEqual(func.called, expect)


### PR DESCRIPTION
I splitted a test to check if cudnn is used and a test to check if expected version of API is called. The former one is for chainer test and the later is for cupy.
related to #2413 