### PR TITLE
Make None serializable

### DIFF
--- a/chainer/serializer.py
+++ b/chainer/serializer.py
@@ -28,10 +28,15 @@ class AbstractSerializer(object):
         the ``value`` argument is used just for determining the type of
         restored value to be converted, and the converted value is returned.
         For arrays, the restored elements are directly copied into the
-        ``value`` argument. String values are treated like scalars. If the
-        ``value`` argument is ``None``, the type of the restored value will
-        typically be a numpy array but can depend on the particular subclass
-        implementation.
+        ``value`` argument. String values are treated like scalars.
+        
+        .. note::
+           As of v2.0.0, serializers and deserializers are required to
+           correctly handle the ``None`` value. When ``value`` is ``None``,
+           serializers save it in format-dependent ways, and deserializers
+           just return the loaded value. When the saved ``None`` value is
+           loaded by a deserializer, it should quietly return the ``None``
+           value without modifying the ``value`` object.
 
         Args:
             key (str): Name of the serialization entry.

--- a/chainer/serializer.py
+++ b/chainer/serializer.py
@@ -29,7 +29,7 @@ class AbstractSerializer(object):
         restored value to be converted, and the converted value is returned.
         For arrays, the restored elements are directly copied into the
         ``value`` argument. String values are treated like scalars.
-        
+
         .. note::
            As of v2.0.0, serializers and deserializers are required to
            correctly handle the ``None`` value. When ``value`` is ``None``,

--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -47,8 +47,13 @@ class HDF5Serializer(serializer.Serializer):
         ret = value
         if isinstance(value, cuda.ndarray):
             value = cuda.to_cpu(value)
-        arr = numpy.asarray(value)
-        compression = None if arr.size <= 1 else self.compression
+        if value is None:
+            # use Empty to represent None
+            arr = h5py.Empty('f')
+            compression = None
+        else:
+            arr = numpy.asarray(value)
+            compression = None if arr.size <= 1 else self.compression
         self.group.create_dataset(key, data=arr, compression=compression)
         return ret
 
@@ -113,9 +118,12 @@ class HDF5Deserializer(serializer.Deserializer):
             return value
 
         dataset = self.group[key]
+        if dataset.shape is None:  # Empty
+            return None
         if value is None:
             return numpy.asarray(dataset)
-        elif isinstance(value, numpy.ndarray):
+
+        if isinstance(value, numpy.ndarray):
             dataset.read_direct(value)
         elif isinstance(value, cuda.ndarray):
             value.set(numpy.asarray(dataset))

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -104,6 +104,9 @@ class NpzDeserializer(serializer.Deserializer):
             return value
 
         dataset = self.npz[key]
+        if dataset[()] is None:
+            return None
+
         if value is None:
             return dataset
         elif isinstance(value, numpy.ndarray):

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -82,6 +82,15 @@ class TestHDF5Serializer(unittest.TestCase):
 
         self.assertIs(ret, 10)
 
+    def test_serialize_none(self):
+        ret = self.serializer('x', None)
+        self.assertIs(ret, None)
+
+        print(list(self.hdf5file.keys()))
+        dset = self.hdf5file['x']
+        self.assertIsInstance(dset, h5py.Dataset)
+        self.assertIs(dset.shape, None)
+
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')
 class TestHDF5Deserializer(unittest.TestCase):
@@ -96,6 +105,7 @@ class TestHDF5Deserializer(unittest.TestCase):
             f.require_group('x')
             f.create_dataset('y', data=self.data)
             f.create_dataset('z', data=numpy.asarray(10))
+            f.create_dataset('w', data=h5py.Empty('f'))
 
         self.hdf5file = h5py.File(path, 'r')
         self.deserializer = hdf5.HDF5Deserializer(self.hdf5file)
@@ -156,6 +166,15 @@ class TestHDF5Deserializer(unittest.TestCase):
                 self.assertEqual(ret, data)
         finally:
             os.remove(path)
