### PR TITLE
Remove requirement that inputs of VAE functions being Variable

### DIFF
--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -43,9 +43,6 @@ def gaussian_kl_divergence(mean, ln_var, reduce='sum'):
             If it is ``'sum'``, the output variable holds a scalar value.
 
     """
-    assert isinstance(mean, variable.Variable)
-    assert isinstance(ln_var, variable.Variable)
-
     if reduce not in ('sum', 'no'):
         raise ValueError(
             "only 'sum' and 'no' are valid for 'reduce', but '%s' is "

--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -3,7 +3,6 @@ import math
 from chainer.functions.activation import softplus
 from chainer.functions.math import exponential
 from chainer.functions.math import sum
-from chainer import variable
 
 
 def gaussian_kl_divergence(mean, ln_var):
@@ -22,9 +21,11 @@ def gaussian_kl_divergence(mean, ln_var):
     and :math:`I` is an identity matrix.
 
     Args:
-        mean (~chainer.Variable): A variable representing mean of given
+        mean (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): A variable representing mean of given
             gaussian distribution, :math:`\\mu`.
-        ln_var (~chainer.Variable): A variable representing logarithm of
+        ln_var (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): A variable representing logarithm of
             variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
 
     Returns:
@@ -32,9 +33,6 @@ def gaussian_kl_divergence(mean, ln_var):
             given gaussian distribution and the standard gaussian.
 
     """
-    assert isinstance(mean, variable.Variable)
-    assert isinstance(ln_var, variable.Variable)
-
     J = mean.size
     var = exponential.exp(ln_var)
     return (sum.sum(mean * mean) + sum.sum(var) - sum.sum(ln_var) - J) * 0.5
@@ -60,17 +58,16 @@ def bernoulli_nll(x, y):
        directly.
 
     Args:
-        x (~chainer.Variable): Input variable.
-        y (~chainer.Variable): A variable representing the parameter of
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Input variable.
+        y (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): A variable representing the parameter of
             Bernoulli distribution.
 
     Returns:
         ~chainer.Variable: A variable representing negative log-likelihood.
 
     """
-    assert isinstance(x, variable.Variable)
-    assert isinstance(y, variable.Variable)
-
     return sum.sum(softplus.softplus(y)) - sum.sum(x * y)
 
 
@@ -91,20 +88,19 @@ def gaussian_nll(x, mean, ln_var):
     matrix where :math:`S_{ii} = \\sigma_i^2`.
 
     Args:
-        x (~chainer.Variable): Input variable.
-        mean (~chainer.Variable): A variable representing mean of a Gaussian
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Input variable.
+        mean (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): A variable representing mean of a Gaussian
             distribution, :math:`\\mu`.
-        ln_var (~chainer.Variable): A variable representing logarithm of
+        ln_var (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): A variable representing logarithm of
             variance of a Gaussian distribution, :math:`\\log(\\sigma^2)`.
 
     Returns:
         ~chainer.Variable: A variable representing the negative log-likelihood.
 
     """
-    assert isinstance(x, variable.Variable)
-    assert isinstance(mean, variable.Variable)
-    assert isinstance(ln_var, variable.Variable)
-
     D = x.size
     x_prec = exponential.exp(-ln_var)
     x_diff = x - mean

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -40,7 +40,8 @@ class TestGaussianKLDivergence(unittest.TestCase):
             ln_var = chainer.Variable(ln_var)
         actual = cuda.to_cpu(
             F.gaussian_kl_divergence(mean, ln_var, self.reduce).data)
-        actual = cuda.to_cpu(F.gaussian_kl_divergence(mean, ln_var, self.reduce).data)
+        actual = cuda.to_cpu(
+            F.gaussian_kl_divergence(mean, ln_var, self.reduce).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)
@@ -54,7 +55,7 @@ class TestGaussianKLDivergence(unittest.TestCase):
                                           cuda.to_gpu(self.ln_var))
 
 
-class TestGaussianNLLInvalidReductionOption(unittest.TestCase):
+class TestGaussianKLDivergenceInvalidReductionOption(unittest.TestCase):
 
     def setUp(self):
         self.mean = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -11,9 +11,11 @@ from chainer.testing import condition
 
 
 @testing.parameterize(
-    {'variable_wrap': True},
-    {'variable_wrap': False}
-)
+    *testing.product({
+        'wrap_m': [True, False],
+        'wrap_v': [True, False]
+    })
+ )
 class TestGaussianKLDivergence(unittest.TestCase):
 
     def setUp(self):
