### PR TITLE
Assert output size of max_pooling_2d in GPU cases

### DIFF
--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -34,8 +34,10 @@ class MaxPooling2D(pooling_2d.Pooling2D):
         n, c, h, w = x[0].shape
         y_h = conv.get_conv_outsize(
             h, self.kh, self.sy, self.ph, self.cover_all)
+        assert y_h > 0, 'Height in the output should be positive.'
         y_w = conv.get_conv_outsize(
             w, self.kw, self.sx, self.pw, self.cover_all)
+        assert y_w > 0, 'Width in the output should be positive.'
         y = cuda.cupy.empty((n, c, y_h, y_w), dtype=x[0].dtype)
         self.indexes = cuda.cupy.empty((n, c, y_h, y_w), dtype=numpy.int32)
 

--- a/chainer/functions/pooling/pooling_2d.py
+++ b/chainer/functions/pooling/pooling_2d.py
@@ -53,8 +53,10 @@ class Pooling2D(function.Function):
         n, c, h, w = x.shape
         y_h = conv.get_conv_outsize(
             h, self.kh, self.sy, self.ph, self.cover_all)
+        assert y_h > 0, 'Height in the output should be positive.'
         y_w = conv.get_conv_outsize(
             w, self.kw, self.sx, self.pw, self.cover_all)
+        assert y_w > 0, 'Width in the output should be positive.'
         y = cuda.cupy.empty((n, c, y_h, y_w), dtype=x.dtype)
 
         handle = cudnn.get_handle()

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -65,6 +65,18 @@ class TestMaxPooling2D(unittest.TestCase):
         x = chainer.Variable(x_data)
         functions.max_pooling_2d(x, 6, stride=6, pad=0)
 
+    def test_forward_output_size_zero_cpu(self):
+        with self.assertRaisesRegexp(
+                AssertionError, 'Height in the output should be positive.'):
+            x_data = numpy.random.rand(4, 4, 1, 4).astype(self.dtype)
+            x = chainer.Variable(x_data)
+            functions.max_pooling_2d(x, 3, stride=2)
+        with self.assertRaisesRegexp(
+                AssertionError, 'Width in the output should be positive.'):
+            x_data = numpy.random.rand(4, 4, 4, 1).astype(self.dtype)
+            x = chainer.Variable(x_data)
+            functions.max_pooling_2d(x, 3, stride=2)
+
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
@@ -74,6 +86,34 @@ class TestMaxPooling2D(unittest.TestCase):
     @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_output_size_zero_gpu(self):
+        with self.assertRaisesRegexp(
+                AssertionError, 'Height in the output should be positive.'):
+            x_data = cuda.cupy.random.rand(4, 4, 1, 4).astype(self.dtype)
+            x = chainer.Variable(x_data)
+            functions.max_pooling_2d(x, 3, stride=2, use_cudnn=False)
+        with self.assertRaisesRegexp(
+                AssertionError, 'Width in the output should be positive.'):
+            x_data = cuda.cupy.random.rand(4, 4, 4, 1).astype(self.dtype)
+            x = chainer.Variable(x_data)
+            functions.max_pooling_2d(x, 3, stride=2, use_cudnn=False)
+
+    @attr.cudnn
+    @condition.retry(3)
+    def test_forward_output_size_zero_cudnn(self):
+        with self.assertRaisesRegexp(
+                AssertionError, 'Height in the output should be positive.'):
+            x_data = cuda.cupy.random.rand(4, 4, 1, 4).astype(self.dtype)
+            x = chainer.Variable(x_data)
+            functions.max_pooling_2d(x, 3, stride=2, use_cudnn=True)
+        with self.assertRaisesRegexp(
+                AssertionError, 'Width in the output should be positive.'):
+            x_data = cuda.cupy.random.rand(4, 4, 4, 1).astype(self.dtype)
+            x = chainer.Variable(x_data)
+            functions.max_pooling_2d(x, 3, stride=2, use_cudnn=True)
 
     def check_backward(self, x_data, y_grad, use_cudnn=True):
         gradient_check.check_backward(

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -87,6 +87,7 @@ class TestMaxPooling2D(unittest.TestCase):
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
+    @attr.gpu
     def test_forward_output_size_zero_gpu(self):
         with self.assertRaisesRegexp(
                 AssertionError, 'Height in the output should be positive.'):
@@ -99,6 +100,7 @@ class TestMaxPooling2D(unittest.TestCase):
             x = chainer.Variable(x_data)
             functions.max_pooling_2d(x, 3, stride=2, use_cudnn=False)
 
+    @attr.cudnn
     def test_forward_output_size_zero_cudnn(self):
         with self.assertRaisesRegexp(
                 AssertionError, 'Height in the output should be positive.'):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -87,8 +87,6 @@ class TestMaxPooling2D(unittest.TestCase):
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), False)
 
