### PR TITLE
Replace all get_device() functions with get_device_from_id() or get_device_from_array()

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -153,14 +153,14 @@ else:
 # ------------------------------------------------------------------------------
 # Global states
 # ------------------------------------------------------------------------------
-def get_device_from_id(device_id):
+def get_device_from_id(device_id=None):
     """Gets the device from an ID integer.
 
     Args:
         device_id (int or None): The ID of the device which this function
             returns.
     """
-    if device_id is not None:
+    if type(device_id) in _integer_types:
         check_cuda_available()
         return Device(device_id)
     else:

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -235,12 +235,12 @@ def get_device(*args):
 # cupy.ndarray allocation and copy
 # ------------------------------------------------------------------------------
 
-def to_gpu(array, device=None, stream=None):
+def to_gpu(array, device_id=None, stream=None):
     """Copies the given CPU array to specified device.
 
     Args:
         array: Array to be sent to GPU.
-        device: Device specifier.
+        device_id (int): A target device ID.
         stream (cupy.cuda.Stream): CUDA stream. If not ``None``, the copy runs
             asynchronously.
 
@@ -253,8 +253,8 @@ def to_gpu(array, device=None, stream=None):
 
     """
     check_cuda_available()
-    with get_device(device):
-        array_dev = get_device(array)
+    with get_device_from_id(device_id):
+        array_dev = get_device_from_array(array)
         if array_dev.id == cupy.cuda.device.get_device_id():
             return array
 

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -255,6 +255,8 @@ def to_gpu(array, device=None, stream=None):
     check_cuda_available()
     if type(device) in _integer_types:
         device = get_device_from_id(device)
+    elif device is None:
+        device = DummyDevice
     with device:
         array_dev = get_device_from_array(array)
         if array_dev.id == cupy.cuda.device.get_device_id():

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -235,12 +235,12 @@ def get_device(*args):
 # cupy.ndarray allocation and copy
 # ------------------------------------------------------------------------------
 
-def to_gpu(array, device_id=None, stream=None):
+def to_gpu(array, device=None, stream=None):
     """Copies the given CPU array to specified device.
 
     Args:
         array: Array to be sent to GPU.
-        device_id (int): A target device ID.
+        device: Device specifier.
         stream (cupy.cuda.Stream): CUDA stream. If not ``None``, the copy runs
             asynchronously.
 
@@ -253,7 +253,9 @@ def to_gpu(array, device_id=None, stream=None):
 
     """
     check_cuda_available()
-    with get_device_from_id(device_id):
+    if type(device) in _integer_types:
+        device = get_device_from_id(device)
+    with device:
         array_dev = get_device_from_array(array)
         if array_dev.id == cupy.cuda.device.get_device_id():
             return array

--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -119,7 +119,7 @@ def _concat_arrays(arrays, padding):
         return _concat_arrays_with_padding(arrays, padding)
 
     xp = cuda.get_array_module(arrays[0])
-    with cuda.get_device(arrays[0]):
+    with cuda.get_device_from_array(arrays[0]):
         return xp.concatenate([array[None] for array in arrays])
 
 
@@ -131,7 +131,7 @@ def _concat_arrays_with_padding(arrays, padding):
     shape = tuple(numpy.insert(shape, 0, len(arrays)))
 
     xp = cuda.get_array_module(arrays[0])
-    with cuda.get_device(arrays[0]):
+    with cuda.get_device_from_array(arrays[0]):
         result = xp.full(shape, padding, dtype=arrays[0].dtype)
         for i in six.moves.range(len(arrays)):
             src = arrays[i]

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -195,7 +195,7 @@ class Function(object):
         for hook in six.itervalues(hooks):
             hook.forward_preprocess(self, in_data)
         # Forward prop
-        with cuda.get_device(*in_data):
+        with cuda.get_device_from_array(*in_data):
             outputs = self.forward(in_data)
             assert type(outputs) == tuple
         for hook in six.itervalues(hooks):

--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -43,9 +43,9 @@ class Copy(function.Function):
 
     def backward_gpu(self, x, gy):
         if self.out_device == -1:
-            return cuda.to_gpu(gy[0], device=cuda.get_device(x[0])),
+            return cuda.to_gpu(gy[0], device=cuda.get_device_from_array(x[0])),
         else:
-            return cuda.copy(gy[0], out_device=cuda.get_device(x[0])),
+            return cuda.copy(gy[0], out_device=cuda.get_device_from_array(x[0])),
 
 
 def copy(x, dst):

--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -45,7 +45,8 @@ class Copy(function.Function):
         if self.out_device == -1:
             return cuda.to_gpu(gy[0], device=cuda.get_device_from_array(x[0])),
         else:
-            return cuda.copy(gy[0], out_device=cuda.get_device_from_array(x[0])),
+            return cuda.copy(
+                gy[0], out_device=cuda.get_device_from_array(x[0])),
 
 
 def copy(x, dst):

--- a/chainer/functions/theano/theano_function.py
+++ b/chainer/functions/theano/theano_function.py
@@ -35,7 +35,7 @@ class TheanoFunction(function.Function):
         if gpu:
             # TODO(unno): We can remove redundant gpu-cpu copy using
             # theano.sandbox.cuda.CudaNdarray.gpudata
-            device = cuda.get_device(inputs)
+            device = cuda.get_device_from_array(inputs)
             outputs = [cuda.to_gpu(x, device) for x in outputs]
 
         return tuple(outputs)
@@ -53,7 +53,7 @@ class TheanoFunction(function.Function):
         if gpu:
             # TODO(unno): We can remove redundant gpu-cpu copy using
             # theano.sandbox.cuda.CudaNdarray.gpudata
-            device = cuda.get_device(inputs)
+            device = cuda.get_device_from_array(inputs)
             outputs = [cuda.to_gpu(x, device) for x in outputs]
 
         results = []

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -623,8 +623,8 @@ class Chain(Link):
             d[name].to_cpu()
         return self
 
-    def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device.id if device else None):
+    def to_gpu(self, device_id=None):
+        with cuda.get_device_from_id(device_id):
             super(Chain, self).to_gpu()
             d = self.__dict__
             for name in self._children:
@@ -777,8 +777,8 @@ class ChainList(Link):
             link.to_cpu()
         return self
 
-    def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device.id if device else None):
+    def to_gpu(self, device_id=None):
+        with cuda.get_device_from_id(device_id):
             super(ChainList, self).to_gpu()
             for link in self._children:
                 link.to_gpu()

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -310,7 +310,7 @@ class Link(object):
         self._device_id = None
         return self
 
