### PR TITLE
Check old arguments which is not supported in v2 to show error message.

### DIFF
--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -17,6 +17,7 @@ from chainer.functions.array import split_axis
 from chainer.functions.array import stack
 from chainer.functions.connection import linear
 from chainer.functions.noise import dropout
+from chainer.utils import argument
 from chainer.utils import type_check
 
 
@@ -373,8 +374,10 @@ def _stack_weight(ws):
 
 
 def n_step_lstm(
-        n_layers, dropout_ratio, hx, cx, ws, bs, xs):
-    """Stacked Long Short-Term Memory function for sequence inputs.
+        n_layers, dropout_ratio, hx, cx, ws, bs, xs, **kwargs):
+    """n_step_lstm(n_layers, dropout_ratio, hx, cx, ws, bs, xs)
+
+    Stacked Long Short-Term Memory function for sequence inputs.
 
     This function calculates stacked LSTM with sequences. This function gets
     an initial hidden state :math:`h_0`, an initial cell state :math:`c_0`,
@@ -401,6 +404,14 @@ def n_step_lstm(
     of ``k``-th layer is hidden state ``h_t`` of ``k-1``-th layer.
     Note that all input variables except first layer may have different shape
     from the first layer.
+
+    .. warning::
+
+       ``train`` and ``use_cudnn`` arguments are not supported anymore since
+       v2.
+       Instead, use ``chainer.using_config('train', train)`` and
+       ``chainer.using_config('use_cudnn', use_cudnn)``.
+       See :func:`chainer.using_config`.
 
     Args:
         n_layers(int): Number of layers.
@@ -453,6 +464,13 @@ def n_step_lstm(
        :func:`chainer.functions.lstm`
 
     """
+
+    argument.check_unexpected_kwargs(
+        kwargs, train='train argument is not supported anymore. '
+        'Use chainer.using_config',
+        use_cudnn='use_cudnn argument is not supported anymore. '
+        'Use chainer.using_config')
+    argument.parse_kwargs(kwargs)
 
     xp = cuda.get_array_module(hx, hx.data)
 

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -470,7 +470,7 @@ def n_step_lstm(
         'Use chainer.using_config',
         use_cudnn='use_cudnn argument is not supported anymore. '
         'Use chainer.using_config')
-    argument.parse_kwargs(kwargs)
+    argument.assert_kwargs_empty(kwargs)
 
     xp = cuda.get_array_module(hx, hx.data)
 

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -410,7 +410,7 @@ def n_step_lstm(
        ``train`` and ``use_cudnn`` arguments are not supported anymore since
        v2.
        Instead, use ``chainer.using_config('train', train)`` and
-       ``chainer.using_config('use_cudnn', use_cudnn)``.
+       ``chainer.using_config('use_cudnn', use_cudnn)`` respectively.
        See :func:`chainer.using_config`.
 
     Args:

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -3,6 +3,7 @@ import numpy
 from chainer import configuration
 from chainer import cuda
 from chainer import function
+from chainer.utils import argument
 from chainer.utils import type_check
 
 
@@ -33,12 +34,20 @@ class Dropout(function.Function):
         return gy[0] * self.mask,
 
 
-def dropout(x, ratio=.5):
-    """Drops elements of input variable randomly.
+def dropout(x, ratio=.5, **kwargs):
+    """dropout(x, ratio=.5):
+
+    Drops elements of input variable randomly.
 
     This function drops input elements randomly with probability ``ratio`` and
     scales the remaining elements by factor ``1 / (1 - ratio)``. In testing
     mode, it does nothing and just returns ``x``.
+
+    .. warning::
+
+       ``train`` argument is not supported anymore since v2.
+       Instead, use ``chainer.using_config('train', train)``.
+       See :func:`chainer.using_config`.
 
     Args:
         x (~chainer.Variable): Input variable.
@@ -51,6 +60,11 @@ def dropout(x, ratio=.5):
     co-adaptation of feature detectors <https://arxiv.org/abs/1207.0580>`_.
 
     """
+    argument.check_unexpected_kwargs(
+        kwargs, train='train argument is not supported anymore. '
+        'Use chainer.using_config')
+    argument.parse_kwargs(kwargs)
+
     if configuration.config.train:
         return Dropout(ratio)(x)
     return x

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -63,7 +63,7 @@ def dropout(x, ratio=.5, **kwargs):
     argument.check_unexpected_kwargs(
         kwargs, train='train argument is not supported anymore. '
         'Use chainer.using_config')
-    argument.parse_kwargs(kwargs)
+    argument.assert_kwargs_empty(kwargs)
 
     if configuration.config.train:
         return Dropout(ratio)(x)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -35,7 +35,7 @@ class Dropout(function.Function):
 
 
 def dropout(x, ratio=.5, **kwargs):
-    """dropout(x, ratio=.5):
+    """dropout(x, ratio=.5)
 
     Drops elements of input variable randomly.
 

--- a/chainer/functions/noise/zoneout.py
+++ b/chainer/functions/noise/zoneout.py
@@ -36,7 +36,7 @@ class Zoneout(function.Function):
 
 
 def zoneout(h, x, ratio=.5, **kwargs):
-    """zoneout(h, x, ratio=.5):
+    """zoneout(h, x, ratio=.5)
 
     Drops elements of input variable and sets to previous variable randomly.
 

--- a/chainer/functions/noise/zoneout.py
+++ b/chainer/functions/noise/zoneout.py
@@ -65,7 +65,7 @@ def zoneout(h, x, ratio=.5, **kwargs):
     argument.check_unexpected_kwargs(
         kwargs, train='train argument is not supported anymore. '
         'Use chainer.using_config')
-    argument.parse_kwargs(kwargs)
+    argument.assert_kwargs_empty(kwargs)
 
     if configuration.config.train:
         return Zoneout(ratio)(h, x)

--- a/chainer/functions/noise/zoneout.py
+++ b/chainer/functions/noise/zoneout.py
@@ -3,6 +3,7 @@ import numpy
 from chainer import configuration
 from chainer import cuda
 from chainer import function
+from chainer.utils import argument
 from chainer.utils import type_check
 
 
@@ -34,12 +35,20 @@ class Zoneout(function.Function):
         return gy[0] * self.flag_h, gy[0] * self.flag_x,
 
 
-def zoneout(h, x, ratio=.5):
-    """Drops elements of input variable and sets to previous variable randomly.
+def zoneout(h, x, ratio=.5, **kwargs):
+    """zoneout(h, x, ratio=.5):
+
+    Drops elements of input variable and sets to previous variable randomly.
 
     This function drops input elements randomly with probability ``ratio`` and
     instead sets dropping element to their previous variable. In testing mode ,
     it does nothing and just returns ``x``.
+
+    .. warning::
+
+       ``train`` argument is not supported anymore since v2.
+       Instead, use ``chainer.using_config('train', train)``.
+       See :func:`chainer.using_config`.
 
     Args:
         h (~chainer.Variable): Previous variable.
@@ -53,6 +62,11 @@ def zoneout(h, x, ratio=.5):
     Activations <https://arxiv.org/abs/1606.01305>`_.
 
     """
+    argument.check_unexpected_kwargs(
+        kwargs, train='train argument is not supported anymore. '
+        'Use chainer.using_config')
+    argument.parse_kwargs(kwargs)
+
     if configuration.config.train:
         return Zoneout(ratio)(h, x)
     return x

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -4,6 +4,7 @@ import chainer
 from chainer import configuration
 from chainer import cuda
 from chainer import function
+from chainer.utils import argument
 from chainer.utils import type_check
 
 if cuda.cudnn_enabled:
@@ -262,9 +263,10 @@ class BatchNormalizationFunction(function.Function):
         return gx, ggamma, gbeta
 
 
-def batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None,
-                        running_var=None, decay=0.9):
-    """Batch normalization function.
+def batch_normalization(x, gamma, beta, **kwargs):
+    """batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None, running_var=None, decay=0.9):
+
+    Batch normalization function.
 
     It takes the input variable ``x`` and two parameter variables ``gamma`` and
     ``beta``. The parameter variables must both have the same dimensionality,
@@ -319,6 +321,14 @@ def batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None,
     .. seealso:: :class:`links.BatchNormalization`
 
     """
+
+    argument.check_unexpected_kwargs(
+        kwargs, train='train argument is not supported anymore. '
+        'Use chainer.using_config')
+    eps, running_mean, running_var, decay = argument.parse_kwargs(
+        kwargs, ('eps', 2e-5), ('running_mean', None),
+        ('running_var', None), ('decay', 0.9))
+
     return BatchNormalizationFunction(eps, running_mean, running_var,
                                       decay)(x, gamma, beta)
 

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -297,6 +297,12 @@ def batch_normalization(x, gamma, beta, **kwargs):
     access the running_mean and/or running_var attributes. See the
     corresponding Link class for an example of how to do this.
 
+    .. warning::
+
+       ``train`` argument is not supported anymore since v2.
+       Instead, use ``chainer.using_config('train', train)``.
+       See :func:`chainer.using_config`.
+
     Args:
         x (Variable): Input variable.
         gamma (Variable): Scaling parameter of normalized data.

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -264,7 +264,7 @@ class BatchNormalizationFunction(function.Function):
 
 
 def batch_normalization(x, gamma, beta, **kwargs):
-    """batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None, running_var=None, decay=0.9):
+    """batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None, running_var=None, decay=0.9)
 
     Batch normalization function.
 
@@ -326,7 +326,7 @@ def batch_normalization(x, gamma, beta, **kwargs):
 
     .. seealso:: :class:`links.BatchNormalization`
 
-    """
+    """  # NOQA
 
     argument.check_unexpected_kwargs(
         kwargs, train='train argument is not supported anymore. '

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -10,6 +10,7 @@ from chainer import configuration
 from chainer import functions
 from chainer import link
 from chainer import links
+from chainer.utils import argument
 
 
 def _protobuf3():
@@ -157,13 +158,21 @@ class CaffeFunction(link.Chain):
                         'Skip the layer "%s", since CaffeFunction does not'
                         'support it' % layer.name)
 
-    def __call__(self, inputs, outputs, disable=()):
-        """Executes a sub-network of the network.
+    def __call__(self, inputs, outputs, disable=(), **kwargs):
+        """__call__(self, inputs, outputs, disable=())
+
+        Executes a sub-network of the network.
 
         This function acts as an interpreter of the network definition for
         Caffe. On execution, it interprets each layer one by one, and if the
         bottom blobs are already computed, then emulates the layer and stores
         output blobs as :class:`~chainer.Variable` objects.
+
+        .. warning::
+
+           ``train`` argument is not supported anymore since v2.
+           Instead, use ``chainer.using_config('train', train)``.
+           See :func:`chainer.using_config`.
 
         Args:
             inputs (dict): A dictionary whose key-value pairs indicate initial
@@ -179,6 +188,11 @@ class CaffeFunction(link.Chain):
                 corresponding to elements of the  `outputs` argument.
 
         """
+        argument.check_unexpected_kwargs(
+            kwargs, train='train argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
+
         variables = dict(inputs)
         for func_name, bottom, top in self.layers:
             if (func_name in disable or

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -191,7 +191,7 @@ class CaffeFunction(link.Chain):
         argument.check_unexpected_kwargs(
             kwargs, train='train argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         variables = dict(inputs)
         for func_name, bottom, top in self.layers:

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -53,7 +53,7 @@ class NStepLSTM(link.ChainList):
         argument.check_unexpected_kwargs(
             kwargs, use_cudnn='use_cudnn argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         weights = []
         for i in six.moves.range(n_layers):

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -99,7 +99,7 @@ class NStepLSTM(link.ChainList):
         argument.check_unexpected_kwargs(
             kwargs, train='train argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         assert isinstance(xs, (list, tuple))
         indices = argsort_list_descent(xs)

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -7,6 +7,7 @@ from chainer.functions.array import permutate
 from chainer.functions.array import transpose_sequence
 from chainer.functions.connection import n_step_lstm as rnn
 from chainer import link
+from chainer.utils import argument
 
 
 def argsort_list_descent(lst):
@@ -48,7 +49,12 @@ class NStepLSTM(link.ChainList):
 
     """
 
-    def __init__(self, n_layers, in_size, out_size, dropout):
+    def __init__(self, n_layers, in_size, out_size, dropout, **kwargs):
+        argument.check_unexpected_kwargs(
+            kwargs, use_cudnn='use_cudnn argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
+
         weights = []
         for i in six.moves.range(n_layers):
             weight = link.Link()
@@ -70,8 +76,16 @@ class NStepLSTM(link.ChainList):
         self.dropout = dropout
         self.out_size = out_size
 
-    def __call__(self, hx, cx, xs):
-        """Calculate all hidden states and cell states.
+    def __call__(self, hx, cx, xs, **kwargs):
+        """__call__(self, hx, cx, xs)
+
+        Calculate all hidden states and cell states.
+
+        .. warning::
+
+           ``train`` argument is not supported anymore since v2.
+           Instead, use ``chainer.using_config('train', train)``.
+           See :func:`chainer.using_config`.
 
         Args:
             hx (~chainer.Variable or None): Initial hidden states. If ``None``
@@ -82,6 +96,11 @@ class NStepLSTM(link.ChainList):
                 Each element ``xs[i]`` is a :class:`chainer.Variable` holding
                 a sequence.
         """
+        argument.check_unexpected_kwargs(
+            kwargs, train='train argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
+
         assert isinstance(xs, (list, tuple))
         indices = argsort_list_descent(xs)
 

--- a/chainer/links/connection/zoneoutlstm.py
+++ b/chainer/links/connection/zoneoutlstm.py
@@ -7,15 +7,20 @@ from chainer.functions.activation import tanh
 from chainer.functions.array import reshape
 from chainer.functions.array import split_axis
 from chainer.functions.noise import zoneout
-
 from chainer import link
 from chainer.links.connection import linear
+from chainer.utils import argument
 from chainer import variable
 
 
 class StatefulZoneoutLSTM(link.Chain):
 
-    def __init__(self, in_size, out_size, c_ratio=0.5, h_ratio=0.5):
+    def __init__(self, in_size, out_size, c_ratio=0.5, h_ratio=0.5, **kwargs):
+        argument.check_unexpected_kwargs(
+            kwargs, train='train argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
+
         super(StatefulZoneoutLSTM, self).__init__(
             upward=linear.Linear(in_size, 4 * out_size),
             lateral=linear.Linear(out_size, 4 * out_size, nobias=True),

--- a/chainer/links/connection/zoneoutlstm.py
+++ b/chainer/links/connection/zoneoutlstm.py
@@ -19,7 +19,7 @@ class StatefulZoneoutLSTM(link.Chain):
         argument.check_unexpected_kwargs(
             kwargs, train='train argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         super(StatefulZoneoutLSTM, self).__init__(
             upward=linear.Linear(in_size, 4 * out_size),

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -176,7 +176,7 @@ class ResNetLayers(link.Chain):
         argument.check_unexpected_kwargs(
             kwargs, test='test argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         h = x
         activations = {}

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -26,6 +26,7 @@ from chainer.links.connection.convolution_2d import Convolution2D
 from chainer.links.connection.linear import Linear
 from chainer.links.normalization.batch_normalization import BatchNormalization
 from chainer.serializers import npz
+from chainer.utils import argument
 from chainer.utils import imgproc
 from chainer.variable import Variable
 
@@ -150,8 +151,16 @@ class ResNetLayers(link.Chain):
                              ' or 152, but {} was given.'.format(n_layers))
         npz.save_npz(path_npz, chainermodel, compression=False)
 
-    def __call__(self, x, layers=['prob']):
-        """Computes all the feature maps specified by ``layers``.
+    def __call__(self, x, layers=['prob'], **kwargs):
+        """__call__(self, x, layers=['prob'])
+
+        Computes all the feature maps specified by ``layers``.
+
+        .. warning::
+
+           ``test`` argument is not supported anymore since v2.
+           Instead, use ``chainer.using_config('train', train)``.
+           See :func:`chainer.using_config`.
 
         Args:
             x (~chainer.Variable): Input variable.
@@ -163,6 +172,11 @@ class ResNetLayers(link.Chain):
             the corresponding feature map variable.
 
         """
+
+        argument.check_unexpected_kwargs(
+            kwargs, test='test argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
 
         h = x
         activations = {}
@@ -177,14 +191,24 @@ class ResNetLayers(link.Chain):
                 target_layers.remove(key)
         return activations
 
-    def extract(self, images, layers=['pool5'], size=(224, 224)):
-        """Extracts all the feature maps of given images.
+    def extract(self, images, layers=['pool5'], size=(224, 224), **kwargs):
+        """extract(self, images, layers=['pool5'], size=(224, 224))
+
+        Extracts all the feature maps of given images.
 
         The difference of directly executing ``__call__`` is that
         it directly accepts images as an input and automatically
         transforms them to a proper variable. That is,
         it is also interpreted as a shortcut method that implicitly calls
         ``prepare`` and ``__call__`` functions.
+
+        .. warning::
+
+           ``test`` and ``volatile`` arguments are not supported anymore since
+           v2.
+           Instead, use ``chainer.using_config('train', train)`` and
+           ``chainer.using_config('enable_backprop', not volatile)``.
+           See :func:`chainer.using_config`.
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
@@ -200,6 +224,13 @@ class ResNetLayers(link.Chain):
             the corresponding feature map variable.
 
         """
+
+        argument.check_unexpected_kwargs(
+            kwargs, test='test argument is not supported anymore. '
+            'Use chainer.using_config',
+            volatile='volatile argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
 
         x = concat_examples([prepare(img, size=size) for img in images])
         x = Variable(self.xp.asarray(x))

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -207,7 +207,8 @@ class ResNetLayers(link.Chain):
            ``test`` and ``volatile`` arguments are not supported anymore since
            v2.
            Instead, use ``chainer.using_config('train', train)`` and
-           ``chainer.using_config('enable_backprop', not volatile)``.
+           ``chainer.using_config('enable_backprop', not volatile)``
+           respectively.
            See :func:`chainer.using_config`.
 
         Args:

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -231,7 +231,7 @@ class ResNetLayers(link.Chain):
             'Use chainer.using_config',
             volatile='volatile argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         x = concat_examples([prepare(img, size=size) for img in images])
         x = Variable(self.xp.asarray(x))

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -235,7 +235,7 @@ class VGG16Layers(link.Chain):
             'Use chainer.using_config',
             volatile='volatile argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         x = concat_examples([prepare(img, size=size) for img in images])
         x = Variable(self.xp.asarray(x))

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -211,7 +211,8 @@ class VGG16Layers(link.Chain):
            ``test`` and ``volatile`` arguments are not supported anymore since
            v2.
            Instead, use ``chainer.using_config('train', train)`` and
-           ``chainer.using_config('enable_backprop', not volatile)``.
+           ``chainer.using_config('enable_backprop', not volatile)``
+           respectively.
            See :func:`chainer.using_config`.
 
         Args:

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -154,8 +154,16 @@ class VGG16Layers(link.Chain):
         caffemodel = CaffeFunction(path_caffemodel)
         npz.save_npz(path_npz, caffemodel, compression=False)
 
-    def __call__(self, x, layers=['prob']):
-        """Computes all the feature maps specified by ``layers``.
+    def __call__(self, x, layers=['prob'], **kwargs):
+        """__call__(self, x, layers=['prob'])
+
+        Computes all the feature maps specified by ``layers``.
+
+        .. warning::
+
+           ``test`` argument is not supported anymore since v2.
+           Instead, use ``chainer.using_config('train', train)``.
+           See :func:`chainer.using_config`.
 
         Args:
             x (~chainer.Variable): Input variable.
@@ -167,6 +175,11 @@ class VGG16Layers(link.Chain):
             the corresponding feature map variable.
 
         """
+
+        argument.check_unexpected_kwargs(
+            kwargs, test='test argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
 
         h = x
         activations = {}
@@ -181,14 +194,24 @@ class VGG16Layers(link.Chain):
                 target_layers.remove(key)
         return activations
 
-    def extract(self, images, layers=['fc7'], size=(224, 224)):
-        """Extracts all the feature maps of given images.
+    def extract(self, images, layers=['fc7'], size=(224, 224), **kwargs):
+        """extract(self, images, layers=['fc7'], size=(224, 224))
+
+        Extracts all the feature maps of given images.
 
         The difference of directly executing ``__call__`` is that
         it directly accepts images as an input and automatically
         transforms them to a proper variable. That is,
         it is also interpreted as a shortcut method that implicitly calls
         ``prepare`` and ``__call__`` functions.
+
+        .. warning::
+
+           ``test`` and ``volatile`` arguments are not supported anymore since
+           v2.
+           Instead, use ``chainer.using_config('train', train)`` and
+           ``chainer.using_config('enable_backprop', not volatile)``.
+           See :func:`chainer.using_config`.
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
@@ -204,6 +227,13 @@ class VGG16Layers(link.Chain):
             the corresponding feature map variable.
 
         """
+
+        argument.check_unexpected_kwargs(
+            kwargs, test='test argument is not supported anymore. '
+            'Use chainer.using_config',
+            volatile='volatile argument is not supported anymore. '
+            'Use chainer.using_config')
+        argument.parse_kwargs(kwargs)
 
         x = concat_examples([prepare(img, size=size) for img in images])
         x = Variable(self.xp.asarray(x))

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -25,6 +25,7 @@ from chainer import link
 from chainer.links.connection.convolution_2d import Convolution2D
 from chainer.links.connection.linear import Linear
 from chainer.serializers import npz
+from chainer.utils import argument
 from chainer.utils import imgproc
 from chainer.variable import Variable
 
@@ -179,7 +180,7 @@ class VGG16Layers(link.Chain):
         argument.check_unexpected_kwargs(
             kwargs, test='test argument is not supported anymore. '
             'Use chainer.using_config')
-        argument.parse_kwargs(kwargs)
+        argument.assert_kwargs_empty(kwargs)
 
         h = x
         activations = {}

--- a/chainer/utils/argument.py
+++ b/chainer/utils/argument.py
@@ -11,3 +11,7 @@ def parse_kwargs(kwargs, *name_and_values):
         args = ', '.join(["'%s'" % arg for arg in kwargs.keys()])
         raise TypeError('got unexpected keyword argument(s) %s' % args)
     return tuple(values)
+
+
+def assert_kwargs_empty(kwargs):
+    return parse_kwargs(kwargs)

--- a/chainer/utils/argument.py
+++ b/chainer/utils/argument.py
@@ -14,4 +14,5 @@ def parse_kwargs(kwargs, *name_and_values):
 
 
 def assert_kwargs_empty(kwargs):
-    return parse_kwargs(kwargs)
+    # It only checks if kwargs is empty.
+    parse_kwargs(kwargs)


### PR DESCRIPTION
I applied #2556 to all functions which had `train` or `test` arguments.