### PR TITLE
Support zero-dim results in split_axis

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -45,12 +45,6 @@ class SplitAxis(function.Function):
             cdimx = x[0].shape[self.axis]
             ind = list(self.indices_or_sections)
             ind.append(cdimx)
-            prev_i = 0
-            for i in ind:
-                cdimy = max(0, min(i, cdimx) - prev_i)
-                if cdimy == 0:
-                    raise ValueError('Not support if shape contains 0')
-                prev_i = i
         xp = cuda.get_array_module(*x)
         return tuple(xp.split(x[0], self.indices_or_sections, self.axis))
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -29,9 +29,8 @@ from chainer.testing import attr
         {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [2, 5],
          'slices': [[slice(None), slice(None, 2)], [slice(None), slice(2, 5)],
                     [slice(None), slice(5, None)]]},
-        {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [2, 5],
-         'slices': [[slice(None), slice(None, 2)], [slice(None), slice(2, 5)],
-                    [slice(None), slice(5, None)]]},
+        {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [0],
+         'slices': [[slice(None), slice(None, 0)], [slice(None), slice(0, 7)]]},
     ],
     [
         {'dtype': numpy.float16},

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -30,7 +30,8 @@ from chainer.testing import attr
          'slices': [[slice(None), slice(None, 2)], [slice(None), slice(2, 5)],
                     [slice(None), slice(5, None)]]},
         {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [0],
-         'slices': [[slice(None), slice(None, 0)], [slice(None), slice(0, 7)]]},
+         'slices': [[slice(None), slice(None, 0)], [slice(None), slice(0, 7)]]
+         },
     ],
     [
         {'dtype': numpy.float16},


### PR DESCRIPTION
We can support that split_axis method returns zero-size array.