### PR TITLE
Skip itruediv test when numpy 1.9 is installed

### DIFF
--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -994,6 +994,8 @@ class TestFusionFuse(unittest.TestCase):
         res = g(a, b, c)
         return c + res
 
+    # NumPy 1.9 accepts itruediv between integers
+    @testing.with_requires('numpy>=1.10')
     @testing.for_int_dtypes()
     @testing.numpy_cupy_raises()
     def test_fuse_int_itruediv_py3_raises(self, xp, dtype):


### PR DESCRIPTION
itruediv between integer arrays is acceptable in NumPy 1.9. So, i fixed the test to skip this situation.
This problem can be reproduces with python3 and numpy 1.9.