### PR TITLE
fix doctest of docs/source/tutorial/type_check

### DIFF
--- a/docs/source/tutorial/type_check.rst
+++ b/docs/source/tutorial/type_check.rst
@@ -67,7 +67,7 @@ Otherwise this code throws an exception, and the user gets a message like this:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: in_types[0].ndim == 2
+   chainer.utils.type_check.InvalidType: Expect: in_types[0].ndim == 2
    Actual: 3 != 2
 
 This error message means that "``ndim`` of the first argument expected to be ``2``, but actually it is ``3``".
@@ -102,8 +102,8 @@ And an error is like this:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: in_types[0].dtype == <type 'numpy.float64'>
-   Actual: float32 != <type 'numpy.float64'>
+   chainer.utils.type_check.InvalidType: Expect: in_types[0].dtype == <class 'numpy.float64'>
+   Actual: float32 != <class 'numpy.float64'>
 
 You can also check ``kind`` of ``dtype``.
 This code checks if the type is floating point
@@ -162,7 +162,7 @@ When ``x_type.shape[0] == 3`` and ``y_type.shape[0] == 1``, users can get the er
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: in_types[0].shape[0] == in_types[1].shape[0] * 4
+   chainer.utils.type_check.InvalidType: Expect: in_types[0].shape[0] == in_types[1].shape[0] * 4
    Actual: 3 != 4
 
 
@@ -222,7 +222,7 @@ The above example produces an error message like this:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: sum(in_types[0].shape) == 10
+   chainer.utils.type_check.InvalidType: Expect: sum(in_types[0].shape) == 10
    Actual: 7 != 10
 
 
@@ -255,7 +255,7 @@ This code generates the following error message:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: Shape is expected to be ...
+   chainer.utils.type_check.InvalidType: Expect: Shape is expected to be ...
    Actual: Shape is ...
 
 


### PR DESCRIPTION
Before the PR, the doctest result is
```
Document: tutorial/type_check
-----------------------------
**********************************************************************
File "tutorial/type_check.rst", line 117, in default
Failed example:
    utils.type_check.expect(x_type.ndim == 2)
Expected:
    Traceback (most recent call last):
    ...
    InvalidType: Expect: in_types[0].ndim == 2
    Actual: 3 != 2
Got:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 1, in <module>
        utils.type_check.expect(x_type.ndim == 2)
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 487, in expect
        expr.expect()
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 449, in expect
        '{0} {1} {2}'.format(left, self.inv, right))
    chainer.utils.type_check.InvalidType: Expect: in_types[0].ndim == 2
    Actual: 3 != 2
**********************************************************************
File "tutorial/type_check.rst", line 189, in default
Failed example:
    utils.type_check.expect(x_type.dtype == np.float64)
Expected:
    Traceback (most recent call last):
    ...
    InvalidType: Expect: in_types[0].dtype == <type 'numpy.float64'>
    Actual: float32 != <type 'numpy.float64'>
Got:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 1, in <module>
        utils.type_check.expect(x_type.dtype == np.float64)
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 487, in expect
        expr.expect()
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 449, in expect
        '{0} {1} {2}'.format(left, self.inv, right))
    chainer.utils.type_check.InvalidType: Expect: in_types[0].dtype == <class 'numpy.float64'>
    Actual: float32 != <class 'numpy.float64'>
**********************************************************************
File "tutorial/type_check.rst", line 309, in default
Failed example:
    utils.type_check.expect(x_type.shape[0] == y_type.shape[0] * 4)
Expected:
    Traceback (most recent call last):
    ...
    InvalidType: Expect: in_types[0].shape[0] == in_types[1].shape[0] * 4
    Actual: 3 != 4
Got:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 1, in <module>
        utils.type_check.expect(x_type.shape[0] == y_type.shape[0] * 4)
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 487, in expect
        expr.expect()
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 449, in expect
        '{0} {1} {2}'.format(left, self.inv, right))
    chainer.utils.type_check.InvalidType: Expect: in_types[0].shape[0] == in_types[1].shape[0] * 4
    Actual: 3 != 4
**********************************************************************
File "tutorial/type_check.rst", line 417, in default
Failed example:
    sum = utils.type_check.Variable(np.sum, 'sum')
    utils.type_check.expect(sum(x_type.shape) == 10)
Expected:
    Traceback (most recent call last):
    ...
    InvalidType: Expect: sum(in_types[0].shape) == 10
    Actual: 7 != 10
Got:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 2, in <module>
        utils.type_check.expect(sum(x_type.shape) == 10)
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 487, in expect
        expr.expect()
      File "/home/kumezawa/dev/chainer/chainer/utils/type_check.py", line 449, in expect
        '{0} {1} {2}'.format(left, self.inv, right))
    chainer.utils.type_check.InvalidType: Expect: sum(in_types[0].shape) == 10
    Actual: 7 != 10
**********************************************************************
File "tutorial/type_check.rst", line 485, in default
Failed example:
    x_shape = x_type.shape.eval()  # get actual shape (int tuple)
    if not more_complicated_condition(x_shape):
        expect_msg = 'Shape is expected to be ...'
        actual_msg = 'Shape is ...'
        raise utils.type_check.InvalidType(expect_msg, actual_msg)
Expected:
    Traceback (most recent call last):
    ...
    InvalidType: Expect: Shape is expected to be ...
    Actual: Shape is ...
Got:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 5, in <module>
        raise utils.type_check.InvalidType(expect_msg, actual_msg)
    chainer.utils.type_check.InvalidType: Expect: Shape is expected to be ...
    Actual: Shape is ...
**********************************************************************
1 items had failures:
   5 of  19 in default
19 tests in 1 items.
14 passed and 5 failed.
***Test Failed*** 5 failures.
```

After the PR, the result is
```
Document: tutorial/type_check
-----------------------------
1 items passed all tests:
  19 tests in default
19 tests in 1 items.
19 passed and 0 failed.
Test passed.
```