### PR TITLE
Implement cupy.sort again after reverted.

### DIFF
--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -1,12 +1,17 @@
 from __future__ import print_function
 from distutils import ccompiler
+from distutils import errors
 from distutils import sysconfig
+from distutils import unixccompiler
 import os
 from os import path
+import re
+import subprocess
 import sys
 
 import pkg_resources
 import setuptools
+from setuptools.command import build_ext
 
 from install import build
 from install import utils
@@ -75,6 +80,28 @@ MODULES = [
             'cusolver',
         ],
         'check_method': build.check_cusolver_version,
+    },
+    {
+        # The value of the key 'file' is a list that contains extension names
+        # or tuples of an extension name and a list of other souces files
+        # required to build the extension such as .cpp files and .cu files.
+        #
+        #   <extension name> | (<extension name>, a list of <other source>)
+        #
+        # The extension name is also interpreted as the name of the Cython
+        # source file required to build the extension with appending '.pyx'
+        # file extension.
+        'name': 'thrust',
+        'file': [
+            ('cupy.cuda.thrust', ['cupy/cuda/cupy_thrust.cu']),
+        ],
+        'include': [
+            'thrust/device_ptr.h',
+            'thrust/sort.h',
+        ],
+        'libraries': [
+            'cudart',
+        ],
     }
 ]
 
@@ -88,6 +115,36 @@ if sys.platform == 'win32':
             'Cannot find nvToolsExt. nvtx was disabled.')
     else:
         mod_cuda['libraries'].append('nvToolsExt64_1')
+
+
+def ensure_module_file(file):
+    if isinstance(file, tuple):
+        return file
+    else:
+        return (file, [])
+
+
+def module_extension_name(file):
+    return ensure_module_file(file)[0]
+
+
+def module_extension_sources(file, use_cython, no_cuda):
+    pyx, others = ensure_module_file(file)
+    ext = '.pyx' if use_cython else '.cpp'
+    pyx = path.join(*pyx.split('.')) + ext
+
+    # If CUDA SDK is not available, remove CUDA C files from extension sources
+    # and use stubs defined in header files.
+    if no_cuda:
+        others1 = []
+        for source in others:
+            base, ext = os.path.splitext(source)
+            if ext == '.cu':
+                continue
+            others1.append(source)
+        others = others1
+
+    return [pyx] + others
 
 
 def check_readthedocs_environment():
@@ -146,7 +203,6 @@ def make_extensions(options, compiler, use_cython):
         settings['define_macros'].append(('CUPY_NO_CUDA', '1'))
 
     ret = []
-    ext = '.pyx' if use_cython else '.cpp'
     for module in MODULES:
         print('Include directories:', settings['include_dirs'])
         print('Library directories:', settings['library_dirs'])
@@ -187,9 +243,12 @@ def make_extensions(options, compiler, use_cython):
             elif compiler.compiler_type == 'msvc':
                 args.append('/openmp')
 
-        ret.extend([
-            setuptools.Extension(f, [path.join(*f.split('.')) + ext], **s)
-            for f in module['file']])
+        for f in module['file']:
+            name = module_extension_name(f)
+            sources = module_extension_sources(f, use_cython, no_cuda)
+            extension = setuptools.Extension(name, sources, **s)
+            ret.append(extension)
+
     return ret
 
 
@@ -268,3 +327,74 @@ def get_ext_modules():
 
     check_extensions(extensions)
     return extensions
