### PR TITLE
Add axis option to softmax function

### DIFF
--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -29,12 +29,6 @@ class Softmax(function.Function):
             x_type.ndim > 1,
         )
 
-    def _get_cube_shape(self, shape):
-        left_shape = numpy.prod(shape[slice(0, self.axis)], dtype=numpy.int)
-        center_shape = shape[self.axis]
-        right_shape = numpy.prod(shape[slice(self.axis+1, len(shape))], dtype=numpy.int)
-        return left_shape, center_shape, right_shape
-
     def forward(self, x):
         xp = cuda.get_array_module(*x)
         if (xp != numpy and cuda.cudnn_enabled and self.use_cudnn and
@@ -78,6 +72,13 @@ class Softmax(function.Function):
             gx -= self.y * sumdx
 
         return gx,
+
+    def _get_cube_shape(self, shape):
+        left_shape = numpy.prod(shape[slice(0, self.axis)], dtype=numpy.int)
+        center_shape = shape[self.axis]
+        right_shape = numpy.prod(
+            shape[slice(self.axis + 1, len(shape))], dtype=numpy.int)
+        return left_shape, center_shape, right_shape
 
 
 def softmax(x, use_cudnn=True, axis=1):

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -27,6 +27,7 @@ class Softmax(function.Function):
         type_check.expect(
             x_type.dtype.kind == 'f',
             x_type.ndim > 1,
+            self.axis < x_type.ndim
         )
 
     def forward(self, x):

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -82,7 +82,7 @@ class Softmax(function.Function):
 
 
 def softmax(x, use_cudnn=True, axis=1):
-    """Channelwise softmax function.
+    """Softmax function.
 
     This function computes its softmax along an axis. Let
     :math:`x = (x_1, x_2, \\dots, x_d)^{\\top}` be the d dimensional index

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -95,6 +95,7 @@ def softmax(x, use_cudnn=True, axis=1):
         x (~chainer.Variable): Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
+        axis: The axis along which the softmax is to be computed.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -12,10 +12,9 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-f = open('out', 'w')
 @testing.parameterize(*testing.product({
     'shape_axis':
-        [{'shape': None, 'axis': 1},] +
+        [{'shape': None, 'axis': 1}, ] +
         testing.product({'shape': ((3, 4),), 'axis': (0, 1)}) +
         testing.product({'shape': ((3, 4, 5),), 'axis': (0, 1, 2)}) +
         testing.product({'shape': ((3, 4, 5, 6),), 'axis': (0, 1, 2, 3)}),
@@ -26,7 +25,6 @@ class TestSoftmax(unittest.TestCase):
     def setUp(self):
         self.shape = self.shape_axis['shape']
         self.axis = self.shape_axis['axis']
-        f.write(str(self.shape) + str(self.axis) + str(self.dtype) + '\n')
         if self.shape is None:
             # For checking numerical stability
             value = -5 if self.dtype == numpy.float16 else -1000
@@ -71,7 +69,8 @@ class TestSoftmax(unittest.TestCase):
 
     def check_backward(self, x_data, gy_data, use_cudnn=True):
         gradient_check.check_backward(
-            functions.Softmax(use_cudnn=use_cudnn, axis=self.axis), x_data, gy_data,
+            functions.Softmax(use_cudnn=use_cudnn,
+                              axis=self.axis), x_data, gy_data,
             **self.check_backward_options)
 
     @condition.retry(10)


### PR DESCRIPTION
fix #2536, although only one axis is supported.

This PR enables the specification of an axis along which the `softmax` is computed, so that it can be used not just for "channel-wise" computation but also for situations like "pixel-wise" computation.