### PR TITLE
Add dependency to openmp for cusolver

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -178,6 +178,15 @@ def make_extensions(options, compiler, use_cython):
         if not no_cuda:
             s['libraries'] = module['libraries']
 
+        if module['name'] == 'cusolver':
+            args = s.setdefault('extra_link_args', [])
+            # openmp is required for cusolver
+            if compiler.compiler_type == 'unix' and sys.platform != 'darwin':
+                # In mac environment, openmp is not required.
+                args.append('-fopenmp')
+            elif compiler.compiler_type == 'msvc':
+                args.append('/openmp')
+
         ret.extend([
             setuptools.Extension(f, [path.join(*f.split('.')) + ext], **s)
             for f in module['file']])


### PR DESCRIPTION
cuSolver depends on openmp. When i use cuSolver, i got this error and cuSolver is not enabled.
```
/usr/local/cuda/lib64/libcusolver.so.8.0: undefined symbol: GOMP_critical_end
```
The test for cuSolver is skipped in this situation.