### PR TITLE
Add TransformDataset

### DIFF
--- a/chainer/datasets/__init__.py
+++ b/chainer/datasets/__init__.py
@@ -4,6 +4,7 @@ from chainer.datasets import image_dataset  # NOQA
 from chainer.datasets import mnist  # NOQA
 from chainer.datasets import ptb  # NOQA
 from chainer.datasets import sub_dataset  # NOQA
+from chainer.datasets import transform_dataset  # NOQA
 from chainer.datasets import tuple_dataset  # NOQA
 
 
@@ -21,4 +22,5 @@ from chainer.datasets.sub_dataset import get_cross_validation_datasets_random  #
 from chainer.datasets.sub_dataset import split_dataset  # NOQA
 from chainer.datasets.sub_dataset import split_dataset_random  # NOQA
 from chainer.datasets.sub_dataset import SubDataset  # NOQA
+from chainer.datasets.transform_dataset import TransformDataset  # NOQA
 from chainer.datasets.tuple_dataset import TupleDataset  # NOQA

--- a/chainer/datasets/transform_dataset.py
+++ b/chainer/datasets/transform_dataset.py
@@ -9,6 +9,8 @@ class TransformDataset(dataset_mixin.DatasetMixin):
     dataset's :meth:`__getitem__`. Arrays returned by :meth:`__getitem__` of
     the base dataset with integer as an argument are transformed by the given
     function :obj:`transform`.
+    Also, :meth:`__len__` returns the integer returned by the base dataset's
+    :meth:`__len__`.
 
     The function :obj:`transform` takes, as an argument, :obj:`in_data`, which
     is the output of the base dataset's :meth:`__getitem__`, and returns
@@ -25,7 +27,9 @@ class TransformDataset(dataset_mixin.DatasetMixin):
 
     Args:
         dataset: The underlying dataset. The index of this dataset corresponds
-            to the index of the base dataset.
+            to the index of the base dataset. This object needs to support
+            functions :meth:`__getitem__` and :meth:`__len__` as described
+            above.
         transform (callable): A function that is called to transform values
             returned by the underlying dataset's :meth:`__getitem__`.
 

--- a/chainer/datasets/transform_dataset.py
+++ b/chainer/datasets/transform_dataset.py
@@ -39,9 +39,9 @@ class TransformDataset(dataset_mixin.DatasetMixin):
         self._dataset = dataset
         self._transform = transform
 
+    def __len__(self):
+        return len(self._dataset)
+
     def get_example(self, i):
         in_data = self._dataset[i]
         return self._transform(in_data)
-
-    def __len__(self):
-        return len(self._dataset)

--- a/chainer/datasets/transform_dataset.py
+++ b/chainer/datasets/transform_dataset.py
@@ -1,0 +1,43 @@
+from chainer.dataset import dataset_mixin
+
+
+class TransformDataset(dataset_mixin.DatasetMixin):
+
+    """Dataset that indexes the base dataset and transforms the data.
+
+    This dataset wraps the base dataset by modifying the behavior of the base
+    dataset's :meth:`__getitem__`. Arrays returned by :meth:`__getitem__` of
+    the base dataset with integer as an argument are transformed by the given
+    function :obj:`transform`.
+
+    The function :obj:`transform` takes, as an argument, :obj:`in_data`, which
+    is the output of the base dataset's :meth:`__getitem__`, and returns
+    the transformed arrays as output. Please see the following example.
+
+    >>> from chainer.datasets import get_mnist
+    >>> from chainer.datasets import TransformDataset
+    >>> dataset, _ = get_mnist()
+    >>> def transform(in_data):
+    >>>     img, label = in_data
+    >>>     img -= 0.5  # scale to [-0.5, -0.5]
+    >>>     return img, label
+    >>> dataset = TransformDataset(dataset, transform)
+
+    Args:
+        dataset: The underlying dataset. The index of this dataset corresponds
+            to the index of the base dataset.
+        transform (callable): A function that is called to transform values
+            returned by the underlying dataset's :meth:`__getitem__`.
+
+    """
+
+    def __init__(self, dataset, transform):
+        self._dataset = dataset
+        self._transform = transform
+
+    def get_example(self, i):
+        in_data = self._dataset[i]
+        return self._transform(in_data)
+
+    def __len__(self):
+        return len(self._dataset)

