### PR TITLE
Implement aggressive buffer release

### DIFF
--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -32,6 +32,7 @@ class ReLU(function.Function):
         if (chainer.should_use_cudnn('==always') and
                 x[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
+            print('cudnn forward')
             y = cudnn.activation_forward(x[0], _mode)
             self.y = y
         else:
@@ -45,6 +46,7 @@ class ReLU(function.Function):
         if (chainer.should_use_cudnn('==always') and
                 x[0].flags.c_contiguous and gy[0].flags.c_contiguous and
                 (_cudnn_version >= 3000 or x[0].dtype != numpy.float16)):
+            print('cudnn backward')
             gx = cudnn.activation_backward(x[0], self.y, gy[0], _mode)
         else:
             gx = cuda.elementwise(

--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -48,7 +48,9 @@ class Concat(function.Function):
         if len(xs) == 1:
             return gy
 
-        sizes = numpy.array([shape[self.axis] for shape in self._x_shapes[:-1]]).cumsum()
+        sizes = numpy.array(
+            [shape[self.axis] for shape in self._x_shapes[:-1]]
+        ).cumsum()
         return self._xp.split(gy[0], sizes, axis=self.axis)
 
 

--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -39,16 +39,17 @@ class Concat(function.Function):
                 type_check.expect(in_types[0].shape[d] == in_types[i].shape[d])
 
     def forward(self, xs):
-        xp = cuda.get_array_module(*xs)
-        return xp.concatenate(xs, axis=self.axis),
+        self.retain_inputs(())
+        self._xp = cuda.get_array_module(*xs)
+        self._x_shapes = [x.shape for x in xs]
+        return self._xp.concatenate(xs, axis=self.axis),
 
     def backward(self, xs, gy):
         if len(xs) == 1:
             return gy
 
-        xp = cuda.get_array_module(*xs)
-        sizes = numpy.array([x.shape[self.axis] for x in xs[:-1]]).cumsum()
-        return xp.split(gy[0], sizes, axis=self.axis)
+        sizes = numpy.array([shape[self.axis] for shape in self._x_shapes[:-1]]).cumsum()
+        return self._xp.split(gy[0], sizes, axis=self.axis)
 
 
 def concat(xs, axis=1):

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -56,6 +56,7 @@ class Neg(function.Function):
         type_check.expect(in_types.size() == 1)
 
     def forward(self, x):
+        self.retain_inputs(())
         return utils.force_array(-x[0]),
 
     def backward(self, x, gy):
@@ -118,6 +119,7 @@ class Add(function.Function):
         )
 
     def forward(self, x):
+        self.retain_inputs(())
         y = utils.force_array(x[0] + x[1])
         return y,
 
@@ -138,6 +140,7 @@ class AddConstant(function.Function):
         type_check.expect(in_types.size() == 1)
 
     def forward(self, x):
+        self.retain_inputs(())
         value = _preprocess_const(x[0], self.value)
         return utils.force_array(x[0] + value),
 
@@ -171,6 +174,7 @@ class Sub(function.Function):
         )
 
     def forward(self, x):
+        self.retain_inputs(())
         return utils.force_array(x[0] - x[1]),
 
     def backward(self, x, gy):
@@ -203,6 +207,7 @@ class SubFromConstant(function.Function):
         type_check.expect(in_types.size() == 1)
 
     def forward(self, x):
+        self.retain_inputs(())
         value = _preprocess_const(x[0], self.value)
         return utils.force_array(value - x[0]),
 
@@ -260,6 +265,7 @@ class MulConstant(function.Function):
         return utils.force_array(value * x[0]),
 
     def backward(self, x, gy):
+        # TODO(beam2d): Make it not use the input
         value = _preprocess_const(x[0], self.value)
         return utils.force_array(value * gy[0]),
 
@@ -343,6 +349,7 @@ class DivFromConstant(function.Function):
         return utils.force_array(-value * gy[0] / (x[0] ** 2)),
 
     def backward_gpu(self, x, gy):
+        # TODO(beam2d): Make it not use the input
         value = _preprocess_const(x[0], self.value)
         gx = cuda.elementwise('T x, T gy, T value', 'T gx',
                               'gx = -value * gy / (x * x)',
@@ -462,6 +469,7 @@ class PowConstVar(function.Function):
         return self.y,
 
     def backward_cpu(self, x, gy):
+        # TODO(beam2d): Make it not use the input
         value = _preprocess_const(x[0], self.value)
         return utils.force_array(
             numpy.log(value, dtype=x[0].dtype) * self.y * gy[0]),
@@ -520,12 +528,14 @@ class MatMulVarConst(function.Function):
         )
 
     def forward(self, x):
+        self.retain_inputs(())
+        self._x_shape = x[0].shape
         return _matmul._matmul(x[0], self.value),
 
     def backward(self, x, gy):
         gx0 = _matmul._matmul(
             gy[0], self.value, transb=True, transout=False
-        ).reshape(x[0].shape)
+        ).reshape(self._x_shape)
         return gx0,
 
 
