### PR TITLE
fix doctest of cupy-reference/testing

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -146,7 +146,7 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
 
     >>> import unittest
     >>> from cupy import testing
-    ... @testing.gpu
+    >>> @testing.gpu
     ... class TestFoo(unittest.TestCase):
     ...
     ...     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
I fixed the doctest of cupy-reference/testing.

The error is below,
```
Document: cupy-reference/testing
--------------------------------
**********************************************************************
File "cupy-reference/testing.rst", line 44, in default
Failed example:
    from cupy import testing
    @testing.gpu
    class TestFoo(unittest.TestCase):

        @testing.numpy_cupy_allclose()
        def test_foo(self, xp):
            # ...
            # Prepare data with xp
            # ...

            xp_result = xp.zeros(10)
            return xp_result
Exception raised:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/site-packages/Sphinx-1.5.1-py3.6.egg/sphinx/ext/doctest.py", line 369, in compile
        return compile(code, name, self.type, flags, dont_inherit)
      File "<doctest default[1]>", line 1
        from cupy import testing
                               ^
    SyntaxError: multiple statements found while compiling a single statement
**********************************************************************
1 items had failures:
   1 of   8 in default
8 tests in 1 items.
7 passed and 1 failed.
***Test Failed*** 1 failures.
```

After this PR, the doctest result will be below,
```
Document: cupy-reference/testing
--------------------------------
1 items passed all tests:
   9 tests in default
9 tests in 1 items.
9 passed and 0 failed.
Test passed.
```