-    def to_gpu(self, device=None):
+    def to_gpu(self, device_id=None):
         """Copies parameter variables and persistent values to GPU.
 
         This method does not handle non-registered attributes. If some of such
@@ -318,8 +318,8 @@ class Link(object):
         override this method to do so.
 
         Args:
-            device: Target device specifier. If omitted, the current device is
-                used.
+            device_id (int): The target device ID. If omitted, the current
+                device is used.
 
         Returns: self
 
@@ -328,7 +328,9 @@ class Link(object):
         if not self._cpu:
             return self
         d = self.__dict__
-        with cuda.get_device_from_id(device.id if device else None):
+        if not device_id:
+            device_id = cuda.cupy.cuda.get_device_id()
+        with cuda.get_device_from_id(device_id):
             for name in self._params:
                 d[name].to_gpu()
             for name in self._persistent:

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -331,6 +331,8 @@ class Link(object):
         if device is None:
             device_id = cuda.cupy.cuda.get_device_id()
             device = cuda.get_device_from_id(device_id)
+        elif type(device) in cuda._integer_types:
+            device = cuda.get_device_from_id(device)
         with device:
             for name in self._params:
                 d[name].to_gpu()

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -328,7 +328,7 @@ class Link(object):
         if not self._cpu:
             return self
         d = self.__dict__
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             for name in self._params:
                 d[name].to_gpu()
             for name in self._persistent:
@@ -622,7 +622,7 @@ class Chain(Link):
         return self
 
     def to_gpu(self, device=None):
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             super(Chain, self).to_gpu()
             d = self.__dict__
             for name in self._children:
@@ -776,7 +776,7 @@ class ChainList(Link):
         return self
 
     def to_gpu(self, device=None):
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             super(ChainList, self).to_gpu()
             for link in self._children:
                 link.to_gpu()

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -624,8 +624,13 @@ class Chain(Link):
             d[name].to_cpu()
         return self
 
-    def to_gpu(self, device_id=None):
-        with cuda.get_device_from_id(device_id):
+    def to_gpu(self, device=None):
+        if device is None:
+            device_id = cuda.cupy.cuda.get_device_id()
+            device = cuda.get_device_from_id(device_id)
+        elif type(device) in cuda._integer_types:
+            device = cuda.get_device_from_id(device)
+        with device:
             super(Chain, self).to_gpu()
             d = self.__dict__
             for name in self._children:
@@ -778,8 +783,13 @@ class ChainList(Link):
             link.to_cpu()
         return self
 
-    def to_gpu(self, device_id=None):
-        with cuda.get_device_from_id(device_id):
+    def to_gpu(self, device=None):
+        if device is None:
+            device_id = cuda.cupy.cuda.get_device_id()
+            device = cuda.get_device_from_id(device_id)
+        elif type(device) in cuda._integer_types:
+            device = cuda.get_device_from_id(device)
+        with device:
             super(ChainList, self).to_gpu()
             for link in self._children:
                 link.to_gpu()

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -310,7 +310,7 @@ class Link(object):
         self._device_id = None
         return self
 
-    def to_gpu(self, device_id=None):
+    def to_gpu(self, device=None):
         """Copies parameter variables and persistent values to GPU.
 
         This method does not handle non-registered attributes. If some of such
@@ -318,8 +318,8 @@ class Link(object):
         override this method to do so.
 
         Args:
-            device_id (int): The target device ID. If omitted, the current
-                device is used.
+            device: Target device specifier. If omitted, the current device is
+                used.
 
         Returns: self
 
@@ -328,9 +328,10 @@ class Link(object):
         if not self._cpu:
             return self
         d = self.__dict__
-        if device_id is None:
+        if device is None:
             device_id = cuda.cupy.cuda.get_device_id()
-        with cuda.get_device_from_id(device_id):
+            device = cuda.get_device_from_id(device_id)
+        with device:
             for name in self._params:
                 d[name].to_gpu()
             for name in self._persistent:

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -326,12 +326,7 @@ class Link(object):
         if not self._cpu:
             return self
         d = self.__dict__
-        if device is None:
-            device_id = cuda.cupy.cuda.get_device_id()
-            device = cuda.get_device_from_id(device_id)
-        elif type(device) in cuda._integer_types:
-            device = cuda.get_device_from_id(device)
-        with device:
+        with cuda.get_device_from_id(device):
             for name in self._params:
                 d[name].to_gpu()
             for name in self._persistent:
@@ -625,12 +620,7 @@ class Chain(Link):
         return self
 
     def to_gpu(self, device=None):
-        if device is None:
-            device_id = cuda.cupy.cuda.get_device_id()
-            device = cuda.get_device_from_id(device_id)
-        elif type(device) in cuda._integer_types:
-            device = cuda.get_device_from_id(device)
-        with device:
+        with cuda.get_device_from_id(device):
             super(Chain, self).to_gpu()
             d = self.__dict__
             for name in self._children:
@@ -784,12 +774,7 @@ class ChainList(Link):
         return self
 
     def to_gpu(self, device=None):
-        if device is None:
-            device_id = cuda.cupy.cuda.get_device_id()
-            device = cuda.get_device_from_id(device_id)
-        elif type(device) in cuda._integer_types:
-            device = cuda.get_device_from_id(device)
-        with device:
+        with cuda.get_device_from_id(device):
             super(ChainList, self).to_gpu()
             for link in self._children:
                 link.to_gpu()

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -328,7 +328,7 @@ class Link(object):
         if not self._cpu:
             return self
         d = self.__dict__
-        if not device_id:
+        if device_id is None:
             device_id = cuda.cupy.cuda.get_device_id()
         with cuda.get_device_from_id(device_id):
             for name in self._params:

