### PR TITLE
Fix Windows NVTX support.

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -83,6 +83,7 @@ if sys.platform == 'win32':
     mod_cuda['libraries'].remove('nvToolsExt')
     if utils.search_on_path(['nvToolsExt64_1.dll']) is None:
         mod_cuda['file'].remove('cupy.cuda.nvtx')
+        mod_cuda['include'].remove('nvToolsExt.h')
         utils.print_warning(
             'Cannot find nvToolsExt. nvtx was disabled.')
     else:


### PR DESCRIPTION
This PR follows #2423, which is already merged to the master.

In #2423, reference to nvToolsExt.h is alive even when NVTX is not found on a Windows environment and it prevents `cupy.cuda` module from being built when `check_library` function is called.

This PR removes the reference to nvToolsExt.h in such a case.