@@ -554,12 +564,14 @@ class MatMulConstVar(function.Function):
         )
 
     def forward(self, x):
+        self.retain_inputs(())
+        self._x_shape = x[0].shape
         return _matmul._matmul(self.value, x[0]),
 
     def backward(self, x, gy):
         gx1 = _matmul._matmul(
             self.value, gy[0], transa=True, transout=False
-        ).reshape(x[0].shape)
+        ).reshape(self._x_shape)
         return gx1,
 
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -92,6 +92,7 @@ class VariableNode(object):
         name (str): Name of the variable node.
 
     """
+
     def __init__(self, variable, grad=None):
         self._variable = weakref.ref(variable)
         self._creator = None

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -3,6 +3,7 @@ import copy
 import heapq
 import traceback
 import warnings
+import weakref
 
 import numpy
 import six
@@ -37,6 +38,9 @@ https://github.com/pfnet/chainer/issues/new.
         detail += message
         return detail
 
+    if x.data is None or gx is None:
+        # ``x.data is None`` implies that the data array is not retained
+        return
     if not isinstance(gx, type(x.data)):
         msg = ('Type of data and grad mismatch\n%s != %s' %
                (type(x.data), type(gx)))
@@ -51,6 +55,139 @@ https://github.com/pfnet/chainer/issues/new.
         raise ValueError(make_message(msg))
 
 
+class VariableNode(object):
+
+    """Node in the backward computational graph representing a variable.
+
+    This object represents a variable node in a computational graph. The node
+    is used in error backpropagation (a.k.a. backprop) to determine which
+    gradient to be passed to each function.
+
+    A variable node is held by the corresponding :class:`Variable` object,
+    which is managed by users. :class:`Function` objects that take the variable
+    as an input also hold references to the variable node.
+
+    Note that the node does not hold a reference to the corresponding data
+    array in general. The data array is actually accessible by the node in the
+    following cases.
+
+    1. If there exists a :class:`Variable` object that holds a reference to the
+       variable node, the variable node holds a weak reference to the variable
+       object, and thus the data array is accessible via the weak reference.
+    2. If :meth:`retain_data` is called, the node holds a reference to the data
+       array. It is mainly called by a function that needs the input or output
+       data array in its backprop procedure. See :meth:`Function.retain_inputs`
+       and :meth:`Function.retain_outputs` for more details.
+
+    Users usually do not need to touch this variable node object. The
+    computational graph is automatically managed by Chainer, and any interface
+    that is beneficial for users is also provided by :class:`Variable`.
+
+    Args:
+        variable (Variable): The corresponding variable object.
+
+    Attributes:
+        dtype: Data type of the data array.
+        shape: Shape of the data array.
+        name (str): Name of the variable node.
+
+    """
+    def __init__(self, variable, grad=None):
+        self._variable = weakref.ref(variable)
+        self._creator = None
+        self._data = None
+        self._rank = 0
+        self.name = variable.name
+
+        vdata = variable.data
+        if vdata is not None:
+            self._set_data_type(vdata)
+        else:
+            self.dtype = None
+            self.shape = None
+
+        self.grad = grad
+
+    @property
+    def creator(self):
+        """Function node that created this variable node."""
+        return self._creator
+
+    @property
+    def data(self):
+        """Data array of the corresponding variable.
+
+        If the data is not available, it returns ``None``.
+
+        """
+        return self._data
+
+    @data.setter
+    def data(self, d):
+        self._data = d
+        if d is not None:
+            self._set_data_type(d)
+
+    @property
+    def grad(self):
+        """Gradient array of the corresponding variable."""
+        return self._grad
+
+    @grad.setter
+    def grad(self, g):
+        _check_grad_type(None, self, g)
+        self._grad = g
+
+    @property
+    def label(self):
+        """Short text that represents the variable node."""
+        if self.shape == ():
+            return str(self.dtype)
+        return '(%s), %s' % (', '.join(map(str, self.shape)),
+                             str(self.dtype))
+
+    @property
+    def rank(self):
+        return self._rank
+
+    def set_creator(self, creator):
+        """Sets a :class:`Function` object that created this node.
+
+        Args:
+            creator (Function): Function object that created this node.
+
+        """
+        self._creator = creator
+        self._rank = creator.rank + 1
+
+    def unchain(self):
+        """Deletes the reference to the creator of this variable node."""
+        self._creator = None
+
+    def retain_data(self):
+        """Lets the node hold a reference to the underlying data array.
+
+        This method gets the data array of the corresponding variable and keeps
+        it. If the weak reference to the corresponding variable is dead, it
+        raises an error.
+
+        """
+        variable = self._variable()
+        if variable is not None:
+            self.data = variable.data
+        else:
+            raise RuntimeError('cannot retain variable data: the variable has '
+                               'been already released')
+
+    def _set_data_type(self, d):
+        self.dtype = d.dtype
+        self.shape = d.shape
+
+    def _set_grad_with_check(self, g, func, var):
+        _check_grad_type(func, var, g)
+        self._grad = g
+
+
 class Variable(object):
 
     """Array with a structure to keep track of computation.
