### PR TITLE
Minor fix on gzip.open() encoding

### DIFF
--- a/examples/seq2seq/europal.py
+++ b/examples/seq2seq/europal.py
@@ -3,6 +3,7 @@ import collections
 import gzip
 import os
 import re
+import sys
 
 import numpy
 import progressbar
@@ -25,7 +26,7 @@ def split_sentence(s):
 
 def open_file(path):
     if path.endswith('.gz'):
-        return gzip.open(path)
+        return gzip.open(path, 'rt', sys.getdefaultencoding())
     else:
         # Find gzipped version of the file
         gz = path + '.gz'

--- a/examples/seq2seq/europal.py
+++ b/examples/seq2seq/europal.py
@@ -1,9 +1,9 @@
 # coding: utf-8
+import codecs
 import collections
 import gzip
 import os
 import re
-import sys
 
 import numpy
 import progressbar
@@ -26,14 +26,14 @@ def split_sentence(s):
 
 def open_file(path):
     if path.endswith('.gz'):
-        return gzip.open(path, 'rt', sys.getdefaultencoding())
+        return gzip.open(path, 'rt', 'utf-8')
     else:
         # Find gzipped version of the file
         gz = path + '.gz'
         if os.path.exists(gz):
             return open_file(gz)
         else:
-            return open(path)
+            return codecs.open(path, encoding='utf-8')
 
 
 def count_lines(path):


### PR DESCRIPTION
The current open_file() function in europal.py supports opening gzipped files.
However, gzip.open functions does not automatically decode the input stream
and users must specify input encoding explicitly.
This PR fixes the issue by using sys.getdefaultencoding().
