### PR TITLE
Improve tests of manual schedule trigger

### DIFF
--- a/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
@@ -45,7 +45,7 @@ class DummyUpdater(training.Updater):
         self.iteration = serializer('iteration', self.iteration)
 
 
-@testing.parameterize(*testing.product_dict([
+@testing.parameterize(
     # single iteration
     {
         'iters_per_epoch': 2, 'schedule': (2, 'iteration'), 'resume': 3,
@@ -86,7 +86,7 @@ class DummyUpdater(training.Updater):
     {
         'iters_per_epoch': 0.5, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
         'expected': [True, False, False, False, False, False, False]},
-]))
+)
 class TestTrigger(unittest.TestCase):
 
     def test_trigger(self):

--- a/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
@@ -78,6 +78,14 @@ class DummyUpdater(training.Updater):
     {
         'iters_per_epoch': 2.5, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
         'expected': [False, False, True, False, True, False, False]},
+    # single tiny epoch
+    {
+        'iters_per_epoch': 0.5, 'schedule': (1, 'epoch'), 'resume': 4,
+        'expected': [True, False, False, False, False, False, False]},
+    # multiple tiny epoch
+    {
+        'iters_per_epoch': 0.5, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
+        'expected': [True, False, False, False, False, False, False]},
 ]))
 class TestTrigger(unittest.TestCase):
 

--- a/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
@@ -1,10 +1,11 @@
 from __future__ import division
 
+import tempfile
 import unittest
 
+from chainer import serializers
 from chainer import testing
 from chainer import training
-from chainer.training import triggers
 
 
 class DummyUpdater(training.Updater):
@@ -40,118 +41,71 @@ class DummyUpdater(training.Updater):
     def is_new_epoch(self):
         return 0 <= self.iteration % self.iters_per_epoch < 1
 
-
-def _test_trigger(self, updater, trigger, expecteds):
-    trainer = training.Trainer(updater)
-    for expected in expecteds:
-        updater.update()
-        self.assertEqual(trigger(trainer), expected)
+    def serialize(self, serializer):
+        self.iteration = serializer('iteration', self.iteration)
 
 
-class TestIterationManualScheduleTrigger(unittest.TestCase):
+@testing.parameterize(*testing.product_dict([
+    # single iteration
+    {
+        'iters_per_epoch': 2, 'schedule': (2, 'iteration'), 'resume': 3,
+        'expected': [False, True, False, False, False, False, False]},
+    # multiple iteration
+    {
+        'iters_per_epoch': 2, 'schedule': ([2, 4], 'iteration'), 'resume': 3,
+        'expected': [False, True, False, True, False, False, False]},
+    # single epoch
+    {
+        'iters_per_epoch': 3, 'schedule': (1, 'epoch'), 'resume': 3,
+        'expected': [False, False, True, False, False, False, False]},
+    # multiple epoch
+    {
+        'iters_per_epoch': 3, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
+        'expected': [False, False, True, False, False, True, False]},
+    # single fractional epoch
+    {
+        'iters_per_epoch': 2, 'schedule': (1.5, 'epoch'), 'resume': 4,
+        'expected': [False, False, True, False, False, False, False]},
+    # multiple fractional epoch
+    {
+        'iters_per_epoch': 2, 'schedule': ([1.5, 2.5], 'epoch'), 'resume': 4,
+        'expected': [False, False, True, False, True, False, False]},
+    # single unaligned epoch
+    {
+        'iters_per_epoch': 2.5, 'schedule': (1, 'epoch'), 'resume': 4,
+        'expected': [False, False, True, False, False, False, False]},
+    # multiple unaligned epoch
+    {
+        'iters_per_epoch': 2.5, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
+        'expected': [False, False, True, False, True, False, False]},
+]))
+class TestTrigger(unittest.TestCase):
 
