### PR TITLE
Strengthen the unittest of F.stack

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_stack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_stack.py
@@ -16,6 +16,8 @@ from chainer.testing import attr
         {'shape': (3, 4), 'axis': 1, 'y_shape': (3, 2, 4)},
         {'shape': (3, 4), 'axis': 2, 'y_shape': (3, 4, 2)},
         {'shape': (3, 4), 'axis': -1, 'y_shape': (3, 4, 2)},
+        {'shape': (3, 4), 'axis': -2, 'y_shape': (3, 2, 4)},
+        {'shape': (3, 4), 'axis': -3, 'y_shape': (2, 3, 4)},
         {'shape': (), 'axis': 0, 'y_shape': (2,)},
         {'shape': (), 'axis': -1, 'y_shape': (2,)},
     ],


### PR DESCRIPTION
Current unittest of `F.stack` does not check `axis=-(ndim+1)` case, which is valid. As we would like to add this case to the document (#2491), I add this case to confirm it works.