--- a/chainer/links/activation/simplified_dropconnect.py
+++ b/chainer/links/activation/simplified_dropconnect.py
@@ -89,7 +89,7 @@ class SimplifiedDropconnect(link.Link):
 
         """
         if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self._initialize_params(x.size // len(x.data))
         if mask is not None and 'mask' not in self.__dict__:
             self.add_persistent('mask', mask)

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -102,7 +102,7 @@ class Convolution2D(link.Link):
 
         """
         if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self._initialize_params(x.shape[1])
         return convolution_2d.convolution_2d(
             x, self.W, self.b, self.stride, self.pad, self.use_cudnn,

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -109,7 +109,7 @@ class Deconvolution2D(link.Link):
 
     def __call__(self, x):
         if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self._initialize_params(x.shape[1])
         return deconvolution_2d.deconvolution_2d(
             x, self.W, self.b, self.stride, self.pad,

--- a/chainer/links/connection/depthwise_convolution_2d.py
+++ b/chainer/links/connection/depthwise_convolution_2d.py
@@ -99,7 +99,7 @@ class DepthwiseConvolution2D(link.Link):
 
         """
         if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self._initialize_params(x.shape[1])
         return depthwise_convolution_2d.depthwise_convolution_2d(
             x, self.W, self.b, self.stride, self.pad)

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -95,7 +95,7 @@ class DilatedConvolution2D(link.Link):
 
         """
         if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self._initialize_params(x.shape[1])
         return dilated_convolution_2d.dilated_convolution_2d(
             x, self.W, self.b, self.stride,

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -88,6 +88,6 @@ class Linear(link.Link):
 
         """
         if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self._initialize_params(x.size // x.shape[0])
         return linear.linear(x, self.W, self.b)

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -84,7 +84,7 @@ class StatelessLSTM(LSTMBase):
         """
         if self.upward.has_uninitialized_params:
             in_size = x.size // x.shape[0]
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self.upward._initialize_params(in_size)
                 self._initialize_params()
 
@@ -93,7 +93,7 @@ class StatelessLSTM(LSTMBase):
             lstm_in += self.lateral(h)
         if c is None:
             xp = self.xp
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 c = variable.Variable(
                     xp.zeros((x.shape[0], self.state_size), dtype=x.dtype),
                     volatile='auto')
@@ -219,7 +219,7 @@ class LSTM(LSTMBase):
 
         """
         if self.upward.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 in_size = x.size // x.shape[0]
                 self.upward._initialize_params(in_size)
                 self._initialize_params()
@@ -243,7 +243,7 @@ class LSTM(LSTMBase):
                 lstm_in += self.lateral(self.h)
         if self.c is None:
             xp = self.xp
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self.c = variable.Variable(
                     xp.zeros((batch, self.state_size), dtype=x.dtype),
                     volatile='auto')

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -90,7 +90,7 @@ class NStepLSTM(link.ChainList):
 
         xs = permutate_list(xs, indices, inv=False)
         if hx is None:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 hx = chainer.Variable(
                     self.xp.zeros(
                         (self.n_layers, len(xs), self.out_size),
@@ -100,7 +100,7 @@ class NStepLSTM(link.ChainList):
             hx = permutate.permutate(hx, indices, axis=1, inv=False)
 
         if cx is None:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 cx = chainer.Variable(
                     self.xp.zeros(
                         (self.n_layers, len(xs), self.out_size),

--- a/chainer/links/connection/parameter.py
+++ b/chainer/links/connection/parameter.py
@@ -24,7 +24,7 @@ class Parameter(link.Link):
         self.add_param('W', array.shape, dtype=array.dtype)
         self.W.data = array
         if isinstance(array, cuda.ndarray):
-            self.to_gpu(array)
+            self.to_gpu(cuda.get_device_from_array(array))
 
     def __call__(self, volatile='off'):
         """Returns the parameter variable.

--- a/chainer/links/connection/peephole.py
+++ b/chainer/links/connection/peephole.py
@@ -99,7 +99,7 @@ class StatefulPeepholeLSTM(link.Chain):
             lstm_in += self.lateral(self.h)
         if self.c is None:
             xp = self.xp
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self.c = variable.Variable(
                     xp.zeros((x.shape[0], self.state_size), dtype=x.dtype),
                     volatile='auto')

--- a/chainer/links/connection/zoneoutlstm.py
+++ b/chainer/links/connection/zoneoutlstm.py
@@ -87,14 +87,14 @@ class StatefulZoneoutLSTM(link.Chain):
             lstm_in += self.lateral(self.h)
         else:
             xp = self.xp
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self.h = variable.Variable(
                     xp.zeros((len(x.data), self.state_size),
                              dtype=x.data.dtype),
                     volatile='auto')
         if self.c is None:
             xp = self.xp
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self.c = variable.Variable(
                     xp.zeros((len(x.data), self.state_size),
                              dtype=x.data.dtype),

--- a/chainer/links/loss/black_out.py
+++ b/chainer/links/loss/black_out.py
@@ -35,7 +35,7 @@ class BlackOut(link.Link):
         self.sampler.to_cpu()
 
     def to_gpu(self, device=None):
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             super(BlackOut, self).to_gpu()
             self.sampler.to_gpu()
 

--- a/chainer/links/loss/black_out.py
+++ b/chainer/links/loss/black_out.py
@@ -35,7 +35,7 @@ class BlackOut(link.Link):
         self.sampler.to_cpu()
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device.id if device else None):
+        with cuda.get_device_from_id(device):
             super(BlackOut, self).to_gpu()
             self.sampler.to_gpu()
 

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -112,7 +112,7 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
         )
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device.id if device else None):
+        with cuda.get_device_from_id(device):
             self.paths = cuda.to_gpu(self.paths)
             self.codes = cuda.to_gpu(self.codes)
             self.begins = cuda.to_gpu(self.begins)
@@ -301,7 +301,7 @@ class BinaryHierarchicalSoftmax(link.Link):
         self.W.data[...] = numpy.random.uniform(-1, 1, self.W.shape)
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device.id if device else None):
+        with cuda.get_device_from_id(device):
             super(BinaryHierarchicalSoftmax, self).to_gpu(device)
             self._func.to_gpu(device)
 

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -112,7 +112,7 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
         )
 
     def to_gpu(self, device=None):
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             self.paths = cuda.to_gpu(self.paths)
             self.codes = cuda.to_gpu(self.codes)
             self.begins = cuda.to_gpu(self.begins)
@@ -301,7 +301,7 @@ class BinaryHierarchicalSoftmax(link.Link):
         self.W.data[...] = numpy.random.uniform(-1, 1, self.W.shape)
 
     def to_gpu(self, device=None):
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             super(BinaryHierarchicalSoftmax, self).to_gpu(device)
             self._func.to_gpu(device)
 

--- a/chainer/links/loss/negative_sampling.py
+++ b/chainer/links/loss/negative_sampling.py
@@ -43,7 +43,7 @@ class NegativeSampling(link.Link):
         self.sampler.to_cpu()
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device.id if device else None):
+        with cuda.get_device_from_id(device):
             super(NegativeSampling, self).to_gpu()
             self.sampler.to_gpu()
 