-    @attr.gpu
-    @condition.retry(3)
     def test_forward_output_size_zero_gpu(self):
         with self.assertRaisesRegexp(
                 AssertionError, 'Height in the output should be positive.'):
@@ -101,8 +99,6 @@ class TestMaxPooling2D(unittest.TestCase):
             x = chainer.Variable(x_data)
             functions.max_pooling_2d(x, 3, stride=2, use_cudnn=False)
 
-    @attr.cudnn
-    @condition.retry(3)
     def test_forward_output_size_zero_cudnn(self):
         with self.assertRaisesRegexp(
                 AssertionError, 'Height in the output should be positive.'):


### PR DESCRIPTION
In the CPU code of `max_pooling_2d`, the size of the expected output is checked before calculation (in [`chainer/utils/conv.py`](https://github.com/pfnet/chainer/blob/master/chainer/utils/conv.py#L25-L28])) so that the output never becomes a 0-dimentional tensor.

However, this check is missing in the GPU code (with and without cudnn) and thus passing an invalid input to `max_pooling_2d.py` yields a very un-friendly error as exampled below.

This PR adds assertions that check the output size of `max_pooling_2d` for GPU cases, and also improves the tests to check the added behavior.

Sample output before this PR is applied:
```
>>> import chainer
>>> x_data = chainer.cuda.cupy.random.rand(4, 4, 1, 4)
>>> x = chainer.Variable(x_data)
>>> chainer.functions.max_pooling_2d(x, 3, stride=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/soramichi/src/anaconda3/lib/python3.6/site-packages/chainer/functions/pooling/max_pooling_2d.py", line 175, in max_pooling_2d
    return MaxPooling2D(ksize, stride, pad, cover_all, use_cudnn)(x)
  File "/home/soramichi/src/anaconda3/lib/python3.6/site-packages/chainer/function.py", line 199, in __call__
    outputs = self.forward(in_data)
  File "/home/soramichi/src/anaconda3/lib/python3.6/site-packages/chainer/function.py", line 310, in forward
    return self.forward_gpu(inputs)
  File "/home/soramichi/src/anaconda3/lib/python3.6/site-packages/chainer/functions/pooling/max_pooling_2d.py", line 32, in forward_gpu
    return super(MaxPooling2D, self).forward_gpu(x)
  File "/home/soramichi/src/anaconda3/lib/python3.6/site-packages/chainer/functions/pooling/pooling_2d.py", line 65, in forward_gpu
    y_desc = cudnn.create_tensor_descriptor(y)
  File "/home/soramichi/src/anaconda3/lib/python3.6/site-packages/cupy/cudnn.py", line 78, in create_tensor_descriptor
    cudnn.setTensor4dDescriptor(desc.value, format, data_type, *arr.shape)
  File "cupy/cuda/cudnn.pyx", line 444, in cupy.cuda.cudnn.setTensor4dDescriptor (cupy/cuda/cudnn.cpp:2967)
  File "cupy/cuda/cudnn.pyx", line 449, in cupy.cuda.cudnn.setTensor4dDescriptor (cupy/cuda/cudnn.cpp:2833)
  File "cupy/cuda/cudnn.pyx", line 392, in cupy.cuda.cudnn.check_status (cupy/cuda/cudnn.cpp:2017)
cupy.cuda.cudnn.CuDNNError: CUDNN_STATUS_BAD_PARAM: b'CUDNN_STATUS_BAD_PARAM'
```
