### PR TITLE
Fix strict option in deserializer to support recursive calls

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -95,7 +95,8 @@ class HDF5Deserializer(serializer.Deserializer):
 
     def __getitem__(self, key):
         name = self.group.name + '/' + key
-        return HDF5Deserializer(self.group.require_group(name))
+        return HDF5Deserializer(
+            self.group.require_group(name), strict=self.strict)
 
     def __call__(self, key, value):
         if not self.strict and key not in self.group:

--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -97,11 +97,11 @@ class HDF5Deserializer(serializer.Deserializer):
         name = self.group.name + '/' + key
         try:
             group = self.group.require_group(name)
-            return HDF5Deserializer(group, strict=self.strict)
         except ValueError:
             # require_group raises ValueError if there does not exist
             # the given group and the file is read mode.
-            return HDF5Deserializer(None, strict=self.strict)
+            group = None
+        return HDF5Deserializer(group, strict=self.strict)
 
     def __call__(self, key, value):
         if self.group is None:

--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -109,6 +109,8 @@ class HDF5Deserializer(serializer.Deserializer):
                 return value
             else:
                 raise ValueError('Inexistent group is specified')
+        if not self.strict and key not in self.group:
+            return value
 
         dataset = self.group[key]
         if value is None:

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -95,7 +95,8 @@ class NpzDeserializer(serializer.Deserializer):
 
     def __getitem__(self, key):
         key = key.strip('/')
-        return NpzDeserializer(self.npz, self.path + key + '/')
+        return NpzDeserializer(
+            self.npz, self.path + key + '/', strict=self.strict)
 
     def __call__(self, key, value):
         key = self.path + key.lstrip('/')

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -165,6 +165,31 @@ class TestHDF5DeserializerNonStrict(unittest.TestCase):
         fd, path = tempfile.mkstemp()
         os.close(fd)
         self.temp_file_path = path
