### PR TITLE
SquaredError

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -73,6 +73,7 @@ from chainer.functions.loss import mean_squared_error  # NOQA
 from chainer.functions.loss import negative_sampling  # NOQA
 from chainer.functions.loss import sigmoid_cross_entropy  # NOQA
 from chainer.functions.loss import softmax_cross_entropy  # NOQA
+from chainer.functions.loss import squared_error  # NOQA
 from chainer.functions.loss import triplet  # NOQA
 from chainer.functions.loss import vae  # NOQA  # NOQA
 from chainer.functions.math import average  # NOQA
@@ -261,6 +262,8 @@ from chainer.functions.loss.sigmoid_cross_entropy import sigmoid_cross_entropy  
 from chainer.functions.loss.sigmoid_cross_entropy import SigmoidCrossEntropy  # NOQA
 from chainer.functions.loss.softmax_cross_entropy import softmax_cross_entropy  # NOQA
 from chainer.functions.loss.softmax_cross_entropy import SoftmaxCrossEntropy  # NOQA
+from chainer.functions.loss.squared_error import squared_error  # NOQA
+from chainer.functions.loss.squared_error import SquaredError  # NOQA
 from chainer.functions.loss.triplet import triplet  # NOQA
 from chainer.functions.loss.triplet import Triplet  # NOQA
 from chainer.functions.loss.vae import bernoulli_nll  # NOQA

--- a/chainer/functions/loss/squared_error.py
+++ b/chainer/functions/loss/squared_error.py
@@ -1,0 +1,35 @@
+import numpy
+
+from chainer import function
+from chainer.utils import type_check
+
+
+class SquaredError(function.Function):
+
+    """Squared error function."""
+
+    def check_type_forward(self, in_types):
+        type_check.expect(
+            in_types[0].dtype == numpy.float32,
+            in_types[1].dtype == numpy.float32,
+            in_types[0].shape == in_types[1].shape
+        )
+
+    def forward(self, inputs):
+        x0, x1 = inputs
+        self.diff = x0 - x1
+        return self.diff * self.diff,
+
+    def backward(self, inputs, gy):
+        g = gy[0] * 2 * self.diff
+        return g, -g
+
+
+def squared_error(x0, x1):
+    """Squared error function.
+
+    This function computes Squared error between two variables. Note that
+    the error is not scaled by 1/2.
+
+    """
+    return SquaredError()(x0, x1)

--- a/chainer/functions/loss/squared_error.py
+++ b/chainer/functions/loss/squared_error.py
@@ -1,6 +1,7 @@
 import numpy
 
 from chainer import function
+from chainer import utils
 from chainer.utils import type_check
 
 
@@ -19,11 +20,13 @@ class SquaredError(function.Function):
     def forward(self, inputs):
         x0, x1 = inputs
         self.diff = x0 - x1
-        return self.diff * self.diff,
+        return utils.force_array(self.diff * self.diff, dtype=x0.dtype),
 
     def backward(self, inputs, gy):
         g = gy[0] * 2 * self.diff
-        return g, -g
+        return (
+            utils.force_array(g, dtype=gy[0].dtype),
+            utils.force_array(-g, dtype=gy[0].dtype))
 
 
 def squared_error(x0, x1):

--- a/chainer/functions/loss/squared_error.py
+++ b/chainer/functions/loss/squared_error.py
@@ -9,6 +9,7 @@ class SquaredError(function.Function):
     """Squared error function."""
 
     def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
         type_check.expect(
             in_types[0].dtype == numpy.float32,
             in_types[1].dtype == numpy.float32,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
@@ -1,0 +1,64 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+
+@testing.parameterize(
+    {'shape': (4, 3)},
+    {'shape': (4, 3, 2)},
+    {'shape': (4,)},
+)
+class TestSquaredError(unittest.TestCase):
+
+    def setUp(self):
+        self.x0 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        self.x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        self.gy = numpy.random.random(self.shape).astype(numpy.float32)
+
+    def check_forward(self, x0_data, x1_data):
+        x0 = chainer.Variable(x0_data)
+        x1 = chainer.Variable(x1_data)
+        loss = functions.squared_error(x0, x1)
+        loss_value = cuda.to_cpu(loss.data)
+        self.assertEqual(loss_value.dtype, numpy.float32)
+        self.assertEqual(loss_value.shape, x0_data.shape)
+
+        for i in numpy.ndindex(self.x0.shape):
+            # Compute expected value
+            loss_expect = (self.x0[i] - self.x1[i]) ** 2
+            self.assertAlmostEqual(loss_value[i], loss_expect, places=5)
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward(self.x0, self.x1)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
+
+    def check_backward(self, x0_data, x1_data, y_grad):
+        gradient_check.check_backward(
+            functions.SquaredError(),
+            (x0_data, x1_data), y_grad, eps=1e-2)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x0, self.x1, self.gy)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward(
+            cuda.to_gpu(self.x0), cuda.to_gpu(self.x1), cuda.to_gpu(self.gy))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
@@ -15,6 +15,9 @@ from chainer.testing import condition
     {'shape': (4, 3)},
     {'shape': (4, 3, 2)},
     {'shape': (4,)},
+    {'shape': ()},
+    {'shape': (1,)},
+    {'shape': (1, 1)},
 )
 class TestSquaredError(unittest.TestCase):
 


### PR DESCRIPTION
`MeanSquaredError` without reduction. The new function is named `SquaredError`. The original `MeanSquaredError` is kept as is. This PR is related to #2558.