### PR TITLE
Stop installing chainer on python 3.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,22 @@
 #!/usr/bin/env python
 
+import os
 from setuptools import setup
+import sys
 
 import chainer_setup_build
+
+
+if sys.version_info[:3] == (3, 5, 0):
+    if not int(os.getenv('CHAINER_PYTHON_350_FORCE', '0')):
+        msg = """
+Chainer does not work with Python 3.5.0.
+
+We strongly recommend to use another version of Python.
+If you want to use Chainer with Python 3.5.0 at your own risk,
+set 1 to CHAINER_PYTHON_350_FORCE environment variable."""
+        print(msg)
+        sys.exit(1)
 
 
 setup_requires = []


### PR DESCRIPTION
fixes #1659 