### PR TITLE
Support cuDNN v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requirements for some features:
   - filelock
   - g++ 4.8.4+
 - cuDNN support
-  - cuDNN v2, v3, v4, v5, v5.1
+  - cuDNN v2, v3, v4, v5, v5.1, v6
 - Caffe model support
   - Protocol Buffers (pip install protobuf)
     - protobuf>=3.0.0 is required for Py3

--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -200,17 +200,17 @@ cpdef destroyFilterDescriptor(size_t filterDesc)
 
 cpdef size_t createConvolutionDescriptor() except *
 cpdef setConvolution2dDescriptor_v4(
-    size_t convDesc, int pad_h, int pad_w, int u, int v, int upscalex,
-    int upscaley, int mode)
+    size_t convDesc, int pad_h, int pad_w, int u, int v, int dilation_h,
+    int dilation_w, int mode)
 cpdef setConvolution2dDescriptor_v5(
-    size_t convDesc, int pad_h, int pad_w, int u, int v, int upscalex,
-    int upscaley, int mode, size_t computeType)
+    size_t convDesc, int pad_h, int pad_w, int u, int v, int dilation_h,
+    int dilation_w, int mode, size_t computeType)
 cpdef setConvolutionNdDescriptor_v2(
     size_t convDesc, int arrayLength, size_t padA, size_t filterStrideA,
-    size_t upscaleA, int mode)
+    size_t dilationA, int mode)
 cpdef setConvolutionNdDescriptor_v3(
     size_t convDesc, int arrayLength, size_t padA, size_t filterStrideA,
-    size_t upscaleA, int mode, int dataType)
+    size_t dilationA, int mode, int dataType)
 cpdef destroyConvolutionDescriptor(size_t convDesc)
 cpdef findConvolutionForwardAlgorithm(
     size_t handle, size_t xDesc, size_t wDesc, size_t convDesc, size_t yDesc,

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -70,17 +70,17 @@ cdef extern from "cupy_cudnn.h":
     int cudnnCreateConvolutionDescriptor(ConvolutionDescriptor* convDesc) nogil
     int cudnnSetConvolution2dDescriptor_v4(
         ConvolutionDescriptor convDesc, int pad_h, int pad_w, int u,
-        int v, int upscalex, int upscaley, ConvolutionMode mode) nogil
+        int v, int dilation_h, int dilation_w, ConvolutionMode mode) nogil
     int cudnnSetConvolution2dDescriptor_v5(
         ConvolutionDescriptor convDesc, int pad_h, int pad_w, int u,
-        int v, int upscalex, int upscaley, ConvolutionMode mode,
+        int v, int dilation_h, int dilation_w, ConvolutionMode mode,
         DataType computeType) nogil
     int cudnnSetConvolutionNdDescriptor_v2(
         ConvolutionDescriptor convDesc, int arrayLength, int* padA,
-        int* filterStrideA, int* upscaleA, ConvolutionMode mode) nogil
+        int* filterStrideA, int* dilationA, ConvolutionMode mode) nogil
     int cudnnSetConvolutionNdDescriptor_v3(
         ConvolutionDescriptor convDesc, int arrayLength, int* padA,
-        int* filterStrideA, int* upscaleA, ConvolutionMode mode,
+        int* filterStrideA, int* dilationA, ConvolutionMode mode,
         DataType dataType) nogil
     int cudnnDestroyConvolutionDescriptor(ConvolutionDescriptor conDesc) nogil
     int cudnnFindConvolutionForwardAlgorithm(
@@ -566,38 +566,38 @@ cpdef size_t createConvolutionDescriptor() except *:
 
 
 cpdef setConvolution2dDescriptor_v4(
-        size_t convDesc, int pad_h, int pad_w, int u, int v, int upscalex,
-        int upscaley, int mode):
+        size_t convDesc, int pad_h, int pad_w, int u, int v, int dilation_h,
+        int dilation_w, int mode):
     status = cudnnSetConvolution2dDescriptor_v4(
-        <ConvolutionDescriptor>convDesc, pad_h, pad_w, u, v, upscalex,
-        upscaley, <ConvolutionMode>mode)
+        <ConvolutionDescriptor>convDesc, pad_h, pad_w, u, v, dilation_h,
+        dilation_w, <ConvolutionMode>mode)
     check_status(status)
 
 
 cpdef setConvolution2dDescriptor_v5(
-        size_t convDesc, int pad_h, int pad_w, int u, int v, int upscalex,
-        int upscaley, int mode, size_t computeType):
+        size_t convDesc, int pad_h, int pad_w, int u, int v, int dilation_h,
+        int dilation_w, int mode, size_t computeType):
     status = cudnnSetConvolution2dDescriptor_v5(
-        <ConvolutionDescriptor>convDesc, pad_h, pad_w, u, v, upscalex,
-        upscaley, <ConvolutionMode>mode, <DataType>computeType)
+        <ConvolutionDescriptor>convDesc, pad_h, pad_w, u, v, dilation_h,
+        dilation_w, <ConvolutionMode>mode, <DataType>computeType)
     check_status(status)
 
 
 cpdef setConvolutionNdDescriptor_v2(
         size_t convDesc, int arrayLength, size_t padA, size_t filterStrideA,
-        size_t upscaleA, int mode):
+        size_t dilationA, int mode):
     status = cudnnSetConvolutionNdDescriptor_v2(
         <ConvolutionDescriptor>convDesc, arrayLength, <int*>padA,
-        <int*>filterStrideA, <int*>upscaleA, <ConvolutionMode>mode)
+        <int*>filterStrideA, <int*>dilationA, <ConvolutionMode>mode)
     check_status(status)
 
 
 cpdef setConvolutionNdDescriptor_v3(
         size_t convDesc, int arrayLength, size_t padA, size_t filterStrideA,
-        size_t upscaleA, int mode, int dataType):
+        size_t dilationA, int mode, int dataType):
     status = cudnnSetConvolutionNdDescriptor_v3(
         <ConvolutionDescriptor>convDesc, arrayLength, <int*>padA,
-        <int*>filterStrideA, <int*>upscaleA, <ConvolutionMode>mode,
+        <int*>filterStrideA, <int*>dilationA, <ConvolutionMode>mode,
         <DataType>dataType)
     check_status(status)
 

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -167,13 +167,6 @@ cudnnStatus_t cudnnSoftmaxBackward(...) {
 extern "C" {
 
 
-#if !defined(CUPY_NO_CUDA)
-
-#define cudnnSetConvolution2dDescriptor_v4 cudnnSetConvolution2dDescriptor
-
-#endif // #if !define(CUPY_NO_CUDA)
-
-
 #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 3000)
 // ***_v3 functions are not declared in cuDNN v2.
 // Following definitions are for compatibility with cuDNN v3.
@@ -245,6 +238,11 @@ cudnnStatus_t cudnnSetConvolutionNdDescriptor_v3(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
+#endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 3000)
+
+#if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 3000) || (CUDNN_VERSION >= 6000)
+// some ***_v3 functions are not declared in cuDNN v2 and v6.
+
 cudnnStatus_t cudnnSetFilter4dDescriptor_v3(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
@@ -269,7 +267,7 @@ cudnnStatus_t cudnnActivationBackward_v3(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
-#endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 3000)
+#endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 3000) || (CUDNN_VERSION >= 6000)
 
 
 #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 4000)
@@ -511,6 +509,28 @@ cudnnStatus_t cudnnConvolutionBackwardData_v2(...) {
 }
 
 #endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION >= 5000)
+
+
+#if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION < 6000)
+
+#define cudnnSetConvolution2dDescriptor_v4 cudnnSetConvolution2dDescriptor
+
+#endif // #if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION < 6000)
+
+
+#if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 6000)
+// Some functions are renamed in cuDNN v6.
+// Following definitions are for compatibility with cuDNN v6 and higher.
+
+#define cudnnSetFilter4dDescriptor_v4 cudnnSetFilter4dDescriptor
+#define cudnnSetFilterNdDescriptor_v4 cudnnSetFilterNdDescriptor
+#define cudnnGetFilterNdDescriptor_v4 cudnnGetFilterNdDescriptor
+#define cudnnSetPooling2dDescriptor_v4 cudnnSetPooling2dDescriptor
+#define cudnnSetPoolingNdDescriptor_v4 cudnnSetPoolingNdDescriptor
+#define cudnnActivationForward_v4 cudnnActivationForward
+#define cudnnActivationBackward_v4 cudnnActivationBackward
+
+#endif // #if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 6000)
 
 
 } // extern "C"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -42,7 +42,7 @@ CUDA support
 
 cuDNN support
 
-* `cuDNN <https://developer.nvidia.com/cudnn>`_ v2, v3, v4, v5, v5.1
+* `cuDNN <https://developer.nvidia.com/cudnn>`_ v2, v3, v4, v5, v5.1, v6
 
 Caffe model support
 


### PR DESCRIPTION
This PR supports cuDNN v6.
Also, it changes argument name from `upscale` to `dilation`. Please see user guide of cuDNN v6.