--- a/chainer/links/loss/negative_sampling.py
+++ b/chainer/links/loss/negative_sampling.py
@@ -43,7 +43,7 @@ class NegativeSampling(link.Link):
         self.sampler.to_cpu()
 
     def to_gpu(self, device=None):
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             super(NegativeSampling, self).to_gpu()
             self.sampler.to_gpu()
 

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -107,13 +107,13 @@ class BatchNormalization(link.Link):
         if hasattr(self, 'gamma'):
             gamma = self.gamma
         else:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 gamma = variable.Variable(self.xp.ones(
                     self.avg_mean.shape, dtype=x.dtype), volatile='auto')
         if hasattr(self, 'beta'):
             beta = self.beta
         else:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 beta = variable.Variable(self.xp.zeros(
                     self.avg_mean.shape, dtype=x.dtype), volatile='auto')
 

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -93,7 +93,7 @@ class LayerNormalization(link.Chain):
 
         """
         if self.has_uninitialized_params:
-            with cuda.get_device(self._device_id):
+            with cuda.get_device_from_id(self._device_id):
                 self._initialize_params(x.size // x.shape[0])
 
         normalized = self._normalize(x)

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -19,7 +19,7 @@ class AdaDelta(optimizer.GradientMethod):
     def init_state(self, param, state):
         data = param.data
         xp = cuda.get_array_module(data)
-        with cuda.get_device(data):
+        with cuda.get_device_from_array(data):
             state['msg'] = xp.zeros_like(data)
             state['msdx'] = xp.zeros_like(data)
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -18,7 +18,7 @@ class AdaGrad(optimizer.GradientMethod):
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
+        with cuda.get_device_from_array(param.data):
             state['h'] = xp.zeros_like(param.data)
 
     def update_one_cpu(self, param, state):

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -22,7 +22,7 @@ class Adam(optimizer.GradientMethod):
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
+        with cuda.get_device_from_array(param.data):
             state['m'] = xp.zeros_like(param.data)
             state['v'] = xp.zeros_like(param.data)
 

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -12,7 +12,7 @@ class MomentumSGD(optimizer.GradientMethod):
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
+        with cuda.get_device_from_array(param.data):
             state['v'] = xp.zeros_like(param.data)
 
     def update_one_cpu(self, param, state):

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -19,7 +19,7 @@ class NesterovAG(optimizer.GradientMethod):
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
+        with cuda.get_device_from_array(param.data):
             state['v'] = xp.zeros_like(param.data)
 
     def update_one_cpu(self, param, state):

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -15,7 +15,7 @@ class RMSprop(optimizer.GradientMethod):
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
+        with cuda.get_device_from_array(param.data):
             state['ms'] = xp.zeros_like(param.data)
 
     def update_one_cpu(self, param, state):

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -21,7 +21,7 @@ class RMSpropGraves(optimizer.GradientMethod):
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
+        with cuda.get_device_from_array(param.data):
             state['n'] = xp.zeros_like(param.data)
             state['g'] = xp.zeros_like(param.data)
             state['delta'] = xp.zeros_like(param.data)

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -18,7 +18,7 @@ class SMORMS3(optimizer.GradientMethod):
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
-        with cuda.get_device(param.data):
+        with cuda.get_device_from_array(param.data):
             state['mem'] = xp.ones_like(param.data)
             state['g'] = xp.zeros_like(param.data)
             state['g2'] = xp.zeros_like(param.data)

--- a/chainer/reporter.py
+++ b/chainer/reporter.py
@@ -226,7 +226,7 @@ def _get_device(x):
     if numpy.isscalar(x):
         return cuda.DummyDevice
     else:
-        return cuda.get_device(x)
+        return cuda.get_device_from_array(x)
 
 
 class Summary(object):

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -135,7 +135,7 @@ Actual: {0}'''.format(type(data))
         except AttributeError:
             device = 'CPU'
 
-        with cuda.get_device(self.data) as dev:
+        with cuda.get_device_from_array(self.data) as dev:
             xp = numpy if int(dev) == -1 else cuda.cupy
 
             if self.grad is None:
@@ -223,7 +223,7 @@ Actual: {0}'''.format(type(data))
                 used.
 
         """
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             self.data = cuda.to_gpu(self.data)
             if self._grad is not None:
                 self._grad = cuda.to_gpu(self._grad)
@@ -242,7 +242,7 @@ Actual: {0}'''.format(type(data))
         warnings.warn(
             'Variable.zerograd is deprecated. Use Variable.cleargard instead.',
             DeprecationWarning)
-        with cuda.get_device(self.data) as dev:
+        with cuda.get_device_from_array(self.data) as dev:
             if self._grad is None:
                 xp = numpy if int(dev) == -1 else cuda.cupy
                 self._grad = xp.zeros_like(self.data)
@@ -286,8 +286,8 @@ Actual: {0}'''.format(type(data))
         if src is None:
             return
 
-        src_dev = cuda.get_device(src)
-        dst_dev = cuda.get_device(self.data)
+        src_dev = cuda.get_device_from_array(src)
+        dst_dev = cuda.get_device_from_array(self.data)
 
         if src_dev.id == dst_dev.id:
             with dst_dev:
@@ -368,7 +368,7 @@ Actual: {0}'''.format(type(data))
 
         # Initialize error by 1, if this is a loss variable
         if self.data.size == 1 and self.grad is None:
-            with cuda.get_device(self.data) as device:
+            with cuda.get_device_from_array(self.data) as device:
                 if device is cuda.DummyDevice:
                     self.grad = numpy.ones_like(self.data)
                 else:
@@ -393,7 +393,7 @@ Actual: {0}'''.format(type(data))
                 hooks = collections.OrderedDict(hooks)
                 hooks.update(func.local_function_hooks)
 
-            cuda.get_device(*(in_data + out_grad)).use()
+            cuda.get_device_from_array(*(in_data + out_grad)).use()
             for hook in six.itervalues(hooks):
                 hook.backward_preprocess(func, in_data, out_grad)
             gxs = func.backward(in_data, out_grad)
@@ -405,7 +405,7 @@ Actual: {0}'''.format(type(data))
                 for gx in gxs:
                     if gx is None:
                         continue
-                    cuda.get_device(gx).use()
+                    cuda.get_device_from_array(gx).use()
                     if cuda.get_array_module(gx).isnan(gx).any():
                         msg = 'NaN is detected on backward computation'
                         raise RuntimeError(msg)
@@ -428,7 +428,7 @@ Actual: {0}'''.format(type(data))
                         x.grad = gx
                         need_copy.add(id_x)
                     else:
-                        cuda.get_device(gx).use()
+                        cuda.get_device_from_array(gx).use()
                         if id_x in need_copy:
                             x.grad = utils.force_array(x.grad + gx)  # copy
                             need_copy.remove(id_x)