--- a/chainer/datasets/transform_dataset.py
+++ b/chainer/datasets/transform_dataset.py
@@ -18,9 +18,9 @@ class TransformDataset(dataset_mixin.DatasetMixin):
     >>> from chainer.datasets import TransformDataset
     >>> dataset, _ = get_mnist()
     >>> def transform(in_data):
-    >>>     img, label = in_data
-    >>>     img -= 0.5  # scale to [-0.5, -0.5]
-    >>>     return img, label
+    ...     img, label = in_data
+    ...     img -= 0.5  # scale to [-0.5, -0.5]
+    ...     return img, label
     >>> dataset = TransformDataset(dataset, transform)
 
     Args:

--- a/docs/source/reference/datasets.rst
+++ b/docs/source/reference/datasets.rst
@@ -27,6 +27,9 @@ The first one is :class:`DictDataset` and :class:`TupleDataset`, both of which c
 
 The second one is :class:`SubDataset`, which represents a subset of an existing dataset. It can be used to separate a dataset for hold-out validation or cross validation. Convenient functions to make random splits are also provided.
 
+The third one is :class:`TransformDataset`, which wraps around a dataset by applying a function to data indexed from the underlying dataset.
+It can be used to modify behavior of a dataset that is already prepared.
+
 The last one is a group of domain-specific datasets. Currently, :class:`ImageDataset` and :class:`LabeledImageDataset` are provided for datasets of images.
 
 
@@ -49,6 +52,11 @@ SubDataset
 .. autofunction:: split_dataset_random
 .. autofunction:: get_cross_validation_datasets
 .. autofunction:: get_cross_validation_datasets_random
+
+TransformDataset
+~~~~~~~~~~~~~~~~
+.. autoclass:: TransformDataset
+   :members:
 
 ImageDataset
 ~~~~~~~~~~~~

--- a/tests/chainer_tests/datasets_tests/test_transform_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_transform_dataset.py
@@ -1,0 +1,48 @@
+import unittest
+
+import numpy
+
+from chainer import datasets
+from chainer import testing
+
+
+def _create_list_tuples(shape1, shape2, length):
+    return [(numpy.random.uniform(shape1), numpy.random.uniform(shape2)) for
+            _ in range(length)]
+
+
+@testing.parameterize(
+    {'dataset': numpy.random.uniform(size=(2, 3, 32, 32))},
+    {'dataset': _create_list_tuples((3, 32, 32), (32, 32), 5)}
+)
+class TestTransformDataset(unittest.TestCase):
+
+    def setUp(self):
+        def transform(in_data):
+            if isinstance(in_data, tuple):
+                return tuple([example * 3 for example in in_data])
+            else:
+                return in_data * 3
+        self.transform = transform
+
+    def test_transform_dataset(self):
+        td = datasets.TransformDataset(self.dataset, self.transform)
+        self.assertEqual(len(td), len(self.dataset))
+
+        for i in range(len(td)):
+            example = td[i]
+            if isinstance(example, tuple):
+                for j, arr in enumerate(example):
+                    numpy.testing.assert_array_equal(
+                        arr, self.transform(self.dataset[i][j]))
+            else:
+                numpy.testing.assert_array_equal(
+                    example, self.transform(self.dataset[i]))
+
+    def test_transform_dataset_overrun(self):
+        td = datasets.TransformDataset(self.dataset, self.transform)
+        with self.assertRaises(IndexError):
+            td[len(td) + 1]
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds a general dataset class called `TransformDataset`.
This class lets users to apply a function to a indexed data.
It becomes handy in the case when a user wants to write a custom data augmentation code on top of the prepared dataset class.

This class decouples implementation of data augmentation code and a code to retrieve data from filesystem or from web, making it a lot easier to reuse datasets across different tasks.

The class is already used in ChainerCV, an extension library to Chainer.