### PR TITLE
Import theano on initializer

### DIFF
--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -1,17 +1,12 @@
 import collections
 
-try:
-    import theano
-    _available = True
-except ImportError:
-    _available = False
-
 from chainer.functions.theano import theano_function
 from chainer import link
 from chainer import utils
 
 
 def _to_var_tuple(vs):
+    import theano
     msg = ('inputs and outputs must be a TensorVariable, a list '
            'of TensorVariable or a tuple of TensorVariable')
 
@@ -68,7 +63,12 @@ class TheanoFunction(link.Link):
 
     def __init__(self, inputs, outputs):
         utils.experimental('chainer.links.TheanoFunction')
-        if not _available:
+        try:
+            # When Theano library is imported, it executes a lot of
+            # initialization process. To minimize its side effect,
+            # we need import theano here.
+            import theano
+        except ImportError:
             msg = '''theano is not installed on your environment.
 Please install theano to activate theano function.
 

--- a/chainer/testing/helper.py
+++ b/chainer/testing/helper.py
@@ -24,7 +24,7 @@ def with_requires(*requirements):
     try:
         ws.require(*requirements)
         skip = False
-    except pkg_resources.VersionConflict:
+    except pkg_resources.ResolutionError:
         skip = True
 
     msg = 'requires: {}'.format(','.join(requirements))

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -766,7 +766,7 @@ def with_requires(*requirements):
     try:
         ws.require(*requirements)
         skip = False
-    except pkg_resources.VersionConflict:
+    except pkg_resources.ResolutionError:
         skip = True
 
     msg = 'requires: {}'.format(','.join(requirements))

--- a/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
+++ b/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
@@ -12,11 +12,7 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-if theano_function._available:
-    import theano.tensor as T
-
-
-@unittest.skipUnless(theano_function._available, 'theano is not available')
+@testing.with_requires('theano')
 class TheanoFunctionTestBase(object):
 
     forward_test_options = {}
@@ -98,6 +94,7 @@ class TheanoFunctionTestBase(object):
 class TestTheanoFunction(TheanoFunctionTestBase, unittest.TestCase):
 
     def make_func(self):
+        import theano.tensor as T
         x = T.TensorType(self.inputs[0]['type'],
                          (False,) * len(self.inputs[0]['shape']))('x')
         y = T.TensorType(self.inputs[1]['type'],
@@ -127,6 +124,7 @@ class TestTheanoFunction(TheanoFunctionTestBase, unittest.TestCase):
 class TestTheanoFunctionTwoOutputs(TheanoFunctionTestBase, unittest.TestCase):
 
     def make_func(self):
+        import theano.tensor as T
         x = T.TensorType(self.inputs[0]['type'],
                          (False,) * len(self.inputs[0]['shape']))('x')
         y = T.TensorType(self.inputs[1]['type'],
@@ -152,6 +150,7 @@ class TestTheanoFunctionNonDifferential(
         TheanoFunctionTestBase, unittest.TestCase):
 
     def make_func(self):
+        import theano.tensor as T
         x = T.TensorType(self.inputs[0]['type'],
                          (False,) * len(self.inputs[0]['shape']))('x')
         i = T.TensorType(self.inputs[1]['type'],

--- a/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
+++ b/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
@@ -6,7 +6,6 @@ import chainer
 from chainer import cuda
 from chainer import gradient_check
 from chainer import links
-from chainer.links.theano import theano_function
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition


### PR DESCRIPTION
Theano executes initialization process when it is imported. Such behavior is undesirable especially for users who do not need theano. To minimize its side effect, it needs to be imported on initializer.

See @jekbradbury 's comment:
https://github.com/pfnet/chainer/issues/2570#issuecomment-296408191