@@ -441,7 +441,7 @@ Actual: {0}'''.format(type(data))
                         seen_vars.add(id_x)
                         need_copy.add(id_x)
                     else:
-                        cuda.get_device(gx).use()
+                        cuda.get_device_from_array(gx).use()
                         if id_x in need_copy:  # 2nd visit
                             x._grad = utils.force_array(gx + x._grad)  # copied
                             need_copy.remove(id_x)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -219,7 +219,7 @@ Actual: {0}'''.format(type(data))
         """Copies the data and gradient arrays to specified GPU.
 
         Args:
-            device: arget device specifier. If omitted, the current device is
+            device: Target device specifier. If omitted, the current device is
                 used.
 
         """

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -223,10 +223,9 @@ Actual: {0}'''.format(type(data))
                 device is used.
 
         """
-        with cuda.get_device_from_id(device_id):
-            self.data = cuda.to_gpu(self.data)
-            if self._grad is not None:
-                self._grad = cuda.to_gpu(self._grad)
+        self.data = cuda.to_gpu(self.data, device_id)
+        if self._grad is not None:
+            self._grad = cuda.to_gpu(self._grad, device_id)
 
     def cleargrad(self):
         """Clears the gradient array."""

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -215,15 +215,15 @@ Actual: {0}'''.format(type(data))
         if self._grad is not None:
             self._grad = cuda.to_cpu(self._grad)
 
-    def to_gpu(self, device=None):
+    def to_gpu(self, device_id=None):
         """Copies the data and gradient arrays to specified GPU.
 
         Args:
-            device: Target device specifier. If omitted, the current device is
-                used.
+            device_id (int): The target device ID. If omitted, the current
+                device is used.
 
         """
