### PR TITLE
Skip tests that use axis option of count_nonzero

### DIFF
--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -31,6 +31,7 @@ class TestCount(unittest.TestCase):
             return c
         self.assertEqual(func(numpy), func(cupy))
 
+    @testing.with_requires('numpy>=1.12')
     @testing.for_all_dtypes()
     def test_count_nonzero_int_axis(self, dtype):
         for ax in six.moves.range(3):
@@ -40,6 +41,7 @@ class TestCount(unittest.TestCase):
                 return xp.count_nonzero(a, axis=ax)
             testing.assert_allclose(func(numpy), func(cupy))
 
+    @testing.with_requires('numpy>=1.12')
     @testing.for_all_dtypes()
     def test_count_nonzero_tuple_axis(self, dtype):
         for ax in six.moves.range(3):


### PR DESCRIPTION
`axis` option was introduced to `count_nonzero` in NumPy 1.12.0 . So we have to skip tests that uses this option if NumPy is older.