### PR TITLE
fix doctest of cupy/prof/time_range.py

### DIFF
--- a/cupy/prof/time_range.py
+++ b/cupy/prof/time_range.py
@@ -8,6 +8,7 @@ from cupy.cuda import nvtx  # NOQA
 def time_range(message, color_id=None, argb_color=None):
     """A context manager to describe the enclosed block as a nested range
 
+    >>> from cupy import prof
     >>> with cupy.prof.time_range('some range in green', color_id=0):
     ...    # do something you want to measure
     ...    pass
@@ -40,6 +41,7 @@ class TimeRangeDecorator(object):
 
     Decorated function calls are marked as ranges in NVIDIA profiler timeline.
 
+    >>> from cupy import prof
     >>> @cupy.prof.TimeRangeDecorator()
     ... def function_to_profile():
     ...     pass


### PR DESCRIPTION
Before the PR, the doctest result is
```
Document: cupy-reference/prof
-----------------------------
**********************************************************************
File "cupy-reference/prof.rst", line 8, in default
Failed example:
    @cupy.prof.TimeRangeDecorator()
    def function_to_profile():
        pass
Exception raised:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 1, in <module>
        @cupy.prof.TimeRangeDecorator()
    AttributeError: module 'cupy' has no attribute 'prof'
**********************************************************************
File "cupy-reference/prof.rst", line 6, in default
Failed example:
    with cupy.prof.time_range('some range in green', color_id=0):
       # do something you want to measure
       pass
Exception raised:
    Traceback (most recent call last):
      File "/home/kumezawa/.pyenv/versions/anaconda3-4.3.0/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 1, in <module>
        with cupy.prof.time_range('some range in green', color_id=0):
    AttributeError: module 'cupy' has no attribute 'prof'
**********************************************************************
1 items had failures:
   2 of   2 in default
2 tests in 1 items.
0 passed and 2 failed.
***Test Failed*** 2 failures.
```

After the PR, the result is
```
Document: cupy-reference/prof
-----------------------------
1 items passed all tests:
   3 tests in default
3 tests in 1 items.
3 passed and 0 failed.
Test passed.
```