### PR TITLE
CuPy kernels cannot handle arrays over 2 GiB

### DIFF
--- a/cupy/core/carray.cuh
+++ b/cupy/core/carray.cuh
@@ -163,7 +163,7 @@ public:
   __device__ T& operator[](const int* idx) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = 0; dim < ndim; ++dim) {
-      ptr += strides_[dim] * idx[dim];
+      ptr += static_cast<int64_t>(strides_[dim]) * idx[dim];
     }
     return *reinterpret_cast<T*>(ptr);
   }
@@ -175,11 +175,11 @@ public:
   __device__ T& operator[](int i) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = ndim; --dim > 0; ) {
-      ptr += strides_[dim] * (i % shape_[dim]);
+      ptr += static_cast<int64_t>(strides_[dim]) * (i % shape_[dim]);
       i /= shape_[dim];
     }
     if (ndim > 0) {
-      ptr += strides_[0] * i;
+      ptr += static_cast<int64_t>(strides_[0]) * i;
     }
 
     return *reinterpret_cast<T*>(ptr);

--- a/cupy/core/carray.cuh
+++ b/cupy/core/carray.cuh
@@ -163,7 +163,7 @@ public:
   __device__ T& operator[](const int* idx) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = 0; dim < ndim; ++dim) {
-      ptr += static_cast<int64_t>(strides_[dim]) * idx[dim];
+      ptr += static_cast<ptrdiff_t>(strides_[dim]) * idx[dim];
     }
     return *reinterpret_cast<T*>(ptr);
   }
