### PR TITLE
Skip sqrt test with old numpy

### DIFF
--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -761,7 +761,9 @@ class TestFusionMisc(unittest.TestCase):
         ty = numpy.dtype(dtype).type
         return g(a, ty(3), ty(13))
 
+    @testing.with_requires('numpy>=1.11.2')
     def test_sqrt(self):
+        # numpy.sqrt is broken in numpy<1.11.2
         self.check_unary('sqrt')
 
     def test_square(self):


### PR DESCRIPTION
sqrt function in old numpy is broken. Cupy obeys newer one.