### PR TITLE
Fix typo in docstring of elu function

### DIFF
--- a/chainer/functions/activation/elu.py
+++ b/chainer/functions/activation/elu.py
@@ -76,7 +76,6 @@ def elu(x, alpha=1.0):
         >>> x
         array([[-1.,  0.],
                [ 2., -3.]], dtype=float32)
-        >>> y = F.crelu(x, axis=1)
         >>> y = F.elu(x, alpha=1.)
         >>> y.data
         array([[-0.63212055,  0.        ],


### PR DESCRIPTION
I removed an unnecessary line in the example code.
http://docs.chainer.org/en/latest/reference/functions.html#chainer.functions.elu