+
+
+def _nvcc_gencode_options():
+    """Returns NVCC gencode options generated from NVCC command line help."""
+    help_string = subprocess.check_output(
+        ['nvcc', '--help']).decode('ascii').replace('\n', '')
+
+    arch_options = re.findall("'(compute_\d{2})'", help_string)
+    arch_options = sorted(list(set(arch_options)))
+    arch_options = list(filter(lambda x: x >= 'compute_30', arch_options))
+
+    code_options = re.findall("'(sm_\d{2})'", help_string)
+    code_options = sorted(list(set(code_options)))
+    code_options = list(filter(lambda x: x >= 'sm_30', code_options))
+
+    pairs = []
+    for code_option in code_options:
+        arch_option = code_option.replace('sm_', 'compute_')
+        if arch_option not in arch_options:
+            msg = "No virtual architecture corresponding to '{}'.".format(
+                code_option)
+            raise ValueError(msg)
+        pairs.append((arch_option, code_option))
+
+    gencode_options = []
+    for pair in pairs:
+        gencode_options.append('-gencode=arch={},code={}'.format(*pair))
+
+    return gencode_options
+
+
+class NvidiaCCompiler(unixccompiler.UnixCCompiler):
+    compiler_type = "nvidia"
+    src_extensions = ['.cpp', '.cu']
+
+    def __init__(self, verbose=0, dry_run=0, force=0):
+        unixccompiler.UnixCCompiler.__init__(
+            self, verbose=verbose, dry_run=dry_run, force=force)
+        postargs = _nvcc_gencode_options()
+        if sys.platform == 'win32':
+            self.set_executables(compiler=['nvcc', '-O2'] + postargs,
+                                 compiler_so=['nvcc', '-O2'] + postargs,
+                                 compiler_cxx=['nvcc', '-O2'] + postargs,
+                                 linker_so=['nvcc', '-shared'],
+                                 linker_exe=['nvcc'])
+        else:
+            postargs += ['--compiler-options=-fPIC']
+            self.set_executables(compiler=['nvcc', '-O2'] + postargs,
+                                 compiler_so=['nvcc', '-O2'] + postargs,
+                                 compiler_cxx=['g++', '-O2'] + postargs,
+                                 linker_so=['nvcc', '-shared'],
+                                 linker_exe=['nvcc'])
+
+
+class custom_build_ext(build_ext.build_ext):
+
+    """Custom `build_ext` command to include CUDA C source files."""
+
+    def run(self):
+        if build.get_nvcc_path() is not None:
+            def wrap_new_compiler(func):
+                def _wrap_new_compiler(*args, **kwargs):
+                    try:
+                        return func(*args, **kwargs)
+                    except errors.DistutilsPlatformError:
+                        return NvidiaCCompiler(
+                            None, kwargs["dry_run"], kwargs["force"])
+                return _wrap_new_compiler
+            ccompiler.new_compiler = wrap_new_compiler(ccompiler.new_compiler)
+            self.compiler = "nvidia"
+        build_ext.build_ext.run(self)

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -235,13 +235,16 @@ def make_extensions(options, compiler, use_cython):
             s['libraries'] = module['libraries']
 
         if module['name'] == 'cusolver':
-            args = s.setdefault('extra_link_args', [])
+            compile_args = s.setdefault('extra_compile_args', [])
+            link_args = s.setdefault('extra_link_args', [])
             # openmp is required for cusolver
             if compiler.compiler_type == 'unix' and sys.platform != 'darwin':
                 # In mac environment, openmp is not required.
-                args.append('-fopenmp')
+                compile_args.append('-fopenmp')
+                link_args.append('-fopenmp')
             elif compiler.compiler_type == 'msvc':
-                args.append('--compiler-options=/openmp')
+                compile_args.append('--compiler-options=/openmp')
+                link_args.append('--compiler-options=/openmp')
 
         for f in module['file']:
             name = module_extension_name(f)

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -383,9 +383,14 @@ class NvidiaCCompiler(unixccompiler.UnixCCompiler):
             postargs += ['--compiler-options=-fPIC']
 
         nvcc_cmd = 'nvcc -O2 ' + ' '.join(postargs) + ' ' + cflags
+        if not sys.platform == 'win32':
+            cxx_cmd = 'g++'
+        else:
+            cxx_cmd = 'nvcc'
+        cxx_cmd += ' -O2 ' + ' '.join(postargs) + ' ' + cflags
         self.set_executables(compiler=nvcc_cmd,
                              compiler_so=nvcc_cmd,
-                             compiler_cxx=['g++', '-O2'] + postargs,
+                             compiler_cxx=cxx_cmd,
                              linker_so=ldshared,
                              linker_exe=['nvcc'])
 

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -235,16 +235,13 @@ def make_extensions(options, compiler, use_cython):
             s['libraries'] = module['libraries']
 
         if module['name'] == 'cusolver':
-            compile_args = s.setdefault('extra_compile_args', [])
-            link_args = s.setdefault('extra_link_args', [])
+            args = s.setdefault('extra_compile_args', [])
             # openmp is required for cusolver
             if compiler.compiler_type == 'unix' and sys.platform != 'darwin':
                 # In mac environment, openmp is not required.
-                compile_args.append('-fopenmp')
-                link_args.append('-fopenmp')
+                args.append('-fopenmp')
             elif compiler.compiler_type == 'msvc':
-                compile_args.append('--compiler-options=/openmp')
-                link_args.append('--compiler-options=/openmp')
+                args.append('--compiler-options=/openmp')
 
         for f in module['file']:
             name = module_extension_name(f)

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -241,7 +241,7 @@ def make_extensions(options, compiler, use_cython):
                 # In mac environment, openmp is not required.
                 args.append('-fopenmp')
             elif compiler.compiler_type == 'msvc':