-    def test_iteration_manual_single_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=3)
-        trigger = triggers.ManualScheduleTrigger(2, 'iteration')
-        expected = [False, True, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
+    def test_trigger(self):
+        trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
+        updater = DummyUpdater(self.iters_per_epoch)
+        trainer = training.Trainer(updater)
+        for expected in self.expected:
+            updater.update()
+            self.assertEqual(trigger(trainer), expected)
 
-    def test_iteration_manual_multiple_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=5)
-        trigger = triggers.ManualScheduleTrigger([2, 3], 'iteration')
-        expected = [False, True, True, False, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
+    def test_resumed_trigger(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
+            updater = DummyUpdater(self.iters_per_epoch)
+            trainer = training.Trainer(updater)
+            for expected in self.expected[:self.resume]:
+                updater.update()
+                self.assertEqual(trigger(trainer), expected)
+            serializers.save_npz(f.name, updater)
 
-
-class TestEpochManualScheduleTrigger(unittest.TestCase):
-
-    def test_epoch_manual_single_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=3)
-        trigger = triggers.ManualScheduleTrigger(1, 'epoch')
-        expected = [False, False, True, False, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-    def test_epoch_manual_multiple_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=3)
-        trigger = triggers.ManualScheduleTrigger([1, 2], 'epoch')
-        expected = [False, False, True, False, False, True, False]
-        _test_trigger(self, updater, trigger, expected)
-
-
-class TestFractionalEpochManualScheduleTrigger(unittest.TestCase):
-
-    def test_epoch_manual_single_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2)
-        trigger = triggers.ManualScheduleTrigger(1.5, 'epoch')
-        expected = [False, False, True, False, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-    def test_epoch_manual_multiple_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2)
-        trigger = triggers.ManualScheduleTrigger([1.5, 2.5], 'epoch')
-        expected = [False, False, True, False, True, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-
-class TestUnalignedEpochManualScheduleTrigger(unittest.TestCase):
-
-    def test_unaligned_epoch_single_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2.5)
-        trigger = triggers.ManualScheduleTrigger(1, 'epoch')
-        expected = [False, False, True, False, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-    def test_unaligned_epoch_multiple_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2.5)
-        trigger = triggers.ManualScheduleTrigger([1, 2], 'epoch')
-        expected = [False, False, True, False, True, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-
-class TestResumedIterationManualScheduleTrigger(unittest.TestCase):
-
-    def test_resumed_iteration_single_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=1, initial_iteration=2)
-        trigger = triggers.ManualScheduleTrigger(3, 'iteration')
-        expected = [True, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-    def test_resumed_iteration_multiple_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=1, initial_iteration=2)
-        trigger = triggers.ManualScheduleTrigger([1, 3, 5], 'iteration')
-        expected = [True, False, True, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-
-class TestResumedEpochManualScheduleTrigger(unittest.TestCase):
-
-    def test_resumed_epoch_single_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2, initial_iteration=3)
-        trigger = triggers.ManualScheduleTrigger(2, 'epoch')
-        expected = [True, False, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-    def test_resumed_epoch_multiple_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2, initial_iteration=3)
-        trigger = triggers.ManualScheduleTrigger([1, 2, 3], 'epoch')
-        expected = [True, False, True, False, False]
-        _test_trigger(self, updater, trigger, expected)
-
-
-class TestUnalignedResumedEpochManualScheduleTrigger(unittest.TestCase):
-
-    def test_unaligned_resumed_epoch_single_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2.5, initial_iteration=2)
-        trigger = triggers.ManualScheduleTrigger(3, 'epoch')
-        expected = [False, False, False, False, False, True, False]
-        _test_trigger(self, updater, trigger, expected)
-
-    def test_unaligned_resumed_epoch_multiple_manual_trigger(self):
-        updater = DummyUpdater(iters_per_epoch=2.5, initial_iteration=2)
-        trigger = triggers.ManualScheduleTrigger([1, 3, 5], 'epoch')
-        expected = [True, False, False, False, False,
-                    True, False, False, False, False, True, False]
-        _test_trigger(self, updater, trigger, expected)
+            trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
+            updater = DummyUpdater(self.iters_per_epoch)
+            serializers.load_npz(f.name, updater)
+            trainer = training.Trainer(updater)
+            for expected in self.expected[self.resume:]:
+                updater.update()
+                self.assertEqual(trigger(trainer), expected)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
I rewrote tests of `ManualScheduleTrigger` with `testing.parameterize`. I think this is better than a lot of test classes.