@@ -28,10 +30,11 @@ class TestGaussianKLDivergence(unittest.TestCase):
                         numpy.sum(numpy.exp(self.ln_var))) * 0.5
 
     def check_gaussian_kl_divergence(self, mean, ln_var):
-        if self.variable_wrap:
+        if self.wrap_m:
             mean = chainer.Variable(mean)
+        if self.wrap_v:
             ln_var = chainer.Variable(ln_var)
-        actual = cuda.to_cpu(F.gaussian_kl_divergence(m, v).data)
+        actual = cuda.to_cpu(F.gaussian_kl_divergence(mean, ln_var).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)
@@ -46,9 +49,11 @@ class TestGaussianKLDivergence(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'variable_wrap': True},
-    {'variable_wrap': False}
-)
+    *testing.product({
+        'wrap_x': [True, False],
+        'wrap_y': [True, False]
+    })
+ )
 class TestBernoulliNLL(unittest.TestCase):
 
     def setUp(self):
@@ -62,8 +67,9 @@ class TestBernoulliNLL(unittest.TestCase):
                          numpy.sum((1 - self.x) * numpy.log(1 - p)))
 
     def check_bernoulli_nll(self, x, y):
-        if self.variable_wrap:
+        if self.wrap_x:
             x = chainer.Variable(x)
+        if self.wrap_y:
             y = chainer.Variable(y)
         actual = cuda.to_cpu(F.bernoulli_nll(x, y).data)
         testing.assert_allclose(self.expect, actual)
@@ -80,9 +86,12 @@ class TestBernoulliNLL(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'variable_wrap': True},
-    {'variable_wrap': False}
-)
+    *testing.product({
+        'wrap_x': [True, False],
+        'wrap_m': [True, False],
+        'wrap_v': [True, False]
+    })
+ )
 class TestGaussianNLL(unittest.TestCase):
 
     def setUp(self):
@@ -101,9 +110,11 @@ class TestGaussianNLL(unittest.TestCase):
                        numpy.sum(x_d * x_d / var) * 0.5)
 
     def check_gaussian_nll(self, x, mean, ln_var):
-        if self.variable_wrap:
+        if self.wrap_x:
             x = chainer.Variable(x)
+        if self.wrap_m:
             mean = chainer.Variable(mean)
+        if self.wrap_v:
             ln_var = chainer.Variable(ln_var)
         actual = cuda.to_cpu(F.gaussian_nll(x, mean, ln_var).data)
         testing.assert_allclose(self.expect, actual)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -40,7 +40,7 @@ class TestGaussianKLDivergence(unittest.TestCase):
             ln_var = chainer.Variable(ln_var)
         actual = cuda.to_cpu(
             F.gaussian_kl_divergence(mean, ln_var, self.reduce).data)
-        actual = cuda.to_cpu(F.gaussian_kl_divergence(mean, ln_var).data)
+        actual = cuda.to_cpu(F.gaussian_kl_divergence(mean, ln_var, self.reduce).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)
@@ -77,7 +77,8 @@ class TestGaussianNLLInvalidReductionOption(unittest.TestCase):
 @testing.parameterize(
     *testing.product({
         'wrap_x': [True, False],
-        'wrap_y': [True, False]
+        'wrap_y': [True, False],
+        'reduce': ['no', 'sum']
     })
 )
 class TestBernoulliNLL(unittest.TestCase):
@@ -99,7 +100,7 @@ class TestBernoulliNLL(unittest.TestCase):
             x = chainer.Variable(x)
         if self.wrap_y:
             y = chainer.Variable(y)
-        actual = cuda.to_cpu(F.bernoulli_nll(x, y).data)
+        actual = cuda.to_cpu(F.bernoulli_nll(x, y, self.reduce).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -38,7 +38,8 @@ class TestGaussianKLDivergence(unittest.TestCase):
             mean = chainer.Variable(mean)
         if self.wrap_v:
             ln_var = chainer.Variable(ln_var)
-        actual = cuda.to_cpu(F.gaussian_kl_divergence(mean, ln_var, self.reduce).data)
+        actual = cuda.to_cpu(
+            F.gaussian_kl_divergence(mean, ln_var, self.reduce).data)
         actual = cuda.to_cpu(F.gaussian_kl_divergence(mean, ln_var).data)
         testing.assert_allclose(self.expect, actual)
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -15,7 +15,7 @@ from chainer.testing import condition
         'wrap_m': [True, False],
         'wrap_v': [True, False]
     })