-                args.append('/openmp')
+                args.append('--compiler-options=/openmp')
 
         for f in module['file']:
             name = module_extension_name(f)

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -235,16 +235,13 @@ def make_extensions(options, compiler, use_cython):
             s['libraries'] = module['libraries']
 
         if module['name'] == 'cusolver':
-            compile_args = s.setdefault('extra_compile_args', [])
-            link_args = s.setdefault('extra_link_args', [])
+            args = s.setdefault('extra_link_args', [])
             # openmp is required for cusolver
             if compiler.compiler_type == 'unix' and sys.platform != 'darwin':
                 # In mac environment, openmp is not required.
-                compile_args.append('-fopenmp')
-                link_args.append('-fopenmp')
+                args.append('-fopenmp')
             elif compiler.compiler_type == 'msvc':
-                compile_args.append('--compiler-options=/openmp')
-                link_args.append('--compiler-options=/openmp')
+                args.append('--compiler-options=/openmp')
 
         for f in module['file']:
             name = module_extension_name(f)

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -407,7 +407,7 @@ class custom_build_ext(build_ext.build_ext):
                         return func(*args, **kwargs)
                     except errors.DistutilsPlatformError:
                         return NvidiaCCompiler(
-                            None, kwargs["dry_run"], kwargs["force"])
+                            None, kwargs['dry_run'], kwargs['force'])
                 return _wrap_new_compiler
             ccompiler.new_compiler = wrap_new_compiler(ccompiler.new_compiler)
             self.compiler = "nvidia"

--- a/chainer_setup_build.py
+++ b/chainer_setup_build.py
@@ -235,13 +235,16 @@ def make_extensions(options, compiler, use_cython):
             s['libraries'] = module['libraries']
 
         if module['name'] == 'cusolver':
-            args = s.setdefault('extra_compile_args', [])
+            compile_args = s.setdefault('extra_compile_args', [])
+            link_args = s.setdefault('extra_link_args', [])
             # openmp is required for cusolver
             if compiler.compiler_type == 'unix' and sys.platform != 'darwin':
                 # In mac environment, openmp is not required.
-                args.append('-fopenmp')
+                compile_args.append('-fopenmp')
+                link_args.append('-fopenmp')
             elif compiler.compiler_type == 'msvc':
-                args.append('--compiler-options=/openmp')
+                compile_args.append('--compiler-options=/openmp')
+                link_args.append('--compiler-options=/openmp')
 
         for f in module['file']:
             name = module_extension_name(f)

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -388,6 +388,8 @@ from cupy.core.fusion import where  # NOQA
 from cupy.sorting.search import argmax  # NOQA
 from cupy.sorting.search import argmin  # NOQA
 
+from cupy.sorting.sort import sort  # NOQA
+
 # -----------------------------------------------------------------------------
 # Statistics
 # -----------------------------------------------------------------------------

--- a/cupy/cuda/common.pxd
+++ b/cupy/cuda/common.pxd
@@ -1,0 +1,13 @@
+# distutils: language = c++
+
+cdef extern from '../cuda/cupy_common.h':  # thru parent to import in core
+    ctypedef char cpy_byte
+    ctypedef unsigned char cpy_ubyte
+    ctypedef short cpy_short
+    ctypedef unsigned short cpy_ushort
+    ctypedef int cpy_int
+    ctypedef unsigned int cpy_uint
+    ctypedef long cpy_long
+    ctypedef unsigned long cpy_ulong
+    ctypedef float cpy_float
+    ctypedef double cpy_double

