### PR TITLE
AbsoluteError

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -60,6 +60,7 @@ from chainer.functions.connection import n_step_lstm  # NOQA
 from chainer.functions.evaluation import accuracy  # NOQA
 from chainer.functions.evaluation import binary_accuracy  # NOQA
 from chainer.functions.evaluation import classification_summary  # NOQA
+from chainer.functions.loss import absolute_error  # NOQA
 from chainer.functions.loss import black_out  # NOQA
 from chainer.functions.loss import contrastive  # NOQA
 from chainer.functions.loss import crf1d  # NOQA
@@ -237,6 +238,8 @@ from chainer.functions.evaluation.classification_summary import precision  # NOQ
 from chainer.functions.evaluation.classification_summary import recall  # NOQA
 from chainer.functions.evaluation.r2_score import r2_score  # NOQA
 
+from chainer.functions.loss.absolute_error import absolute_error  # NOQA
+from chainer.functions.loss.absolute_error import AbsoluteError  # NOQA
 from chainer.functions.loss.black_out import black_out  # NOQA
 from chainer.functions.loss.contrastive import contrastive  # NOQA
 from chainer.functions.loss.contrastive import Contrastive  # NOQA

--- a/chainer/functions/loss/absolute_error.py
+++ b/chainer/functions/loss/absolute_error.py
@@ -1,0 +1,36 @@
+import numpy
+
+from chainer import cuda
+from chainer import function
+from chainer.utils import type_check
+
+
+class AbsoluteError(function.Function):
+
+    """Absolute error function."""
+
+    def check_type_forward(self, in_types):
+        type_check.expect(
+            in_types[0].dtype == numpy.float32,
+            in_types[1].dtype == numpy.float32,
+            in_types[0].shape == in_types[1].shape
+        )
+
+    def forward(self, inputs):
+        x0, x1 = inputs
+        self.diff = x0 - x1
+        return abs(self.diff),
+
+    def backward(self, inputs, gy):
+        xp = cuda.get_array_module(*inputs)
+        g = gy[0] * xp.sign(self.diff)
+        return g, -g
+
+
+def absolute_error(x0, x1):
+    """Absolute error function.
+
+    This function computes absolute error between two variables.
+
+    """
+    return AbsoluteError()(x0, x1)

--- a/chainer/functions/loss/absolute_error.py
+++ b/chainer/functions/loss/absolute_error.py
@@ -2,6 +2,7 @@ import numpy
 
 from chainer import cuda
 from chainer import function
+from chainer import utils
 from chainer.utils import type_check
 
 
@@ -10,6 +11,7 @@ class AbsoluteError(function.Function):
     """Absolute error function."""
 
     def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
         type_check.expect(
             in_types[0].dtype == numpy.float32,
             in_types[1].dtype == numpy.float32,
@@ -19,12 +21,14 @@ class AbsoluteError(function.Function):
     def forward(self, inputs):
         x0, x1 = inputs
         self.diff = x0 - x1
-        return abs(self.diff),
+        return utils.force_array(abs(self.diff), dtype=x0.dtype),
 
     def backward(self, inputs, gy):
         xp = cuda.get_array_module(*inputs)
         g = gy[0] * xp.sign(self.diff)
-        return g, -g
+        return (
+            utils.force_array(g, dtype=gy[0].dtype),
+            utils.force_array(-g, dtype=gy[0].dtype))
 
 
 def absolute_error(x0, x1):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
@@ -1,0 +1,67 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+
+@testing.parameterize(
+    {'shape': (4, 3)},
+    {'shape': (4, 3, 2)},
+    {'shape': (4,)},
+)
+class TestAbsoluteError(unittest.TestCase):
+
+    def setUp(self):
+        self.x0 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        # Add sufficient margin to prevent computational error
+        diff = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        diff[abs(diff) < 0.01] = 0.5
+        self.x1 = self.x0 + diff
+        self.gy = numpy.random.random(self.shape).astype(numpy.float32)
+
+    def check_forward(self, x0_data, x1_data):
+        x0 = chainer.Variable(x0_data)
+        x1 = chainer.Variable(x1_data)
+        loss = functions.absolute_error(x0, x1)
+        loss_value = cuda.to_cpu(loss.data)
+        self.assertEqual(loss_value.dtype, numpy.float32)
+        self.assertEqual(loss_value.shape, x0_data.shape)
+
+        for i in numpy.ndindex(self.x0.shape):
+            # Compute expected value
+            loss_expect = abs(self.x0[i] - self.x1[i])
+            self.assertAlmostEqual(loss_value[i], loss_expect, places=5)
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward(self.x0, self.x1)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
+
+    def check_backward(self, x0_data, x1_data, y_grad):
+        gradient_check.check_backward(
+            functions.AbsoluteError(),
+            (x0_data, x1_data), y_grad, eps=1e-2)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x0, self.x1, self.gy)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward(
+            cuda.to_gpu(self.x0), cuda.to_gpu(self.x1), cuda.to_gpu(self.gy))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
@@ -15,6 +15,9 @@ from chainer.testing import condition
     {'shape': (4, 3)},
     {'shape': (4, 3, 2)},
     {'shape': (4,)},
+    {'shape': ()},
+    {'shape': (1,)},
+    {'shape': (1, 1)},
 )
 class TestAbsoluteError(unittest.TestCase):
 
@@ -23,7 +26,7 @@ class TestAbsoluteError(unittest.TestCase):
         # Add sufficient margin to prevent computational error
         diff = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
         diff[abs(diff) < 0.01] = 0.5
-        self.x1 = self.x0 + diff
+        self.x1 = numpy.asarray(self.x0 + diff)
         self.gy = numpy.random.random(self.shape).astype(numpy.float32)
 
     def check_forward(self, x0_data, x1_data):


### PR DESCRIPTION
`MeanAbsoluteError` without reduction. The new function is named `AbsoluteError`. The original `MeanAbsoluteError` is kept as is. This PR is related to #2558.