-        with cuda.get_device_from_id(device.id if device else None):
+        with cuda.get_device_from_id(device_id):
             self.data = cuda.to_gpu(self.data)
             if self._grad is not None:
                 self._grad = cuda.to_gpu(self._grad)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -215,17 +215,17 @@ Actual: {0}'''.format(type(data))
         if self._grad is not None:
             self._grad = cuda.to_cpu(self._grad)
 
-    def to_gpu(self, device_id=None):
+    def to_gpu(self, device=None):
         """Copies the data and gradient arrays to specified GPU.
 
         Args:
-            device_id (int): The target device ID. If omitted, the current
-                device is used.
+            device: arget device specifier. If omitted, the current device is
+                used.
 
         """
-        self.data = cuda.to_gpu(self.data, device_id)
+        self.data = cuda.to_gpu(self.data, device)
         if self._grad is not None:
-            self._grad = cuda.to_gpu(self._grad, device_id)
+            self._grad = cuda.to_gpu(self._grad, device)
 
     def cleargrad(self):
         """Clears the gradient array."""

--- a/docs/source/tutorial/gpu.rst
+++ b/docs/source/tutorial/gpu.rst
@@ -106,21 +106,25 @@ It is equivalent to the following code using CuPy:
    If user uses only one device, these device switching is not needed.
    :func:`chainer.cuda.to_cpu` and :func:`chainer.cuda.to_gpu` functions automatically switch the current device correctly.
 
-Chainer also provides a convenient function :func:`chainer.cuda.get_device` to select a device.
-It accepts an integer, CuPy array, NumPy array, or None (indicating the current device), and returns an appropriate device object.
-If the argument is a NumPy array, then *a dummy device object* is returned.
-The dummy device object supports *with* statements like above which does nothing.
-Here are some examples:
+Chainer also provides a convenient function :func:`chainer.cuda.get_device_from_id` and :func:`chainer.cuda.get_device_from_array` to select a device.
+The former function accepts an integer or None.
+When None is given, it returns *a dummy device object*.
+Otherwise, it returns a corresponding device object.
+The latter function accepts CuPy array or NumPy array.
+When a NumPy array is given, it returns *a dummy device object*.
+Otherwise, it returns a corresponding device object to the give CuPy array.
+The dummy device object also supports *with* statements like the above example but does nothing.
+Here are some other examples:
 
 .. testcode::
 
-   cuda.get_device(1).use()
+   cuda.get_device_from_id(1).use()
    x_gpu1 = cupy.empty((4, 3), dtype='f')  # 'f' indicates float32
 
-   with cuda.get_device(1):
+   with cuda.get_device_from_id(1):
        x_gpu1 = cuda.empty((4, 3), dtype='f')
 
-   with cuda.get_device(x_gpu1):
+   with cuda.get_device_from_array(x_gpu1):
        y_gpu1 = x_gpu + 1
 
 Since it accepts NumPy arrays, we can write a function that accepts both NumPy and CuPy arrays with correct device switching:
@@ -128,7 +132,7 @@ Since it accepts NumPy arrays, we can write a function that accepts both NumPy a
 .. testcode::
 
    def add1(x):
-       with cuda.get_device(x):
+       with cuda.get_device_from_array(x):
            return x + 1
 
 The compatibility of CuPy with NumPy enables us to write CPU/GPU generic code.

--- a/examples/cifar/train_cifar.py
+++ b/examples/cifar/train_cifar.py
@@ -58,7 +58,8 @@ def main():
         raise RuntimeError('Invalid dataset choice.')
     model = L.Classifier(models.VGG.VGG(class_labels))
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()  # Make a specified GPU current
+        # Make a specified GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()  # Copy the model to the GPU
 
     optimizer = chainer.optimizers.MomentumSGD(0.1)

--- a/examples/dcgan/train_dcgan.py
+++ b/examples/dcgan/train_dcgan.py
@@ -49,7 +49,8 @@ def main():
     dis = Discriminator()
 
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()  # Make a specified GPU current
+        # Make a specified GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()
         gen.to_gpu()  # Copy the model to the GPU
         dis.to_gpu()
 

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -121,7 +121,7 @@ def main():
         print('Load model from', args.initmodel)
         chainer.serializers.load_npz(args.initmodel, model)
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()  # Make the GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()  # Make the GPU current
         model.to_gpu()
 
     # Load the datasets and mean file

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -63,7 +63,8 @@ def main():
     # iteration, which will be used by the PrintReport extension below.
     model = L.Classifier(MLP(args.unit, 10))
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()  # Make a specified GPU current
+        # Make a specified GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()  # Copy the model to the GPU
 
     # Setup an optimizer

--- a/examples/mnist/train_mnist_data_parallel.py
+++ b/examples/mnist/train_mnist_data_parallel.py
@@ -37,7 +37,7 @@ def main():
     print('# epoch: {}'.format(args.epoch))
     print('')
 
-    chainer.cuda.get_device(args.gpu0).use()
+    chainer.cuda.get_device_from_id(args.gpu0).use()
 
     model = L.Classifier(train_mnist.MLP(args.unit, 10))
     optimizer = chainer.optimizers.Adam()

--- a/examples/mnist/train_mnist_model_parallel.py
+++ b/examples/mnist/train_mnist_model_parallel.py
@@ -73,7 +73,7 @@ def main():
     # See train_mnist.py for the meaning of these lines
 
     model = L.Classifier(ParallelMLP(args.unit, 10, args.gpu0, args.gpu1))
-    chainer.cuda.get_device(args.gpu0).use()
+    chainer.cuda.get_device_from_id(args.gpu0).use()
 
     optimizer = chainer.optimizers.Adam()
     optimizer.setup(model)

--- a/examples/modelzoo/evaluate_caffe_net.py
+++ b/examples/modelzoo/evaluate_caffe_net.py
@@ -58,7 +58,7 @@ print('Loading Caffe model file %s...' % args.model, file=sys.stderr)
 func = caffe.CaffeFunction(args.model)
 print('Loaded', file=sys.stderr)
 if args.gpu >= 0:
-    cuda.get_device(args.gpu).use()
+    cuda.get_device_from_id(args.gpu).use()
     func.to_gpu()
 
 if args.model_type == 'alexnet' or args.model_type == 'caffenet':

--- a/examples/ptb/gentxt.py
+++ b/examples/ptb/gentxt.py
@@ -58,7 +58,7 @@ def main():
     serializers.load_npz(args.model, model)
 
     if args.gpu >= 0:
-        cuda.get_device(args.gpu).use()
+        cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     model.predictor.reset_state()

--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -192,7 +192,8 @@ def main():
     model = L.Classifier(rnn)
     model.compute_accuracy = False  # we only want the perplexity
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()  # make the GPU current
+        # Make a specified GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     # Set up an optimizer

--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -68,7 +68,7 @@ N_test = y_test.size
 # Prepare VAE model, defined in net.py
 model = net.VAE(784, n_latent, 500)
 if args.gpu >= 0:
-    cuda.get_device(args.gpu).use()
+    cuda.get_device_from_id(args.gpu).use()
     model.to_gpu()
 xp = np if args.gpu < 0 else cuda.cupy
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -49,7 +49,7 @@ parser.set_defaults(test=False)
 args = parser.parse_args()
 
 if args.gpu >= 0:
-    chainer.cuda.get_device(args.gpu).use()
+    chainer.cuda.get_device_from_id(args.gpu).use()
     cuda.check_cuda_available()
 
 print('GPU: {}'.format(args.gpu))
@@ -171,7 +171,7 @@ def convert(batch, device):
 
 
 if args.gpu >= 0:
-    cuda.get_device(args.gpu).use()
+    cuda.get_device_from_id(args.gpu).use()
 
 train, val, _ = chainer.datasets.get_ptb_words()
 counts = collections.Counter(train)

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -41,7 +41,7 @@ class TestLSTM(unittest.TestCase):
         xp = self.link.xp
         x1 = chainer.Variable(x1_data) if self.input_variable else x1_data
         h1 = self.link(x1)
-        with cuda.get_device(x1_data):
+        with cuda.get_device_from_array(x1_data):
             c0 = chainer.Variable(xp.zeros((len(self.x1), self.out_size),
                                            dtype=self.x1.dtype))
             c1_expect, h1_expect = functions.lstm(c0, self.link.upward(x1))
@@ -54,7 +54,7 @@ class TestLSTM(unittest.TestCase):
         h1_in, h1_rest = functions.split_axis(
             self.link.h.data, [batch], axis=0)
         y2 = self.link(x2)
-        with cuda.get_device(x1):
+        with cuda.get_device_from_array(x1):
             c2_expect, y2_expect = \
                 functions.lstm(c1_expect,
                                self.link.upward(x2) + self.link.lateral(h1_in))
@@ -81,12 +81,12 @@ class TestLSTM(unittest.TestCase):
 
     @attr.multi_gpu(2)
     def test_forward_gpu_multi(self):
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.link.to_gpu()
             x1 = cuda.to_gpu(self.x1)
             x2 = cuda.to_gpu(self.x2)
             x3 = cuda.to_gpu(self.x3)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.check_forward(x1, x2, x3)
 
 
@@ -261,7 +261,7 @@ class TestStatelessLSTM(unittest.TestCase):
         xp = self.link.xp
         x = chainer.Variable(x_data) if self.input_variable else x_data
         c1, h1 = self.link(None, None, x)
-        with cuda.get_device(x_data):
+        with cuda.get_device_from_array(x_data):
             c0 = chainer.Variable(xp.zeros((len(self.x), self.out_size),
                                            dtype=self.x.dtype))
             c1_expect, h1_expect = functions.lstm(c0, self.link.upward(x))
@@ -285,10 +285,10 @@ class TestStatelessLSTM(unittest.TestCase):
 
     @attr.multi_gpu(2)
     def test_forward_gpu_multi(self):
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.link.to_gpu()
             x = cuda.to_gpu(self.x)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.check_forward(x)
 
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_peephole.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_peephole.py
@@ -18,7 +18,7 @@ def _sigmoid(x):
 
 def _peephole(func, c, h, x):
     xp = cuda.get_array_module(x)
-    with cuda.get_device(x):
+    with cuda.get_device_from_array(x):
         lstm_in = x.dot(func.upward.W.data.T)
         lstm_in += h.dot(func.lateral.W.data.T)
         lstm_in = xp.reshape(lstm_in, (len(lstm_in),
@@ -100,12 +100,12 @@ class TestPeephole(unittest.TestCase):
 
     @attr.multi_gpu(2)
     def test_forward_gpu_multi(self):
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.link.to_gpu()
             c = cuda.to_gpu(self.c)
             h = cuda.to_gpu(self.h)
             x = cuda.to_gpu(self.x)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.check_forward(c, h, x)
 
     def check_backward(self, c_data, h_data, x_data, y_grad):

--- a/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
@@ -18,7 +18,7 @@ def _sigmoid(x):
 
 def _zoneoutlstm(func, c, h, x, c_creator, h_creator):
     xp = cuda.get_array_module(x)
-    with cuda.get_device(x):
+    with cuda.get_device_from_array(x):
         lstm_in = x.dot(func.upward.W.data.T)
         lstm_in += h.dot(func.lateral.W.data.T)
         lstm_in = xp.reshape(lstm_in, (len(lstm_in),
@@ -99,12 +99,12 @@ class TestZoneoutlstm(unittest.TestCase):
 
     @attr.multi_gpu(2)
     def test_forward_gpu_multi(self):
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.link.to_gpu()
             c = cuda.to_gpu(self.c)
             h = cuda.to_gpu(self.h)
             x = cuda.to_gpu(self.x)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.check_forward(c, h, x)
 
     def check_backward(self, c_data, h_data, x_data, y_grad):

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -98,10 +98,10 @@ class BatchNormalizationTest(unittest.TestCase):
     @attr.multi_gpu(2)
     @condition.retry(3)
     def test_forward_multi_gpu(self):
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.link.to_gpu()
             x = cuda.to_gpu(self.x)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.check_forward(x)
 
     def check_backward(self, x_data, y_grad):
@@ -260,10 +260,10 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 
     @attr.multi_gpu(2)
     def test_forward_gpu_multi(self):
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.link.to_gpu()
             x = cuda.to_gpu(self.x)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.check_forward(x)
 
     @attr.cudnn

--- a/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
@@ -72,10 +72,10 @@ class LayerNormalizationTest(unittest.TestCase):
     @attr.multi_gpu(2)
     @condition.retry(3)
     def test_forward_multi_gpu(self):
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.link.to_gpu()
             x = cuda.to_gpu(self.x)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.check_forward(x)
 
     def check_backward(self, x_data, y_grad):

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -70,12 +70,12 @@ class LinearModel(object):
         self.optimizer.setup(self.model)
         return self._train_linear_classifier(self.model, self.optimizer, False)
 
-    def accuracy_gpu(self, device=None):
+    def accuracy_gpu(self, device_id=None):
         model = self.model
         optimizer = self.optimizer
-        model.to_gpu(device=device)
+        model.to_gpu(device_id=device_id)
         optimizer.setup(model)
-        with cuda.get_device_from_id(device.id if device else None):
+        with cuda.get_device_from_id(device_id):
             return self._train_linear_classifier(model, optimizer, True)
 
 

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -75,7 +75,7 @@ class LinearModel(object):
         optimizer = self.optimizer
         model.to_gpu(device=device)
         optimizer.setup(model)
-        with cuda.get_device(device):
+        with cuda.get_device_from_id(device.id):
             return self._train_linear_classifier(model, optimizer, True)
 
 

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -70,12 +70,12 @@ class LinearModel(object):
         self.optimizer.setup(self.model)
         return self._train_linear_classifier(self.model, self.optimizer, False)
 
-    def accuracy_gpu(self, device_id=None):
+    def accuracy_gpu(self, device=None):
         model = self.model
         optimizer = self.optimizer
-        model.to_gpu(device_id=device_id)
+        model.to_gpu(device=device)
         optimizer.setup(model)
-        with cuda.get_device_from_id(device_id):
+        with cuda.get_device_from_id(device):
             return self._train_linear_classifier(model, optimizer, True)
 
 

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -37,7 +37,7 @@ class TestCuda(unittest.TestCase):
 
     @attr.gpu
     def test_get_device_from_id_for_numpy_int(self):
-        self.assertIs(
+        self.assertEqual(
             cuda.get_device_from_id(numpy.int64(0)), cuda.Device(0))
 
     def test_get_device_from_array_for_numpy_int(self):

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -33,15 +33,16 @@ except ImportError:
 class TestCuda(unittest.TestCase):
 
     def test_get_dummy_device(self):
-        self.assertIs(cuda.get_device(), cuda.DummyDevice)
+        self.assertIs(cuda.get_device_from_id(), cuda.DummyDevice)
 
     def test_get_device_for_numpy_int(self):
-        self.assertIs(cuda.get_device(numpy.int64(0)), cuda.DummyDevice)
+        self.assertIs(
+            cuda.get_device_from_id(numpy.int64(0)), cuda.DummyDevice)
 
     @attr.gpu
     def test_get_dummy_device_for_empty_array(self):
         x = cuda.cupy.array([]).reshape((0, 10))
-        self.assertIs(cuda.get_device(x), cuda.DummyDevice)
+        self.assertIs(cuda.get_device_from_array(x), cuda.DummyDevice)
 
     @attr.gpu
     @unittest.skipUnless(
@@ -70,6 +71,15 @@ class TestCuda(unittest.TestCase):
     @attr.gpu
     def test_get_device_for_int(self):
         self.assertEqual(cuda.get_device(0), cuda.Device(0))
+
+    @attr.gpu
+    @unittest.skipUnless(_builtins_available,
+                         'builtins module is not available')
+    def test_get_device_from_id_for_builtin_int(self):
+        # builtins.int is from future package and it is different
+        # from builtin int/long on Python 2.
+        self.assertEqual(
+            cuda.get_device_from_id(builtins.int(0)), cuda.Device(0))
 
     @attr.gpu
     @unittest.skipUnless(_builtins_available,

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -33,7 +33,7 @@ except ImportError:
 class TestCuda(unittest.TestCase):
 
     def test_get_dummy_device(self):
-        self.assertIs(cuda.get_device_from_id(), cuda.DummyDevice)
+        self.assertIs(cuda.get_device_from_id(None), cuda.DummyDevice)
 
     @attr.gpu
     def test_get_device_from_id_for_numpy_int(self):

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -19,8 +19,17 @@ class TestLink(unittest.TestCase):
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'
-        if attr.gpu:
-            self.current_device_id = cuda.cupy.cuda.get_device_id()
+        print('normal setup')
+
+    @attr.gpu
+    def setUp(self):
+        x_shape_0 = 2
+        x_shape_1 = numpy.int64(3)
+        self.link = chainer.Link(x=((x_shape_0, x_shape_1), 'd'), y=2)
+        self.p = numpy.array([1, 2, 3], dtype='f')
+        self.link.add_persistent('p', self.p)
+        self.link.name = 'a'
+        self.current_device_id = cuda.cupy.cuda.get_device_id()
 
     @attr.gpu
     def tearDown(self):

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -98,6 +98,18 @@ class TestLink(unittest.TestCase):
         self.assertIsInstance(self.link.y.grad, cupy.ndarray)
         self.assertIsInstance(self.link.p, cupy.ndarray)
 
+    @attr.gpu
+    def test_to_gpu_different_device(self):
+        cuda.Device(1).use()
+        self.link.to_gpu(0)
+        self.assertEqual(self.link._device_id, 0)
+
+    @attr.gpu
+    def test_to_gpu_current_device(self):
+        cuda.Device(1).use()
+        self.link.to_gpu()
+        self.assertEqual(self.link._device_id, 1)
+
     def test_params(self):
         params = list(self.link.params())
         self.assertEqual({id(p) for p in params},

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -111,7 +111,7 @@ class TestLink(unittest.TestCase):
         self.link.to_gpu(0)
         self.assertEqual(self.link._device_id, 0)
 
-    @attr.gpu
+    @attr.multi_gpu(2)
     def test_to_gpu_current_device(self):
         cuda.Device(1).use()
         self.link.to_gpu()

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -19,7 +19,8 @@ class TestLink(unittest.TestCase):
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'
-        self.current_device_id = cuda.cupy.cuda.get_device_id()
+        if cuda.available:
+            self.current_device_id = cuda.cupy.cuda.get_device_id()
 
     @attr.gpu
     def tearDown(self):

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -105,7 +105,7 @@ class TestLink(unittest.TestCase):
         self.assertIsInstance(self.link.y.grad, cupy.ndarray)
         self.assertIsInstance(self.link.p, cupy.ndarray)
 
-    @attr.gpu
+    @attr.multi_gpu(2)
     def test_to_gpu_different_device(self):
         cuda.Device(1).use()
         self.link.to_gpu(0)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -19,6 +19,13 @@ class TestLink(unittest.TestCase):
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'
+        if attr.gpu:
+            self.current_device_id = cuda.cupy.cuda.get_device_id()
+
+    @attr.gpu
+    def tearDown(self):
+        if cuda.cupy.cuda.get_device_id() != self.current_device_id:
+            cuda.Device(self.current_device_id).use()
 
     def check_param_init(self, name, shape, dtype):
         self.assertTrue(hasattr(self.link, name))

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -19,16 +19,6 @@ class TestLink(unittest.TestCase):
         self.p = numpy.array([1, 2, 3], dtype='f')
         self.link.add_persistent('p', self.p)
         self.link.name = 'a'
-        print('normal setup')
-
-    @attr.gpu
-    def setUp(self):
-        x_shape_0 = 2
-        x_shape_1 = numpy.int64(3)
-        self.link = chainer.Link(x=((x_shape_0, x_shape_1), 'd'), y=2)
-        self.p = numpy.array([1, 2, 3], dtype='f')
-        self.link.add_persistent('p', self.p)
-        self.link.name = 'a'
         self.current_device_id = cuda.cupy.cuda.get_device_id()
 
     @attr.gpu

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -420,8 +420,8 @@ class TestVariable(unittest.TestCase):
             b.cleargrad()
         b.addgrad(a)
         xp.testing.assert_array_equal(b.grad, expect)
-        self.assertEqual(cuda.get_device_from_device(b.data),
-                         cuda.get_device_from_device(b.grad))
+        self.assertEqual(cuda.get_device_from_array(b.data),
+                         cuda.get_device_from_array(b.grad))
 
     def test_addgrad_cpu_to_cpu(self):
         self.check_addgrad(np.full(3, 10, dtype=np.float32),

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -287,8 +287,8 @@ class TestVariable(unittest.TestCase):
         gb = a.grad.copy()
         a.to_gpu(1)
 
-        self.assertEqual(int(cuda.get_device(a.data)), 1)
-        self.assertEqual(int(cuda.get_device(a.grad)), 1)
+        self.assertEqual(int(cuda.get_device_from_array(a.data)), 1)
+        self.assertEqual(int(cuda.get_device_from_array(a.grad)), 1)
         cp.testing.assert_array_equal(a.data, b)
         cp.testing.assert_array_equal(a.grad, gb)
 
@@ -335,24 +335,24 @@ class TestVariable(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_zerograds_multi_gpu(self):
         cupy = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = chainer.Variable(cupy.empty(3, dtype=np.float32))
         a.zerograd()
         self.assertIsNot(a.grad, None)
         self.assertEqual(int(a.grad.device), 1)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             g_expect = cupy.zeros_like(a.data)
             cupy.testing.assert_array_equal(a.grad, g_expect)
 
     @attr.multi_gpu(2)
     def test_zerograds_fill_multi_gpu(self):
         cupy = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = chainer.Variable(cupy.empty(3, dtype=np.float32))
             a.grad = cupy.empty_like(a.data)
         a.zerograd()
         self.assertEqual(int(a.grad.device), 1)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             g_expect = cupy.zeros_like(a.data)
             cupy.testing.assert_array_equal(a.grad, g_expect)
 
@@ -400,10 +400,10 @@ class TestVariable(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_copydata_gpu_to_another_gpu(self):
         cp = cuda.cupy
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             data1 = cp.zeros(3, dtype=np.float32)
             expect = cp.ones(3, dtype=np.float32)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             data2 = cp.ones(3, dtype=np.float32)
         self.check_copydata(data1, data2, expect)
 
@@ -420,7 +420,8 @@ class TestVariable(unittest.TestCase):
             b.cleargrad()
         b.addgrad(a)
         xp.testing.assert_array_equal(b.grad, expect)
-        self.assertEqual(cuda.get_device(b.data), cuda.get_device(b.grad))
+        self.assertEqual(cuda.get_device_from_device(b.data),
+                         cuda.get_device_from_device(b.grad))
 
     def test_addgrad_cpu_to_cpu(self):
         self.check_addgrad(np.full(3, 10, dtype=np.float32),
@@ -451,19 +452,19 @@ class TestVariable(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_addgrad_gpu_to_gpu_multi(self):
         cp = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = cp.full(3, 10, dtype=np.float32)
             b = cp.full(3, 20, dtype=np.float32)
             c = cp.full(3, 30, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.check_addgrad(a, b, c)
 
     @attr.multi_gpu(2)
     def test_addgrad_gpu_to_another_gpu(self):
         cp = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = cp.full(3, 10, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             b = cp.full(3, 20, dtype=np.float32)
             c = cp.full(3, 30, dtype=np.float32)
         self.check_addgrad(a, b, c)
@@ -485,23 +486,23 @@ class TestVariable(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_addgrad_gpu_to_another_gpu_none_src_dev0(self):
         cp = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = cp.full(3, 10, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             b = cp.full(3, 20, dtype=np.float32)
             c = cp.full(3, 20, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.check_addgrad(a, b, c, clear_src_grad=True)
 
     @attr.multi_gpu(2)
     def test_addgrad_gpu_to_another_gpu_none_src_dev1(self):
         cp = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = cp.full(3, 10, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             b = cp.full(3, 20, dtype=np.float32)
             c = cp.full(3, 20, dtype=np.float32)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.check_addgrad(a, b, c, clear_src_grad=True)
 
     def test_addgrad_cpu_to_cpu_none_dst(self):
@@ -521,23 +522,23 @@ class TestVariable(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_addgrad_gpu_to_another_gpu_none_dst_dev0(self):
         cp = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = cp.full(3, 20, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             b = cp.full(3, 10, dtype=np.float32)
             c = cp.full(3, 20, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.check_addgrad(a, b, c, clear_dst_grad=True)
 
     @attr.multi_gpu(2)
     def test_addgrad_gpu_to_another_gpu_none_dst_dev1(self):
         cp = cuda.cupy
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             a = cp.full(3, 20, dtype=np.float32)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             b = cp.full(3, 10, dtype=np.float32)
             c = cp.full(3, 20, dtype=np.float32)
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.check_addgrad(a, b, c, clear_dst_grad=True)
 
     def test_addgrad_none_src_dst(self):


### PR DESCRIPTION
Fix #2545 

Note that the default value of `device_id` argument in `chainer/cuda.py` at L:156 is None and L:163 in the same file has been changed to `if type(device_id) in _integer_types` because this function could take `None` to get `DammyDevice` object and it should return `DammyDevice` also for NumPy's scalar type like `numpy.int64(0)`.