### PR TITLE
Convert inputs of batchnormalization.backward() to be C-contiguous (master)

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -230,6 +230,9 @@ class BatchNormalizationFunction(function.Function):
             # computing gradients in fixed-mean-variance mode, because there
             # is normally no reason to call backward()
             # while in test/evaluation mode.
+            x = cuda.cupy.ascontiguousarray(x)
+            gamma = cuda.cupy.ascontiguousarray(gamma)
+            gy = cuda.cupy.ascontiguousarray(gy)
             dtype = x.dtype
             handle = cudnn.get_handle()
             x_desc = cudnn.create_tensor_descriptor(_as4darray(x))

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -22,7 +22,7 @@ def _batch_normalization(expander, gamma, beta, x, mean, var):
 
 
 @testing.parameterize(*(testing.product({
-    'param_shape': [(3, 4), (3, 2, 3)],
+    'param_shape': [(3,), (3, 4), (3, 2, 3)],
     'ndim': [0, 1, 2],
     'dtype': [numpy.float32],
 }) + testing.product({
@@ -85,12 +85,18 @@ class TestBatchNormalization(unittest.TestCase):
     def test_forward_gpu_no_cudnn(self):
         self.check_forward([cuda.to_gpu(i) for i in self.args], False)
 
-    def check_backward(self, args, y_grad):
+    @attr.cudnn
+    @condition.retry(3)
+    def test_forward_gpu_non_contiguous(self):
+        self.check_forward([cuda.cupy.asfortranarray(cuda.to_gpu(i))
+                            for i in self.args])
+
+    def check_backward(self, args, y_grad, use_cudnn=True):
         gradient_check.check_backward(
             batch_normalization.BatchNormalizationFunction(
                 mean=None, var=None, train=self.train,
-                decay=self.decay, eps=self.eps), args, y_grad,
-            **self.check_backward_options)
+                decay=self.decay, eps=self.eps, use_cudnn=use_cudnn),
+            args, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -101,6 +107,19 @@ class TestBatchNormalization(unittest.TestCase):
     def test_backward_gpu(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu_no_cudnn(self):
+        self.check_backward(
+            [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy), False)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_backward_gpu_non_contiguous(self):
+        self.check_backward(
+            [cuda.cupy.asfortranarray(cuda.to_gpu(i)) for i in self.args],
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
 
 
 @testing.parameterize(*(testing.product({
@@ -166,11 +185,17 @@ class TestFixedBatchNormalization(unittest.TestCase):
     def test_forward_gpu_no_cudnn(self):
         self.check_forward([cuda.to_gpu(i) for i in self.args], False)
 
-    def check_backward(self, args, y_grad):
+    @attr.cudnn
+    @condition.retry(3)
+    def test_forward_gpu_non_contiguous(self):
+        self.check_forward([cuda.cupy.asfortranarray(cuda.to_gpu(i))
+                            for i in self.args])
+
+    def check_backward(self, args, y_grad, use_cudnn=True):
         gradient_check.check_backward(
             batch_normalization.BatchNormalizationFunction(
                 mean=None, var=None, train=self.train,
-                decay=self.decay, eps=self.eps),
+                decay=self.decay, eps=self.eps, use_cudnn=use_cudnn),
             args, y_grad,  **self.check_backward_options)
 
     @condition.retry(3)
@@ -182,6 +207,19 @@ class TestFixedBatchNormalization(unittest.TestCase):
     def test_backward_gpu(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu_no_cudnn(self):
+        self.check_backward(
+            [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy), False)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_backward_gpu_no_contiguous(self):
+        self.check_backward(
+            [cuda.cupy.asfortranarray(cuda.to_gpu(i)) for i in self.args],
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Changed the target branch of #2580 to master.

Also I added tests that use non-c-contiguous inputs as suggested in the comments in #2580. A new argument (param_shape = (3,)) is added because [cudnn is used only if `x.ndim == 4 and head_ndim == 2`](https://github.com/pfnet/chainer/blob/master/chainer/functions/normalization/batch_normalization.py#L107), which requires `len(param_shape) == 1` (or if `x.ndim == 2`, which requires `param_shape == ()` but it causes some inconsistency with the existing test codes). 