+
+    def test_deserialize_none(self):
+        ret = self.deserializer('w', None)
+        self.assertIs(ret, None)
+
+    def test_deserialize_none_by_passing_array(self):
+        y = numpy.empty((1,))
+        ret = self.deserializer('w', y)
+        self.assertIs(ret, None)
 
 
 @unittest.skipUnless(hdf5._available, 'h5py is not available')

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -86,7 +86,6 @@ class TestHDF5Serializer(unittest.TestCase):
         ret = self.serializer('x', None)
         self.assertIs(ret, None)
 
-        print(list(self.hdf5file.keys()))
         dset = self.hdf5file['x']
         self.assertIsInstance(dset, h5py.Dataset)
         self.assertIs(dset.shape, None)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -68,6 +68,17 @@ class TestDictionarySerializer(unittest.TestCase):
 
         self.assertIs(ret, 10)
 
+    def test_serialize_none(self):
+        ret = self.serializer('x', None)
+        dset = self.serializer.target['x']
+
+        self.assertIsInstance(dset, numpy.ndarray)
+        self.assertEqual(dset.shape, ())
+        self.assertEqual(dset.dtype, numpy.object)
+        self.assertIs(dset[()], None)
+
+        self.assertIs(ret, None)
+
 
 @testing.parameterize(*testing.product({'compress': [False, True]}))
 class TestNpzDeserializer(unittest.TestCase):
@@ -81,7 +92,8 @@ class TestNpzDeserializer(unittest.TestCase):
         with open(path, 'wb') as f:
             savez = numpy.savez_compressed if self.compress else numpy.savez
             savez(
-                f, **{'x/': None, 'y': self.data, 'z': numpy.asarray(10)})
+                f, **{'x/': None, 'y': self.data, 'z': numpy.asarray(10),
+                      'w': None})
 
         self.npzfile = numpy.load(path)
         self.deserializer = npz.NpzDeserializer(self.npzfile)
@@ -106,7 +118,7 @@ class TestNpzDeserializer(unittest.TestCase):
         numpy.testing.assert_array_equal(cuda.to_cpu(y), self.data)
         self.assertIs(ret, y)
 
-    def check_deserialize_none_value(self, y, query):
+    def check_deserialize_by_passing_none(self, y, query):
         ret = self.deserializer(query, None)
         numpy.testing.assert_array_equal(cuda.to_cpu(ret), self.data)
 
@@ -114,9 +126,9 @@ class TestNpzDeserializer(unittest.TestCase):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(y, 'y')
 
-    def test_deserialize_none_value_cpu(self):
+    def test_deserialize_by_passing_none_cpu(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
-        self.check_deserialize_none_value(y, 'y')
+        self.check_deserialize_by_passing_none(y, 'y')
 
     @attr.gpu
     def test_deserialize_gpu(self):
@@ -124,9 +136,9 @@ class TestNpzDeserializer(unittest.TestCase):
         self.check_deserialize(cuda.to_gpu(y), 'y')
 
     @attr.gpu
-    def test_deserialize_none_value_gpu(self):
+    def test_deserialize_by_passing_none_gpu(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
-        self.check_deserialize_none_value(cuda.to_gpu(y), 'y')
+        self.check_deserialize_by_passing_none(cuda.to_gpu(y), 'y')
 
     def test_deserialize_cpu_strip_slashes(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
@@ -141,6 +153,15 @@ class TestNpzDeserializer(unittest.TestCase):
         z = 5
         ret = self.deserializer('z', z)
         self.assertEqual(ret, 10)
+
+    def test_deserialize_none(self):
+        ret = self.deserializer('w', None)
+        self.assertIs(ret, None)
+
+    def test_deserialize_by_passing_array(self):
+        y = numpy.empty((1,), dtype=numpy.float32)
+        ret = self.deserializer('w', y)
+        self.assertIs(ret, None)
 
 
 class TestNpzDeserializerNonStrict(unittest.TestCase):


### PR DESCRIPTION
This PR makes each serializer implementation handle `None` appropriately. The change of the "specification" of AbstractSerializer may affect existing codes used by future codes, and so I make this PR for v2.