### PR TITLE
fix mocked trainer

### DIFF
--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import os
 import shutil
 import tempfile
@@ -157,11 +158,17 @@ def _get_mocked_trainer(stop_trigger=(10, 'iteration')):
     updater = mock.Mock()
     updater.get_all_optimizers.return_value = {}
     updater.iteration = 0
-    updater.epoch_detail = 1
+    updater.epoch = 0
+    updater.epoch_detail = 0
+    updater.is_new_epoch = True
+    iter_per_epoch = 10
 
     def update():
         time.sleep(0.001)
         updater.iteration += 1
+        updater.epoch = updater.iteration // iter_per_epoch
+        updater.epoch_detail = updater.iteration / iter_per_epoch
+        updater.is_new_epoch = updater.epoch == updater.epoch_detail
 
     updater.update = update
     return training.Trainer(updater, stop_trigger)


### PR DESCRIPTION
Currently, the design of updater used in `_get_mocked_trainer` is wrong.
- `epoch_detail` before the first iteration is `1`.
    It should be `0` because no samples are processed before the first iteration.
-  `epoch_detail` does not change during iterations.
    This means batchsize is zero or the size of dataset is infinity. However, some test cases use epoch-base triggers.