@@ -175,11 +175,11 @@ public:
   __device__ T& operator[](int i) {
     char* ptr = reinterpret_cast<char*>(data_);
     for (int dim = ndim; --dim > 0; ) {
-      ptr += static_cast<int64_t>(strides_[dim]) * (i % shape_[dim]);
+      ptr += static_cast<ptrdiff_t>(strides_[dim]) * (i % shape_[dim]);
       i /= shape_[dim];
     }
     if (ndim > 0) {
-      ptr += static_cast<int64_t>(strides_[0]) * i;
+      ptr += static_cast<ptrdiff_t>(strides_[0]) * i;
     }
 
     return *reinterpret_cast<T*>(ptr);


### PR DESCRIPTION
Currently kernels generated by CuPy performs pointer computation in 32-bit, which cause overflow when handling array whose size is more than 2 GiB.

The following example tries to run `arange` over 2 GiB + 4 bytes of memory, and it fails with `cudaErrorIllegalAddress`.

```
$ python
Python 2.7.6 (default, Oct 26 2016, 20:30:19) 
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cupy
>>> cupy.arange(pow(2,29)+1, dtype=cupy.int32)
Exception cupy.cuda.runtime.CUDARuntimeError: CUDARuntimeError(u'cudaErrorIllegalAddress: an illegal memory access was encountered',) in 'cupy.cuda.memory.Memory.__dealloc__' ignored
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cupy/core/core.pyx", line 1327, in cupy.core.core.ndarray.__repr__ (cupy/core/core.cpp:28337)
  File "cupy/core/core.pyx", line 1372, in cupy.core.core.ndarray.get (cupy/core/core.cpp:28981)
  File "cupy/cuda/memory.pyx", line 219, in cupy.cuda.memory.MemoryPointer.copy_to_host (cupy/cuda/memory.cpp:4839)
  File "cupy/cuda/runtime.pyx", line 241, in cupy.cuda.runtime.memcpy (cupy/cuda/runtime.cpp:4148)
  File "cupy/cuda/runtime.pyx", line 130, in cupy.cuda.runtime.check_status (cupy/cuda/runtime.cpp:2241)
cupy.cuda.runtime.CUDARuntimeError: cudaErrorIllegalAddress: an illegal memory access was encountered
```

When running under `cuda-memcheck`:

```
cuda-memcheck python
========= CUDA-MEMCHECK
Python 2.7.6 (default, Oct 26 2016, 20:30:19) 
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cupy
>>> cupy.arange(pow(2,29)+1, dtype=cupy.int32)
========= Invalid __global__ write of size 4
=========     at 0x00000118 in cupy_arange
=========     by thread (0,0,0) in block (0,0,0)
=========     Address 0x228a300000 is out of bounds
=========     Saved host backtrace up to driver entry point at kernel launch time
=========     Host Frame:/usr/local/nvidia/lib64/libcuda.so.1 (cuLaunchKernel + 0x2c5) [0x204115]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/driver.so [0x6a95]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/function.so [0xd830]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/function.so [0xf5af]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/core/core.so [0x13f168]
=========     Host Frame:python [0xc2604]
=========     Host Frame:python [0xd26cf]
=========     Host Frame:python (PyEval_EvalFrameEx + 0x98d) [0x1244dd]
=========     Host Frame:python (PyEval_EvalCodeEx + 0x2b1) [0x155551]
=========     Host Frame:python (PyEval_EvalFrameEx + 0x7e8) [0x124338]
=========     Host Frame:python [0x167d14]
=========     Host Frame:python (PyRun_InteractiveOneFlags + 0x18c) [0x65a2d]
=========     Host Frame:python (PyRun_InteractiveLoopFlags + 0xaa) [0x65b49]
=========     Host Frame:python (PyRun_AnyFileExFlags + 0x37) [0x661fe]
=========     Host Frame:python (Py_Main + 0xb5e) [0x66d92]
=========     Host Frame:/lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main + 0xf5) [0x21f45]
=========     Host Frame:python [0x177c2e]
=========
========= Program hit cudaErrorLaunchFailure (error 4) due to "unspecified launch failure" on CUDA API call to cudaMemcpy. 
=========     Saved host backtrace up to driver entry point at error
=========     Host Frame:/usr/local/nvidia/lib64/libcuda.so.1 [0x2eeda3]
=========     Host Frame:/usr/local/cuda/lib64/libcudart.so.7.5 (cudaMemcpy + 0x1df) [0x34b1f]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/runtime.so [0x93cd]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/memory.so [0xe899]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/core/core.so [0x7f7db]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/core/core.so [0x1feb3]
=========     Host Frame:python (PyObject_Repr + 0xf8) [0x12d718]
=========     Host Frame:python [0x1ad1fa]
=========     Host Frame:python (PyFile_WriteObject + 0x1ed) [0x12df7d]
=========     Host Frame:python [0x187db5]
=========     Host Frame:python (PyEval_CallObjectWithKeywords + 0x6b) [0xc8c8b]
=========     Host Frame:python (PyEval_EvalFrameEx + 0x58e3) [0x129433]
=========     Host Frame:python [0x167d14]
=========     Host Frame:python (PyRun_InteractiveOneFlags + 0x18c) [0x65a2d]
=========     Host Frame:python (PyRun_InteractiveLoopFlags + 0xaa) [0x65b49]
=========     Host Frame:python (PyRun_AnyFileExFlags + 0x37) [0x661fe]
=========     Host Frame:python (Py_Main + 0xb5e) [0x66d92]
=========     Host Frame:/lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main + 0xf5) [0x21f45]
=========     Host Frame:python [0x177c2e]
=========
Exception ========= Program hit cudaErrorLaunchFailure (error 4) due to "unspecified launch failure" on CUDA API call to cudaFree. 
cupy.cuda.runtime.=========     Saved host backtrace up to driver entry point at error
=========     Host Frame:/usr/local/nvidia/lib64/libcuda.so.1 [0x2eeda3]
=========     Host Frame:/usr/local/cuda/lib64/libcudart.so.7.5 (cudaFree + 0x186) [0x3c666]
CUDARuntimeError: =========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/runtime.so [0x9749]
CUDARuntimeError(u'cudaErrorLaunchFailure: unspecified launch failure',) in =========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/memory.so [0x88c8]
=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/cuda/memory.so [0x683e]
'cupy.=========     Host Frame:/usr/local/lib/python2.7/dist-packages/cupy/core/core.so [0x1a14f]
cuda.memory.Memory=========     Host Frame:python [0x135283]
.__dealloc__'=========     Host Frame:python (PyEval_EvalFrameEx + 0x5938) [0x129488]
 ignored
=========     Host Frame:python [0x167d14]
=========     Host Frame:python (PyRun_InteractiveOneFlags + 0x18c) [0x65a2d]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
=========     Host Frame:python (PyRun_InteractiveLoopFlags + 0xaa) [0x65b49]
=========     Host Frame:python (PyRun_AnyFileExFlags + 0x37) [0x661fe]
=========     Host Frame:python (Py_Main + 0xb5e) [0x66d92]
=========     Host Frame:/lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main + 0xf5) [0x21f45]
=========     Host Frame:python [0x177c2e]
=========
  File "cupy/core/core.pyx", line 1327, in cupy.core.core.ndarray.__repr__ (cupy/core/core.cpp:28337)
  File "cupy/core/core.pyx", line 1372, in cupy.core.core.ndarray.get (cupy/core/core.cpp:28981)
  File "cupy/cuda/memory.pyx", line 219, in cupy.cuda.memory.MemoryPointer.copy_to_host (cupy/cuda/memory.cpp:4839)
  File "cupy/cuda/runtime.pyx", line 241, in cupy.cuda.runtime.memcpy (cupy/cuda/runtime.cpp:4148)
  File "cupy/cuda/runtime.pyx", line 130, in cupy.cuda.runtime.check_status (cupy/cuda/runtime.cpp:2241)
cupy.cuda.runtime.CUDARuntimeError: cudaErrorLaunchFailure: unspecified launch failure
```

After applying the patch, the above code works as expected. 

```
$ cuda-memcheck python
========= CUDA-MEMCHECK
Python 2.7.6 (default, Oct 26 2016, 20:30:19) 
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cupy
>>> cupy.arange(pow(2,29)+1, dtype=cupy.int32)
array([        0,         1,         2, ..., 536870910, 536870911,
       536870912], dtype=int32)
>>> 
```

In this PR I'm using `int64_t` instead of `intptr_t` to avoid additional header dependency.