### PR TITLE
Add ignore_label option to softmax_cross_entropy

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -12,11 +12,10 @@ class SoftmaxCrossEntropy(function.Function):
 
     """Softmax activation followed by a cross entropy loss."""
 
-    ignore_label = -1
     normalize = True
 
     def __init__(self, use_cudnn=True, normalize=True, cache_score=True,
-                 class_weight=None):
+                 class_weight=None, ignore_label=-1):
         self.use_cudnn = use_cudnn
         self.normalize = normalize
         self.cache_score = cache_score
@@ -29,6 +28,7 @@ class SoftmaxCrossEntropy(function.Function):
             if isinstance(self.class_weight, chainer.Variable):
                 raise ValueError('class_weight should be a numpy.ndarray or '
                                  'cupy.ndarray, not a chainer.Variable')
+        self.ignore_label = ignore_label
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -183,7 +183,7 @@ class SoftmaxCrossEntropy(function.Function):
 
 def softmax_cross_entropy(
         x, t, use_cudnn=True, normalize=True, cache_score=True,
-        class_weight=None):
+        class_weight=None, ignore_label=-1):
     """Computes cross entropy loss for pre-softmax activations.
 
     Args:
@@ -219,5 +219,6 @@ def softmax_cross_entropy(
        This function is differentiable only by ``x``.
 
     """
+
     return SoftmaxCrossEntropy(
-        use_cudnn, normalize, cache_score, class_weight)(x, t)
+        use_cudnn, normalize, cache_score, class_weight, ignore_label)(x, t)

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -195,7 +195,8 @@ def softmax_cross_entropy(
             to 2, it computes a cross entropy of the replicated softmax if the
             number of dimensions is greater than 2.
         t (~chainer.Variable): Variable holding an int32 vector of ground truth
-            labels. If ``t[i] == -1``, corresponding ``x[i]`` is ignored.
+            labels. If ``t[i] == ignore_label``, corresponding ``x[i]`` is
+            ignored.
         normalize (bool): If ``True``, this function normalizes the cross
             entropy loss across all instances. If ``False``, it only
             normalizes along a batch size.
@@ -210,6 +211,8 @@ def softmax_cross_entropy(
             ``y[:, i]`` that is the corresponding log-softmax output of ``x``
             and has the same shape as ``x`` before calculating the actual loss
             value.
+        ignore_label (int): Label value you want to ignore. Its default value
+            is ``-1``. See description of the argument `t`.
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.


### PR DESCRIPTION
I added `ignore_label` argument to `softmax_cross_entropy`.