### PR TITLE
Modify docstring for IDE friendly

### DIFF
--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -14,7 +14,7 @@ class Convolution2D(link.Link):
     holds the filter weight and bias vector as parameters.
 
     Args:
-        in_channels (int): Number of channels of input arrays. If ``None``,
+        in_channels (int or None): Number of channels of input arrays. If ``None``,
             parameter initialization will be deferred until the first forward
             data pass at which time the size will be determined.
         out_channels (int): Number of channels of output arrays.
@@ -28,12 +28,12 @@ class Convolution2D(link.Link):
         bias (float): Initial bias value.
         nobias (bool): If ``True``, then this link does not use the bias term.
         use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
-        initialW (4-D array): Initial weight value. If ``None``, then this
+        initialW (4-D array or None): Initial weight value. If ``None``, then this
             function uses Gaussian distribution scaled by ``w_scale`` to
             initialize weight.
             May also be a callable that takes ``numpy.ndarray`` or
             ``cupy.ndarray`` and edits its value.
-        initial_bias (1-D array): Initial bias value. If ``None``, then this
+        initial_bias (1-D array or None): Initial bias value. If ``None``, then this
             function uses ``bias`` to initialize bias.
             May also be a callable that takes ``numpy.ndarray`` or
             ``cupy.ndarray`` and edits its value.

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -28,12 +28,12 @@ class Convolution2D(link.Link):
         bias (float): Initial bias value.
         nobias (bool): If ``True``, then this link does not use the bias term.
         use_cudnn (bool): If ``True``, then this link uses cuDNN if available.
-        initialW (4-D array or None): Initial weight value. If ``None``, then this
+        initialW (4-D array): Initial weight value. If ``None``, then this
             function uses Gaussian distribution scaled by ``w_scale`` to
             initialize weight.
             May also be a callable that takes ``numpy.ndarray`` or
             ``cupy.ndarray`` and edits its value.
-        initial_bias (1-D array or None): Initial bias value. If ``None``, then this
+        initial_bias (1-D array): Initial bias value. If ``None``, then this
             function uses ``bias`` to initialize bias.
             May also be a callable that takes ``numpy.ndarray`` or
             ``cupy.ndarray`` and edits its value.

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -16,7 +16,7 @@ class Deconvolution2D(link.Link):
     and holds the filter weight and bias vector as parameters.
 
     Args:
-        in_channels (int): Number of channels of input arrays. If ``None``,
+        in_channels (int or None): Number of channels of input arrays. If ``None``,
             parameter initialization will be deferred until the first forward
             data pass at which time the size will be determined.
         out_channels (int): Number of channels of output arrays.

--- a/chainer/links/connection/depthwise_convolution_2d.py
+++ b/chainer/links/connection/depthwise_convolution_2d.py
@@ -14,7 +14,7 @@ class DepthwiseConvolution2D(link.Link):
     function and holds the filter weight and bias vector as parameters.
 
     Args:
-        in_channels (int): Number of channels of input arrays. If ``None``,
+        in_channels (int or None): Number of channels of input arrays. If ``None``,
             parameter initialization will be deferred until the first forward
             data pass at which time the size will be determined.
         channel_multiplier (int): Channel multiplier number. Number of output

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -14,7 +14,7 @@ class DilatedConvolution2D(link.Link):
     function and holds the filter weight and bias vector as parameters.
 
     Args:
-        in_channels (int): Number of channels of input arrays. If ``None``,
+        in_channels (int or None): Number of channels of input arrays. If ``None``,
             parameter initialization will be deferred until the first forward
             data pass at which time the size will be determined.
         out_channels (int): Number of channels of output arrays.

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -21,7 +21,7 @@ class Linear(link.Link):
     does not hold a bias vector.
 
     Args:
-        in_size (int): Dimension of input vectors. If ``None``, parameter
+        in_size (int or None): Dimension of input vectors. If ``None``, parameter
             initialization will be deferred until the first forward data pass
             at which time the size will be determined.
         out_size (int): Dimension of output vectors.

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -57,7 +57,7 @@ class StatelessLSTM(LSTMBase):
     hidden states.
 
     Args:
-        in_size (int): Dimension of input vectors. If ``None``, parameter
+        in_size (int or None): Dimension of input vectors. If ``None``, parameter
             initialization will be deferred until the first forward data pass
             at which time the size will be determined.
         out_size (int): Dimensionality of output vectors.


### PR DESCRIPTION
In some module, in_channel/in_size parameter accepts None, but only int is described in docstring.

This PR add "or None" to docstring.

