### PR TITLE
Delete a noisy print

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -185,7 +185,7 @@ class SoftmaxCrossEntropy(function.Function):
             coeff = gloss * self._coeff
         else:
             coeff = gloss[:, None, ...]
-        print(coeff.shape)
+
         if self.class_weight is None:
             gx = cuda.elementwise(
                 'T y, S t, T coeff, S n_channel, S n_unit',


### PR DESCRIPTION
There seems to be a print that was maybe used for debugging, it's already not needed. It produces `()` everytime the softmax_cross_entropy is called.