--- a/cupy/cuda/cupy_common.h
+++ b/cupy/cuda/cupy_common.h
@@ -1,0 +1,15 @@
+#ifndef INCLUDE_GUARD_CUPY_CUDA_COMMON_H
+#define INCLUDE_GUARD_CUPY_CUDA_COMMON_H
+
+typedef char cpy_byte;
+typedef unsigned char cpy_ubyte;
+typedef short cpy_short;
+typedef unsigned short cpy_ushort;
+typedef int cpy_int;
+typedef unsigned int cpy_uint;
+typedef long long cpy_long;
+typedef unsigned long long cpy_ulong;
+typedef float cpy_float;
+typedef double cpy_double;
+
+#endif // INCLUDE_GUARD_CUPY_CUDA_COMMON_H

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -1,0 +1,24 @@
+#include <thrust/device_ptr.h>
+#include <thrust/sort.h>
+#include "cupy_common.h"
+#include "cupy_thrust.h"
+
+using namespace thrust;
+
+template <typename T>
+void cupy::thrust::_sort(void *start, ptrdiff_t num) {
+    device_ptr<T> dp_first = device_pointer_cast((T *)start);
+    device_ptr<T> dp_last  = device_pointer_cast((T *)start + num);
+    stable_sort< device_ptr<T> >(dp_first, dp_last);
+}
+
+template void cupy::thrust::_sort<cpy_byte>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_ubyte>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_short>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_ushort>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_int>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_uint>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_long>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_ulong>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_float>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_double>(void *, ptrdiff_t);

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -1,0 +1,32 @@
+#ifndef INCLUDE_GUARD_CUPY_CUDA_THRUST_H
+#define INCLUDE_GUARD_CUPY_CUDA_THRUST_H
+
+#ifndef CUPY_NO_CUDA
+
+namespace cupy {
+
+namespace thrust {
+
+template <typename T> void _sort(void *, ptrdiff_t);
+
+} // namespace thrust
+
+} // namespace cupy
+
+#else // CUPY_NO_CUDA
+
+#include "cupy_common.h"
+
+namespace cupy {
+
+namespace thrust {
+
+template <typename T> void _sort(void *, ptrdiff_t) { return; }
+
+} // namespace thrust
+
+} // namespace cupy
+
+#endif // #ifndef CUPY_NO_CUDA
+
+#endif // INCLUDE_GUARD_CUPY_CUDA_THRUST_H

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -1,0 +1,52 @@
+# distutils: language = c++
+
+"""Thin wrapper of Thrust implementations for CuPy API."""
+
+import numpy
+
+from cupy.cuda cimport common
+
+
+###############################################################################
+# Extern
+###############################################################################
+
+cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
+    void _sort[T](void *start, ptrdiff_t num)
+
+
+###############################################################################
+# Python interface
+###############################################################################
+
+cpdef sort(dtype, size_t start, size_t num):
+    cdef void* ptr
+    cdef Py_ssize_t n
+
+    ptr = <void *>start
+    n = <Py_ssize_t> num
+
+    # TODO(takagi): Support float16 and bool
+    if dtype == numpy.int8:
+        _sort[common.cpy_byte](ptr, n)
+    elif dtype == numpy.uint8:
+        _sort[common.cpy_ubyte](ptr, n)
+    elif dtype == numpy.int16:
+        _sort[common.cpy_short](ptr, n)
+    elif dtype == numpy.uint16:
+        _sort[common.cpy_ushort](ptr, n)
+    elif dtype == numpy.int32:
+        _sort[common.cpy_int](ptr, n)
+    elif dtype == numpy.uint32:
+        _sort[common.cpy_uint](ptr, n)
+    elif dtype == numpy.int64:
+        _sort[common.cpy_long](ptr, n)
+    elif dtype == numpy.uint64:
+        _sort[common.cpy_ulong](ptr, n)
+    elif dtype == numpy.float32:
+        _sort[common.cpy_float](ptr, n)
+    elif dtype == numpy.float64:
+        _sort[common.cpy_double](ptr, n)
+    else:
+        msg = "Sorting arrays with dtype '{}' is not supported"
+        raise TypeError(msg.format(dtype))

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -1,7 +1,23 @@
-# flake8: NOQA
-# "flake8: NOQA" to suppress warning "H104  File contains nothing but comments"
+def sort(a):
+    """Returns a sorted copy of an array with a stable sorting algorithm.
 
-# TODO(okuta): Implement sort
+    Args:
+        a (cupy.ndarray): Array to be sorted.
+
+    Returns:
+        cupy.ndarray: Array of the same type and shape as ``a``.
+
+    .. note::
+       For its implementation reason, ``cupy.sort`` currently supports only
+       arrays with their rank of one and does not support ``axis``, ``kind``
+       and ``order`` parameters that ``numpy.sort`` does support.
+
+    .. seealso:: :func:`numpy.sort`
+
+    """
+    ret = a.copy()
+    ret.sort()
+    return ret
 
 
 # TODO(okuta): Implement lexsort

--- a/docs/source/cupy-reference/sorting.rst
+++ b/docs/source/cupy-reference/sorting.rst
@@ -1,6 +1,7 @@
 Sorting, Searching, and Counting
 ================================
 
+.. autofunction:: cupy.sort
 .. autofunction:: cupy.argmax
 .. autofunction:: cupy.argmin
 .. autofunction:: cupy.count_nonzero

--- a/install/build.py
+++ b/install/build.py
@@ -15,14 +15,23 @@ maximum_cudnn_version = 6999
 # provided functions are insufficient to implement cupy.linalg
 minimum_cusolver_cuda_version = 8000
 
