### PR TITLE
Fix broken alex_fp16 example.

### DIFF
--- a/examples/imagenet/alex.py
+++ b/examples/imagenet/alex.py
@@ -54,14 +54,18 @@ class AlexFp16(Alex):
         chainer.Chain.__init__(
             self,
             conv1=L.Convolution2D(None, 96, 11,
-                                  stride=4, initialW=W, bias=bias),
-            conv2=L.Convolution2D(None, 256, 5, pad=2, initialW=W, bias=bias),
-            conv3=L.Convolution2D(None, 384, 3, pad=1, initialW=W, bias=bias),
-            conv4=L.Convolution2D(None, 384, 3, pad=1, initialW=W, bias=bias),
-            conv5=L.Convolution2D(None, 256, 3, pad=1, initialW=W, bias=bias),
-            fc6=L.Linear(None, 4096, initialW=W, bias=bias),
-            fc7=L.Linear(None, 4096, initialW=W, bias=bias),
-            fc8=L.Linear(None, 1000, initialW=W, bias=bias),
+                                  stride=4, initialW=W, initial_bias=bias),
+            conv2=L.Convolution2D(None, 256, 5, pad=2,
+                                  initialW=W, initial_bias=bias),
+            conv3=L.Convolution2D(None, 384, 3, pad=1,
+                                  initialW=W, initial_bias=bias),
+            conv4=L.Convolution2D(None, 384, 3, pad=1,
+                                  initialW=W, initial_bias=bias),
+            conv5=L.Convolution2D(None, 256, 3, pad=1,
+                                  initialW=W, initial_bias=bias),
+            fc6=L.Linear(None, 4096, initialW=W, initial_bias=bias),
+            fc7=L.Linear(None, 4096, initialW=W, initial_bias=bias),
+            fc8=L.Linear(None, 1000, initialW=W, initial_bias=bias),
         )
 
     def __call__(self, x, t):


### PR DESCRIPTION
Since "bias" keyword parameter  in L.Convolution2D.__init__() is removed, alex_fp16 example is broken.

```
Traceback (most recent call last):
  File "examples/imagenet/train_imagenet.py", line 205, in <module>
    main()
  File "examples/imagenet/train_imagenet.py", line 132, in main
    model = archs[args.arch]()
  File "/home/kfukuda/chainermn/examples/imagenet/alex_v2.py", line 58, in __init__
    stride=4, initialW=W, bias=bias),
TypeError: __init__() got an unexpected keyword argument 'bias'
```

I think the `bias` arguments can be simply removed in general cases.
In this case, however, FP16 dtype is used explicitly. So I replaced it with `initial_bias`.
(I'm not confident...)



