### PR TITLE
Convert inputs of batchnormalization.backward() to be C-contiguous

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -224,6 +224,9 @@ class BatchNormalizationFunction(function.Function):
             # computing gradients in fixed-mean-variance mode, because there
             # is normally no reason to call backward()
             # while in test/evaluation mode.
+            x = cuda.cupy.ascontiguousarray(x)
+            gamma = cuda.cupy.ascontiguousarray(gamma)
+            gy = cuda.cupy.ascontiguousarray(gy)
             dtype = x.dtype
             handle = cudnn.get_handle()
             x_desc = cudnn.create_tensor_descriptor(_as4darray(x))


### PR DESCRIPTION
Converting the inputs into c-contiguous forms is done only in `forwrad` in `batchnormalization.py`, although it is done both in `forward` and `backward` in other functions (e.g. convolution_2d, convolution_nd, n_step_lstm). 

Given this fact, this PR converts the inputs for `backward` of `batchnormalization` into c-contiguous. (However I don't have any real example that requires this conversion, so please let me know if this conversion is not required by design and I'll close the PR.)