- )
+)
 class TestGaussianKLDivergence(unittest.TestCase):
 
     def setUp(self):
@@ -53,7 +53,7 @@ class TestGaussianKLDivergence(unittest.TestCase):
         'wrap_x': [True, False],
         'wrap_y': [True, False]
     })
- )
+)
 class TestBernoulliNLL(unittest.TestCase):
 
     def setUp(self):
@@ -91,7 +91,7 @@ class TestBernoulliNLL(unittest.TestCase):
         'wrap_m': [True, False],
         'wrap_v': [True, False]
     })
- )
+)
 class TestGaussianNLL(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -10,6 +10,10 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(
+    {'variable_wrap': True},
+    {'variable_wrap': False}
+)
 class TestGaussianKLDivergence(unittest.TestCase):
 
     def setUp(self):
@@ -24,9 +28,10 @@ class TestGaussianKLDivergence(unittest.TestCase):
                         numpy.sum(numpy.exp(self.ln_var))) * 0.5
 
     def check_gaussian_kl_divergence(self, mean, ln_var):
-        m = chainer.Variable(mean)
-        v = chainer.Variable(ln_var)
-        actual = cuda.to_cpu(vae.gaussian_kl_divergence(m, v).data)
+        if self.variable_wrap:
+            mean = chainer.Variable(mean)
+            ln_var = chainer.Variable(ln_var)
+        actual = cuda.to_cpu(vae.gaussian_kl_divergence(mean, ln_var).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)
@@ -40,6 +45,10 @@ class TestGaussianKLDivergence(unittest.TestCase):
                                           cuda.to_gpu(self.ln_var))
 
 
+@testing.parameterize(
+    {'variable_wrap': True},
+    {'variable_wrap': False}
+)
 class TestBernoulliNLL(unittest.TestCase):
 
     def setUp(self):
@@ -52,9 +61,10 @@ class TestBernoulliNLL(unittest.TestCase):
         self.expect = - (numpy.sum(self.x * numpy.log(p)) +
                          numpy.sum((1 - self.x) * numpy.log(1 - p)))
 
-    def check_bernoulli_nll(self, x_data, y_data):
-        x = chainer.Variable(x_data)
-        y = chainer.Variable(y_data)
+    def check_bernoulli_nll(self, x, y):
+        if self.variable_wrap:
+            x = chainer.Variable(x)
+            y = chainer.Variable(y)
         actual = cuda.to_cpu(vae.bernoulli_nll(x, y).data)
         testing.assert_allclose(self.expect, actual)
 
@@ -69,6 +79,10 @@ class TestBernoulliNLL(unittest.TestCase):
                                  cuda.to_gpu(self.y))
 
 
+@testing.parameterize(
+    {'variable_wrap': True},
+    {'variable_wrap': False}
+)
 class TestGaussianNLL(unittest.TestCase):
 
     def setUp(self):
@@ -86,10 +100,11 @@ class TestGaussianNLL(unittest.TestCase):
                        0.5 * numpy.sum(self.ln_var) +
                        numpy.sum(x_d * x_d / var) * 0.5)
 
-    def check_gaussian_nll(self, x_data, mean_data, ln_var_data):
-        x = chainer.Variable(x_data)
-        mean = chainer.Variable(mean_data)
-        ln_var = chainer.Variable(ln_var_data)
+    def check_gaussian_nll(self, x, mean, ln_var):
+        if self.variable_wrap:
+            x = chainer.Variable(x)
+            mean = chainer.Variable(mean)
+            ln_var = chainer.Variable(ln_var)
         actual = cuda.to_cpu(vae.gaussian_nll(x, mean, ln_var).data)
         testing.assert_allclose(self.expect, actual)
 


### PR DESCRIPTION
Currently, inputs of VAE functions (`gaussian_kl_divergence`, `bernoulli_nll`, and `gaussian_nll`) must be `Variable`. But as Chainer function accepts `xp.ndarray` as well as `Variable` (see #1221). This requirement is too restrictive. This PR loosen the type condition of their inputs.