### PR TITLE
Fixed pep8 file to use autopep8 command locally

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [pep8]
 exclude=caffe_pb*,.eggs,*.egg,build
-diff=True
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
 script:
   - flake8
   - flake8 --config=.flake8.cython
-  - autopep8 -r . --global-config .pep8 | tee check_autopep8
+  - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
   - PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' nosetests -a '!gpu,!slow' --with-doctest tests/install_tests
   - cd tests


### PR DESCRIPTION
When i run autopep8 locally, i cannot use `--inplace` option as it loads `.pep8` file and appends `--diff` option. I removed this option from `.pep8` file.