### PR TITLE
Fix an exception handling problem during importing matplotlib

### DIFF
--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -15,7 +15,7 @@ try:
 
     _available = True
 
-except ImportError:
+except (ImportError, TypeError):
     _available = False
 
 


### PR DESCRIPTION
related to https://github.com/pfnet/chainer/issues/2146

`import matplotlib` sometimes throws `TypeError`. So `TypeError` also should be caught.