@@ -58,13 +195,12 @@ class Variable(object):
     Every variable holds a data array of type either :class:`numpy.ndarray` or
     :class:`cupy.ndarray`.
 
-    A Variable object may be constructed in two ways: by the user or by some
-    function. When a variable is created by some function as one of its
-    outputs, the variable holds a reference to that function. This reference is
-    used in error backpropagation (a.k.a. backprop). It is also used in
-    *backward unchaining*. A variable that does not hold a reference to its
-    creator is called a *root* variable. A variable is root if it is created by
-    the user, or if the reference is deleted by :meth:`unchain_backward`.
+    A variable object holds a data array and a :class:`VariableNode` object of
+    a computational graph. If the variable is constructed by the user, the node
+    is _root_ and does not hold any parent. If the variable is constructed by a
+    :class:`Function` object, the node holds a reference to its parent called
+    `creator`. This reference is used in backpropagation to backtrack the
+    graph.
 
     Users can disable (resp. enable) this chaining behavior by calling
     :func:`~chainer.no_backprop_mode` (resp.
@@ -110,21 +246,19 @@ Actual: {0}'''.format(type(data))
         # Use a list as a data structure to hold the data array indirectly to
         # abstract its initialized/uninitialized state.
         self._data = [data]
-
-        self.rank = 0
-
-        self._grad = grad
-        self.creator = None
-
         self.name = name
+
+        self._node = VariableNode(self, grad)
 
     def __copy__(self):
         copied = Variable()
         copied.__dict__ = copy.copy(self.__dict__)
+        copied._node = VariableNode(copied)
         return copied
 
     def __reduce__(self):
-        return Variable, (self.data, self.name, self._grad)
+        return Variable, (self.data, self.name, self._node._grad,
+                          self.initializer)
 
     def __repr__(self):
         if self.name:
@@ -188,10 +322,11 @@ Actual: {0}'''.format(type(data))
     @property
     def label(self):
         """Short text that represents the variable."""
-        if self.data.shape == ():
-            return str(self.data.dtype)
-        return '(%s), %s' % (', '.join(map(str, self.data.shape)),
-                             str(self.data.dtype))
+        return self._node.label
+
+    @property
+    def creator(self):
+        return self._node._creator
 
     @property
     def data(self):
@@ -200,16 +335,15 @@ Actual: {0}'''.format(type(data))
     @data.setter
     def data(self, d):
         self._data[0] = d
+        self._node._set_data_type(d)
 
     @property
     def grad(self):
-        return self._grad
+        return self._node._grad
 
     @grad.setter
     def grad(self, g):
-        if g is not None:
-            _check_grad_type(None, self, g)
-        self._grad = g
+        self._node._set_grad_with_check(g, None, self)
 
     @property
     def shape(self):
@@ -227,14 +361,26 @@ Actual: {0}'''.format(type(data))
     def dtype(self):
         return self.data.dtype
 
+    @property
+    def rank(self):
+        return self._node.rank
+
+    @property
+    def node(self):
+        return self._node
+
     def to_cpu(self):
         """Copies the data and gradient arrays to CPU."""
         if self.data is None:
             self._initial_device = -1
         else:
             self._data = [cuda.to_cpu(self.data)]
-            if self._grad is not None:
-                self._grad = cuda.to_cpu(self._grad)
+            # ensure that the node tracks the device migration
+            node = self._node
+            if node._data is not None:
+                node.retain_data()
+            if node._grad is not None:
+                node._grad = cuda.to_cpu(node._grad)
 
     def to_gpu(self, device=None):
         """Copies the data and gradient arrays to specified GPU.
@@ -250,12 +396,16 @@ Actual: {0}'''.format(type(data))
         else:
             with cuda.get_device(device):
                 self._data = [cuda.to_gpu(self.data)]
-                if self._grad is not None:
-                    self._grad = cuda.to_gpu(self._grad)
+                # ensure that the node tracks the device migration
+                node = self._node
+                if node._data is not None:
+                    node.retain_data()
+                if node._grad is not None:
+                    node._grad = cuda.to_gpu(node._grad)
 
     def cleargrad(self):
         """Clears the gradient array."""
-        self._grad = None
+        self._node._grad = None
         if self.data is None:
             self._grad_initializer = None
 
@@ -276,11 +426,12 @@ Actual: {0}'''.format(type(data))
             return
 
         with cuda.get_device(self.data) as dev:
-            if self._grad is None:
+            node = self._node
+            if node._grad is None:
                 xp = numpy if int(dev) == -1 else cuda.cupy
-                self._grad = xp.zeros_like(self.data)
+                node._grad = xp.zeros_like(self.data)
             else:
-                self._grad.fill(0)
+                node._grad.fill(0)
 
     def copydata(self, var):
         """Copies the data array from given source variable.
@@ -330,13 +481,13 @@ Actual: {0}'''.format(type(data))
             var (Variable): Source variable.
 
         """
-        src = var._grad
+        src = var._node._grad
         if src is None:
             return
 
         if self.data is None:
             self.initialize(var.shape)
-        dst = self._grad
+        dst = self._node._grad
 
         src_dev = cuda.get_device(src)
         dst_dev = cuda.get_device(self.data)
@@ -345,9 +496,9 @@ Actual: {0}'''.format(type(data))
             with dst_dev:
                 if dst is None:
                     xp = cuda.get_array_module(src)
-                    self._grad = xp.copy(src)
+                    self._node.grad = xp.copy(src)
                 else:
-                    self._grad += src
+                    dst += src
             return
 
         if dst_dev.id < 0:
@@ -356,10 +507,10 @@ Actual: {0}'''.format(type(data))
             src_grad = cuda.to_gpu(src, device=dst_dev)
 
         if dst is None:
-            self._grad = src_grad
+            self._node.grad = src_grad
         else:
             with dst_dev:
-                self._grad += src_grad
+                dst += src_grad
 
     def set_creator(self, gen_func):
         """Notifies the variable that the given function is its creator.
@@ -369,8 +520,7 @@ Actual: {0}'''.format(type(data))
                 one of its outputs.
 
         """
-        self.creator = gen_func
-        self.rank = gen_func.rank + 1
+        self._node.set_creator(gen_func)
 
     def backward(self, retain_grad=False):
         """Runs error backpropagation (a.k.a. backprop) from this variable.
@@ -378,10 +528,10 @@ Actual: {0}'''.format(type(data))
         On backprop, :meth:`Function.backward` is called on each
         :class:`Function` object appearing in the backward graph starting from
         this variable. The backward graph is represented by backward references
-        from variables to their creators, and from functions to their inputs.
-        The backprop stops at all root variables. Some functions set ``None``
-        as gradients of some inputs, where further backprop does not take place
-        at such input variables.
+        from variable nodes to their creators, and from functions to their
+        input variable nodes. The backprop stops at all root nodes. Some
+        functions set ``None`` as gradients of some inputs, where further
+        backprop does not take place at such inputs.
 
         This method uses :data:`grad` as the initial error array. User can
         manually set a gradient array before calling this method. If
@@ -397,8 +547,8 @@ Actual: {0}'''.format(type(data))
                 timing, which may reduce the maximum memory consumption.
 
                 In most cases of training some models, the purpose of backprop
-                is to compute gradients of parameters, not of variables, so it
-                is recommended to set this flag ``False``.
+                is to compute gradients of parameters, not of all variables,
+                and therefore it is recommended to set this flag ``False``.
 
         """
         if self.creator is None:
@@ -464,7 +614,7 @@ Actual: {0}'''.format(type(data))
 
             if not retain_grad:
                 for y in outputs:
-                    if y is not None and y is not self:
+                    if y is not None and y is not self.node:
                         y.grad = None
             for x, gx in zip(func.inputs, gxs):
                 if gx is None:
@@ -482,7 +632,7 @@ Actual: {0}'''.format(type(data))
                     else:
                         cuda.get_device(gx).use()
                         if id_x in need_copy:
-                            x.grad = utils.force_array(x.grad + gx)  # copy
+                            x.grad = utils.force_array(x._grad + gx)  # copy
                             need_copy.remove(id_x)
                         else:
                             x._grad += gx
@@ -495,7 +645,7 @@ Actual: {0}'''.format(type(data))
                     else:
                         cuda.get_device(gx).use()
                         if id_x in need_copy:  # 2nd visit
-                            x._grad = utils.force_array(gx + x._grad)  # copied
+                            x.grad = utils.force_array(gx + x._grad)  # copied
                             need_copy.remove(id_x)
                         else:  # 3rd or later visit
                             x._grad += gx
@@ -526,15 +676,25 @@ Actual: {0}'''.format(type(data))
             axes = axes[0]
         return chainer.functions.transpose(self, axes)
 
-    def unchain_backward(self):
-        """Deletes references between variables and functions backward.
+    def unchain(self):
+        """Deletes the reference to the creator of this variable.
 
-        After this method completes, intermediate variables and functions that
-        are not referenced from anywhere are deallocated by reference
+        This method deletes the reference to the creator from the corresponding
+        variable node. Unlike :meth:`unchain_backward`, it does not backtrack
+        the graph.
+
+        """
+        self._node.unchain()
+
+    def unchain_backward(self):
+        """Deletes references between variable nodes and functions backward.
+
+        After this method completes, intermediate variable nodes and functions
+        that are not referenced from anywhere are deallocated by reference
         count GC. Also this variable itself deletes the reference to its
-        creator function, i.e. this variable becomes root in the computation
-        graph. It indicates that backprop after unchaining stops at this
-        variable. This behavior is useful to implement truncated BPTT.
+        creator function from the node, i.e. the node becomes root in the
+        computation graph. It indicates that backprop after unchaining stops at
+        this variable. This behavior is useful to implement truncated BPTT.
 
         """
         cand_funcs = []
@@ -576,7 +736,11 @@ Actual: {0}'''.format(type(data))
                 grad = cuda.to_gpu(grad, device=self._initial_device)
 
         self._data[0] = data
-        self.grad = grad
+        self._node._grad = grad
+
+    def retain_data(self):
+        """Lets the corresponding variable node keep the underlying array."""
+        self._node.data = self._data[0]
 
     def __lt__(self, other):
         raise NotImplementedError()

--- a/tests/chainer_tests/function_hooks_tests/test_debug_print.py
+++ b/tests/chainer_tests/function_hooks_tests/test_debug_print.py
@@ -57,7 +57,7 @@ class TestPrintHookToFunction(unittest.TestCase):
         self.f(chainer.Variable(self.x))
 
     @attr.gpu
-    def test_fowward_gpu(self):
+    def test_forward_gpu(self):
         self.f(chainer.Variable(cuda.to_gpu(self.x)))
 
     def test_backward_cpu(self):

--- a/tests/chainer_tests/test_computational_graph.py
+++ b/tests/chainer_tests/test_computational_graph.py
@@ -149,12 +149,12 @@ class TestGraphBuilder5(unittest.TestCase):
     def test_edges(self):
         self.assertEqual(len(self.g.edges), 2)
         self.assertSetEqual(set(self.g.edges),
-                            {(self.x, self.f), (self.f, self.y)})
+                            {(self.x.node, self.f), (self.f, self.y.node)})
 
     def test_nodes(self):
         self.assertEqual(len(self.g.nodes), 3)
         self.assertSetEqual(set(self.g.nodes),
-                            {self.x, self.f, self.y})
+                            {self.x.node, self.f, self.y.node})
 
 
 class TestGraphBuilder6(unittest.TestCase):
@@ -169,14 +169,14 @@ class TestGraphBuilder6(unittest.TestCase):
     def test_edges(self):
         self.assertEqual(len(self.g.edges), 3)
         self.assertSetEqual(set(self.g.edges),
-                            {(self.x1, self.f),
-                             (self.x2, self.f),
-                             (self.f, self.y)})
+                            {(self.x1.node, self.f),
+                             (self.x2.node, self.f),
+                             (self.f, self.y.node)})
 
     def test_nodes(self):
         self.assertEqual(len(self.g.nodes), 4)
         self.assertSetEqual(set(self.g.nodes),
-                            {self.x1, self.x2, self.f, self.y})
+                            {self.x1.node, self.x2.node, self.f, self.y.node})
 
 
 class TestGraphBuilder7(unittest.TestCase):


### PR DESCRIPTION
Fix #2368. This PR implements the aggressive buffer release. It only implements the core part and memory reduction for some commonly used functions (`relu`, some arithmetics, `concat`, and `split_axis`). I tried to carefully design the API so that most existing codes will not be affected, but it actually breaks the backward compatibility and may break codes that touch computational graphs.

I quickly compared the memory consumption of the ImageNet example between this branch and Chainer v1.22. I used a batch size of 32 for both training and validation. The following is their GPU memory usage obtained by `nvidia-smi` command kicked during training. Note that I used cuDNN 5.1.3 (EDIT: and used the default workspace size of 8MB). This PR effectively reduces the memory usage. In particular, it is reduced by a factor of 1/3 for ResNet.

architecture | v1.22.0 | v2-abr | ratio
------------ | ------- | ------ | -----
nin | 1233 MB | 910 MB | 74.6%
googlenetbn | 3485 MB | 2959 MB | 84.9%
resnet50 | 5835 MB | 3868 MB | 66.3%

(As for ResNet50, I used an implementation of @yasunorikudo https://github.com/yasunorikudo/chainer-ResNet/blob/master/ResNet50.py with some minor modifications for v2.)

Thank you @jekbradbury, @okuta, and @unnonouno for helpful discussions. The basic idea is inspired by the internal design of [PyTorch](https://github.com/pytorch/pytorch).

Note: this PR depends on #2356, so please merge that first.