### PR TITLE
Add type check to functions/connection/*

### DIFF
--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -51,10 +51,10 @@ class BilinearFunction(function.Function):
         e2 = array.as_mat(inputs[1])
         W = inputs[2]
 
-        if(not type_check.same_types(*inputs)):
+        if not type_check.same_types(*inputs):
             raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): %s, type(e1): %s, type(e2): %s'
-                             % (type(W), type(e1), type(e2)))
+                             'type(W): {0}, type(e1): {1}, type(e2): {2}'
+                             .format(type(W), type(e1), type(e2)))
 
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -83,10 +83,10 @@ class BilinearFunction(function.Function):
         e2 = array.as_mat(inputs[1])
         W = inputs[2]
 
-        if(not type_check.same_types(*inputs)):
+        if not type_check.same_types(*inputs):
             raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): %s, type(e1): %s, type(e2): %s'
-                             % (type(W), type(e1), type(e2)))
+                             'type(W): {0}, type(e1): {1}, type(e2): {2}'
+                             .format(type(W), type(e1), type(e2)))
 
         gy = grad_outputs[0]
 

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -51,6 +51,11 @@ class BilinearFunction(function.Function):
         e2 = array.as_mat(inputs[1])
         W = inputs[2]
 
+        if(not type_check.same_types(*inputs)):
+            raise ValueError('numpy and cupy must not be used together\n'
+                             'type(W): %s, type(e1): %s, type(e2): %s'
+                             % (type(W), type(e1), type(e2)))
+
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:
             y = numpy.einsum('ij,ik,jkl->il', e1, e2, W)
@@ -77,6 +82,12 @@ class BilinearFunction(function.Function):
         e1 = array.as_mat(inputs[0])
         e2 = array.as_mat(inputs[1])
         W = inputs[2]
+
+        if(not type_check.same_types(*inputs)):
+            raise ValueError('numpy and cupy must not be used together\n'
+                             'type(W): %s, type(e1): %s, type(e2): %s'
+                             % (type(W), type(e1), type(e2)))
+
         gy = grad_outputs[0]
 
         xp = cuda.get_array_module(*inputs)

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -63,6 +63,17 @@ class Convolution2DFunction(function.Function):
     def forward_cpu(self, inputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         kh, kw = W.shape[2:]
         self.col = conv.im2col_cpu(
             x, kh, kw, self.sy, self.sx, self.ph, self.pw,
@@ -76,6 +87,16 @@ class Convolution2DFunction(function.Function):
     def forward_gpu(self, inputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
 
         out_c, _, kh, kw = W.shape
         n, c, h, w = x.shape
@@ -145,6 +166,17 @@ class Convolution2DFunction(function.Function):
     def backward_cpu(self, inputs, grad_outputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         gy = grad_outputs[0]
         h, w = x.shape[2:]
 
@@ -163,6 +195,17 @@ class Convolution2DFunction(function.Function):
     def backward_gpu(self, inputs, grad_outputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         gy = grad_outputs[0]
         _, out_c, out_h, out_w = gy.shape
         n, c, h, w = x.shape

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -64,15 +64,15 @@ class Convolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         kh, kw = W.shape[2:]
         self.col = conv.im2col_cpu(
@@ -88,15 +88,15 @@ class Convolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         out_c, _, kh, kw = W.shape
         n, c, h, w = x.shape
@@ -167,15 +167,15 @@ class Convolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         gy = grad_outputs[0]
         h, w = x.shape[2:]
@@ -196,15 +196,15 @@ class Convolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         gy = grad_outputs[0]
         _, out_c, out_h, out_w = gy.shape

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -161,15 +161,15 @@ class ConvolutionND(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:
@@ -289,15 +289,15 @@ class ConvolutionND(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         gy = grad_outputs[0]    # (n, c_O, out_1, out_2, ..., out_N)
 

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -161,6 +161,16 @@ class ConvolutionND(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:
             return self._forward_xp(x, W, b, numpy)
@@ -278,6 +288,17 @@ class ConvolutionND(function.Function):
     def backward(self, inputs, grad_outputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         gy = grad_outputs[0]    # (n, c_O, out_1, out_2, ..., out_N)
 
         xp = cuda.get_array_module(*inputs)

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -75,15 +75,15 @@ class Deconvolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         kh, kw = W.shape[2:]
         _, _, h, w = x.shape
@@ -110,15 +110,15 @@ class Deconvolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         kh, kw = W.shape[2:]
         n, in_c, in_h, in_w = x.shape
@@ -197,15 +197,15 @@ class Deconvolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         gy = grad_outputs[0]
         kh, kw = W.shape[2:]
@@ -227,15 +227,15 @@ class Deconvolution2DFunction(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         gy = grad_outputs[0]
         n, in_c, in_h, in_w = x.shape

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -74,6 +74,17 @@ class Deconvolution2DFunction(function.Function):
     def forward_cpu(self, inputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         kh, kw = W.shape[2:]
         _, _, h, w = x.shape
         gcol = numpy.tensordot(W, x, (0, 1)).astype(x.dtype, copy=False)
@@ -98,6 +109,17 @@ class Deconvolution2DFunction(function.Function):
     def forward_gpu(self, inputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         kh, kw = W.shape[2:]
         n, in_c, in_h, in_w = x.shape
         c = W.shape[1]  # out_c
@@ -174,6 +196,17 @@ class Deconvolution2DFunction(function.Function):
     def backward_cpu(self, inputs, grad_outputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         gy = grad_outputs[0]
         kh, kw = W.shape[2:]
         col = conv.im2col_cpu(
@@ -193,6 +226,17 @@ class Deconvolution2DFunction(function.Function):
     def backward_gpu(self, inputs, grad_outputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         gy = grad_outputs[0]
         n, in_c, in_h, in_w = x.shape
         _, out_channels, kh, kw = W.shape

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -175,6 +175,16 @@ class DeconvolutionND(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:
             return self._forward_xp(x, W, b, numpy)
@@ -287,6 +297,17 @@ class DeconvolutionND(function.Function):
     def backward(self, inputs, grad_outputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if(not type_check.same_types(*inputs)):
+            if b:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s, type(b): %s'
+                                 % (type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): %s, type(x): %s'
+                                 % (type(W), type(x)))
+
         gy = grad_outputs[0]
 
         xp = cuda.get_array_module(*inputs)

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -175,15 +175,15 @@ class DeconvolutionND(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:
@@ -298,15 +298,15 @@ class DeconvolutionND(function.Function):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if(not type_check.same_types(*inputs)):
-            if b:
+        if not type_check.same_types(*inputs):
+            if b is not None:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s, type(b): %s'
-                                 % (type(W), type(x), type(b)))
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
             else:
                 raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): %s, type(x): %s'
-                                 % (type(W), type(x)))
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         gy = grad_outputs[0]
 

--- a/chainer/functions/connection/dilated_convolution_2d.py
+++ b/chainer/functions/connection/dilated_convolution_2d.py
@@ -64,6 +64,17 @@ class DilatedConvolution2DFunction(function.Function):
     def forward_cpu(self, inputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if not type_check.same_types(*inputs):
+            if b is not None:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
+
         kh, kw = W.shape[2:]
         self.col = conv.im2col_cpu(
             x, kh, kw, self.sy, self.sx, self.ph, self.pw,
@@ -77,6 +88,16 @@ class DilatedConvolution2DFunction(function.Function):
     def forward_gpu(self, inputs):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
+
+        if not type_check.same_types(*inputs):
+            if b is not None:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): {0}, type(x): {1}, type(b): {2}'
+                                 .format(type(W), type(x), type(b)))
+            else:
+                raise ValueError('numpy and cupy must not be used together\n'
+                                 'type(W): {0}, type(x): {1}'
+                                 .format(type(W), type(x)))
 
         out_c, _, kh, kw = W.shape
         n, c, h, w = x.shape

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -27,9 +27,10 @@ class EmbedIDFunction(function.Function):
     def forward(self, inputs):
         x, W = inputs
 
-        if(not type_check.same_types(*inputs)):
+        if not type_check.same_types(*inputs):
             raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): %s, type(x): %s' % (type(W), type(x)))
+                             'type(W): {0}, type(x): {1}'
+                             .format(type(W), type(x)))
 
         xp = cuda.get_array_module(*inputs)
         if chainer.is_debug():

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -34,9 +34,10 @@ class LinearFunction(function.Function):
         x = _as_mat(inputs[0])
         W = inputs[1]
 
-        if(not type_check.same_types(*inputs)):
+        if not type_check.same_types(*inputs):
             raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): %s, type(x): %s' % (type(W), type(x)))
+                             'type(W): {0}, type(x): {1}'
+                             .format(type(W), type(x)))
 
         y = x.dot(W.T).astype(x.dtype, copy=False)
         if len(inputs) == 3:
@@ -49,9 +50,10 @@ class LinearFunction(function.Function):
         W = inputs[1]
         gy = grad_outputs[0]
 
-        if(not type_check.same_types(*inputs)):
+        if not type_check.same_types(*inputs):
             raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): %s, type(x): %s' % (type(W), type(x)))
+                             'type(W): {0}, type(x): {1}'
+                             .format(type(W), type(x)))
 
         gx = gy.dot(W).astype(x.dtype, copy=False).reshape(inputs[0].shape)
         gW = gy.T.dot(x).astype(W.dtype, copy=False)

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -33,6 +33,11 @@ class LinearFunction(function.Function):
     def forward(self, inputs):
         x = _as_mat(inputs[0])
         W = inputs[1]
+
+        if(not type_check.same_types(*inputs)):
+            raise ValueError('numpy and cupy must not be used together\n'
+                             'type(W): %s, type(x): %s' % (type(W), type(x)))
+
         y = x.dot(W.T).astype(x.dtype, copy=False)
         if len(inputs) == 3:
             b = inputs[2]
@@ -43,6 +48,10 @@ class LinearFunction(function.Function):
         x = _as_mat(inputs[0])
         W = inputs[1]
         gy = grad_outputs[0]
+
+        if(not type_check.same_types(*inputs)):
+            raise ValueError('numpy and cupy must not be used together\n'
+                             'type(W): %s, type(x): %s' % (type(W), type(x)))
 
         gx = gy.dot(W).astype(x.dtype, copy=False).reshape(inputs[0].shape)
         gW = gy.T.dot(x).astype(W.dtype, copy=False)

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -186,7 +186,7 @@ class NStepLSTM(function.Function):
         bs, inputs = _split(inputs, self.n_layers * 8)
         x_list = inputs
 
-        if(not type_check.same_types(*inputs)):
+        if not type_check.same_types(*inputs):
             raise ValueError('numpy and cupy must not be used together')
 
         hx = cuda.cupy.ascontiguousarray(hx)
@@ -279,7 +279,7 @@ class NStepLSTM(function.Function):
         bs, inputs = _split(inputs, self.n_layers * 8)
         x_list = inputs
 
-        if(not type_check.same_types(*inputs)):
+        if not type_check.same_types(*inputs):
             raise ValueError('numpy and cupy must not be used together')
 
         hx = cuda.cupy.ascontiguousarray(hx)

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -186,6 +186,9 @@ class NStepLSTM(function.Function):
         bs, inputs = _split(inputs, self.n_layers * 8)
         x_list = inputs
 
+        if(not type_check.same_types(*inputs)):
+            raise ValueError('numpy and cupy must not be used together')
+
         hx = cuda.cupy.ascontiguousarray(hx)
         cx = cuda.cupy.ascontiguousarray(cx)
 
@@ -275,6 +278,9 @@ class NStepLSTM(function.Function):
         ws, inputs = _split(inputs, self.n_layers * 8)
         bs, inputs = _split(inputs, self.n_layers * 8)
         x_list = inputs
+
+        if(not type_check.same_types(*inputs)):
+            raise ValueError('numpy and cupy must not be used together')
 
         hx = cuda.cupy.ascontiguousarray(hx)
         cx = cuda.cupy.ascontiguousarray(cx)


### PR DESCRIPTION
Continued from #2255.

Ths PR adds type checking codes to `functions/connection/*.py` to see if numpy and cupy are mixed (and outputs a graceful warning when they are).

I confirmed that all the related tests with @attr.gpu pass in my local environment.