+        with h5py.File(path, 'w') as f:
+            f.require_group('x')
+
+        self.hdf5file = h5py.File(path, 'r')
+        self.deserializer = hdf5.HDF5Deserializer(self.hdf5file, strict=False)
+
+    def tearDown(self):
+        if hasattr(self, 'hdf5file'):
+            self.hdf5file.close()
+        if hasattr(self, 'temp_file_path'):
+            os.remove(self.temp_file_path)
+
+    def test_deserialize_partial(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        ret = self.deserializer('y', y)
+        self.assertIs(ret, y)
+
+
+@unittest.skipUnless(hdf5._available, 'h5py is not available')
+class TestHDF5DeserializerNonStrictGroupHierachy(unittest.TestCase):
+
+    def setUp(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.temp_file_path = path
 
         child = link.Chain(linear=links.Linear(2, 3))
         parent = link.Chain(linear=links.Linear(3, 2), child=child)
@@ -180,7 +205,7 @@ class TestHDF5DeserializerNonStrict(unittest.TestCase):
         if hasattr(self, 'temp_file_path'):
             os.remove(self.temp_file_path)
 
-    def test_deserialize_partial(self):
+    def test_deserialize_hierarchy(self):
         child = link.Chain(linear2=links.Linear(2, 3))
         target = link.Chain(linear=links.Linear(3, 2), child=child)
         target_child_W = numpy.copy(child.linear2.W.data)

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -212,14 +212,14 @@ class TestHDF5DeserializerNonStrictGroupHierachy(unittest.TestCase):
         target_child_b = numpy.copy(child.linear2.b.data)
         self.deserializer.load(target)
 
-        self.assertTrue(numpy.array_equal(
-            self.source.linear.W.data, target.linear.W.data))
-        self.assertTrue(numpy.array_equal(
-            self.source.linear.b.data, target.linear.b.data))
-        self.assertTrue(numpy.array_equal(
-            target.child.linear2.W.data, target_child_W))
-        self.assertTrue(numpy.array_equal(
-            target.child.linear2.b.data, target_child_b))
+        numpy.testing.assert_array_equal(
+            self.source.linear.W.data, target.linear.W.data)
+        numpy.testing.assert_array_equal(
+            self.source.linear.b.data, target.linear.b.data)
+        numpy.testing.assert_array_equal(
+            target.child.linear2.W.data, target_child_W)
+        numpy.testing.assert_array_equal(
+            target.child.linear2.b.data, target_child_b)
 
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -149,9 +149,11 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
         fd, path = tempfile.mkstemp()
         os.close(fd)
         self.temp_file_path = path
-        with open(path, 'wb') as f:
-            numpy.savez(
-                f, **{'x': numpy.asarray(10)})
+
+        child = link.Chain(linear=links.Linear(2, 3))
+        parent = link.Chain(linear=links.Linear(3, 2), child=child)
+        npz.save_npz(self.temp_file_path, parent)
+        self.source = parent
 
         self.npzfile = numpy.load(path)
         self.deserializer = npz.NpzDeserializer(self.npzfile, strict=False)
@@ -163,9 +165,20 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
             os.remove(self.temp_file_path)
 
     def test_deserialize_partial(self):
-        y = numpy.empty((2, 3), dtype=numpy.float32)
-        ret = self.deserializer('y', y)
-        self.assertIs(ret, y)
+        child = link.Chain(linear2=links.Linear(2, 3))
+        target = link.Chain(linear=links.Linear(3, 2), child=child)
+        target_child_W = numpy.copy(child.linear2.W.data)
+        target_child_b = numpy.copy(child.linear2.b.data)
+        self.deserializer.load(target)
+
+        self.assertTrue(numpy.array_equal(
+            self.source.linear.W.data, target.linear.W.data))
+        self.assertTrue(numpy.array_equal(
+            self.source.linear.b.data, target.linear.b.data))
+        self.assertTrue(numpy.array_equal(
+            target.child.linear2.W.data, target_child_W))
+        self.assertTrue(numpy.array_equal(
+            target.child.linear2.b.data, target_child_b))
 
 
 @testing.parameterize(*testing.product({'compress': [False, True]}))

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -196,14 +196,16 @@ class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):
         target_child_b = numpy.copy(child.linear2.b.data)
         self.deserializer.load(target)
 
-        self.assertTrue(numpy.array_equal(
-            self.source.linear.W.data, target.linear.W.data))
-        self.assertTrue(numpy.array_equal(
-            self.source.linear.b.data, target.linear.b.data))
-        self.assertTrue(numpy.array_equal(
-            target.child.linear2.W.data, target_child_W))
-        self.assertTrue(numpy.array_equal(
-            target.child.linear2.b.data, target_child_b))
+        numpy.testing.assert_array_equal(
+            self.source.linear.W.data, target.linear.W.data)
+        numpy.testing.assert_array_equal(
+            self.source.linear.W.data, target.linear.W.data)
+        numpy.testing.assert_array_equal(
+            self.source.linear.b.data, target.linear.b.data)
+        numpy.testing.assert_array_equal(
+            target.child.linear2.W.data, target_child_W)
+        numpy.testing.assert_array_equal(
+            target.child.linear2.b.data, target_child_b)
 
 
 @testing.parameterize(*testing.product({'compress': [False, True]}))

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -149,6 +149,31 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
         fd, path = tempfile.mkstemp()
         os.close(fd)
         self.temp_file_path = path
+        with open(path, 'wb') as f:
+            numpy.savez(
+                f, **{'x': numpy.asarray(10)})
+
+        self.npzfile = numpy.load(path)
+        self.deserializer = npz.NpzDeserializer(self.npzfile, strict=False)
+
+    def tearDown(self):
+        if hasattr(self, 'npzfile'):
+            self.npzfile.close()
+        if hasattr(self, 'temp_file_path'):
+            os.remove(self.temp_file_path)
+
+    def test_deserialize_partial(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        ret = self.deserializer('y', y)
+        self.assertIs(ret, y)
+
+
+class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):
+
+    def setUp(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.temp_file_path = path
 
         child = link.Chain(linear=links.Linear(2, 3))
         parent = link.Chain(linear=links.Linear(3, 2), child=child)
@@ -164,7 +189,7 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
         if hasattr(self, 'temp_file_path'):
             os.remove(self.temp_file_path)
 
-    def test_deserialize_partial(self):
+    def test_deserialize_hierarchy(self):
         child = link.Chain(linear2=links.Linear(2, 3))
         target = link.Chain(linear=links.Linear(3, 2), child=child)
         target_child_W = numpy.copy(child.linear2.W.data)


### PR DESCRIPTION
Current `strict` options in `NpzDeserializer` and `HDF5Deserializer` work well when the link does not have a hierarchical structure, however, it automatically changes `strict` option to `True` after the 2nd level even if users explicitly specify `False`. This PR aims to fix this problem.