### PR TITLE
Fixbug in chainer.datasets.split_dataset_random

### DIFF
--- a/examples/pos/postagging.py
+++ b/examples/pos/postagging.py
@@ -109,7 +109,7 @@ def main():
     optimizer.add_hook(chainer.optimizer.WeightDecay(0.0001))
 
     test_data, train_data = datasets.split_dataset_random(
-        data, len(data) / 10, seed=0)
+        data, len(data) // 10, seed=0)
 
     train_iter = chainer.iterators.SerialIterator(train_data, args.batchsize)
     test_iter = chainer.iterators.SerialIterator(test_data, args.batchsize,


### PR DESCRIPTION
If len(data) is not divisible, datasets.split_dataset_random recieve float value as ```first_size```.

This cause an error in calling ```numpy.random.permutation(len(self.dataset))``` because permutation cannot take a float object as argument.

NOTE: this error occurs in Python3