+get_nvcc_path_warned = False
 
-def get_compiler_setting():
+
+def get_nvcc_path():
+    global get_nvcc_path_warned
     nvcc_path = utils.search_on_path(('nvcc', 'nvcc.exe'))
-    cuda_path_default = None
-    if nvcc_path is None:
+    if nvcc_path is None and not get_nvcc_path_warned:
         utils.print_warning('nvcc not in path.',
                             'Please set path to nvcc.')
-    else:
+        get_nvcc_path_warned = True
+    return nvcc_path
+
+
+def get_compiler_setting():
+    nvcc_path = get_nvcc_path()
+    cuda_path_default = None
+    if nvcc_path is not None:
         cuda_path_default = os.path.normpath(
             os.path.join(os.path.dirname(nvcc_path), '..'))
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
 ]
 
 ext_modules = chainer_setup_build.get_ext_modules()
+build_ext = chainer_setup_build.custom_build_ext
 
 setup(
     name='chainer',
@@ -102,4 +103,5 @@ setup(
     tests_require=['mock',
                    'nose'],
     ext_modules=ext_modules,
+    cmdclass={'build_ext': build_ext}
 )

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -1,5 +1,8 @@
 import unittest
 
+import numpy
+
+import cupy
 from cupy import testing
 
 
@@ -7,3 +10,77 @@ from cupy import testing
 class TestSort(unittest.TestCase):
 
     _multiprocess_can_split_ = True
+
+    # Test ranks
+
+    @testing.numpy_cupy_raises()
+    def test_sort_zero_dim(self, xp):
+        a = testing.shaped_random((), xp)
+        a.sort()
+
+    @testing.numpy_cupy_raises()
+    def test_external_sort_zero_dim(self, xp):
+        a = testing.shaped_random((), xp)
+        return xp.sort(a)
+
+    def test_sort_two_or_more_dim(self):
+        a = testing.shaped_random((2, 3), cupy)
+        with self.assertRaises(ValueError):
+            a.sort()
+
+    def test_external_sort_two_or_more_dim(self):
+        a = testing.shaped_random((2, 3), cupy)
+        with self.assertRaises(ValueError):
+            return cupy.sort(a)
+
+    # Test dtypes
+
+    @testing.for_dtypes(['b', 'h', 'i', 'l', 'q', 'B', 'H', 'I', 'L', 'Q',
+                         numpy.float32, numpy.float64])
+    @testing.numpy_cupy_allclose()
+    def test_sort_dtype(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        a.sort()
+        return a
+
+    @testing.for_dtypes(['b', 'h', 'i', 'l', 'q', 'B', 'H', 'I', 'L', 'Q',
+                         numpy.float32, numpy.float64])
+    @testing.numpy_cupy_allclose()
+    def test_external_sort_dtype(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        return xp.sort(a)
+
+    @testing.for_dtypes([numpy.float16, numpy.bool_])
+    def test_sort_unsupported_dtype(self, dtype):
+        a = testing.shaped_random((10,), cupy, dtype)
+        with self.assertRaises(TypeError):
+            a.sort()
+
+    @testing.for_dtypes([numpy.float16, numpy.bool_])
+    def test_external_sort_unsupported_dtype(self, dtype):
+        a = testing.shaped_random((10,), cupy, dtype)
+        with self.assertRaises(TypeError):
+            return cupy.sort(a)
+
+    # Test contiguous arrays
+
+    @testing.numpy_cupy_allclose()
+    def test_sort_contiguous(self, xp):
+        a = testing.shaped_random((10,), xp)[::]  # C contiguous view
+        a.sort()
+        return a
+
+    def test_sort_non_contiguous(self):
+        a = testing.shaped_random((10,), cupy)[::2]  # Non contiguous view
+        with self.assertRaises(ValueError):
+            a.sort()
+
+    @testing.numpy_cupy_allclose()
+    def test_external_sort_contiguous(self, xp):
+        a = testing.shaped_random((10,), xp)[::]  # C contiguous view
+        return xp.sort(a)
+
+    @testing.numpy_cupy_allclose()
+    def test_external_sort_non_contiguous(self, xp):
+        a = testing.shaped_random((10,), xp)[::2]  # Non contiguous view
+        return xp.sort(a)


### PR DESCRIPTION
`cupy.sort` was once pull requested on #1817, but reverted on #2523 because of some additional fix on handling `CFLAGS`, `LDFLAGS` and `CPPFLAGS` on #2522 .

This PR requests implementing `cupy.sort` again.