### PR TITLE
Fix test name

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -47,7 +47,7 @@ class TestGaussianKLDivergence(unittest.TestCase):
                                           cuda.to_gpu(self.ln_var))
 
 
-class TestGaussianNLLInvalidReductionOption(unittest.TestCase):
+class TestGaussianKLDivergenceInvalidReductionOption(unittest.TestCase):
 
     def setUp(self):
         self.mean = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)


### PR DESCRIPTION
There are two `TestGaussianNLLInvalidReductionOption`, whose contents are different. It causes autopep8 violation in the master branch (see e.g. [this build](https://travis-ci.org/pfnet/chainer/builds/224012219)). This PR changes the name of one of them.