### PR TITLE
Remove outdated comment from example/word2vec/train_word2vec.py

### DIFF
--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -2,7 +2,6 @@
 """Sample script of word embedding model.
 
 This code implements skip-gram model and continuous-bow model.
-Use ../ptb/download.py to download 'ptb.train.txt'.
 """
 import argparse
 import collections


### PR DESCRIPTION
ref: https://github.com/pfnet/chainer/issues/2636

this comment is already outdated.

ptb/download.py existed in v1.10.0 
https://github.com/pfnet/chainer/blob/v1.10.0/examples/ptb/download.py

but outdated in v1.11.0
https://github.com/pfnet/chainer/tree/v1.11.0/examples/ptb/download.py


