### PR TITLE
Remove reduce option from F.gaussian_kl_divergence

### DIFF
--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -22,8 +22,8 @@ def gaussian_kl_divergence(mean, ln_var, reduce='sum'):
     and :math:`I` is an identity matrix.
 
     The output is a varialbe whose value depends on the value of
-    the option `reduce`. If it is `'no'`, it holds the elementwise
-    loss values. If it is `'sum'`, loss values are summed up.
+    the option ``reduce``. If it is ``'no'``, it holds the elementwise
+    loss values. If it is ``'sum'``, loss values are summed up.
 
     Args:
         mean (~chainer.Variable): A variable representing mean of given
@@ -31,14 +31,15 @@ def gaussian_kl_divergence(mean, ln_var, reduce='sum'):
         ln_var (~chainer.Variable): A variable representing logarithm of
             variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
         recude (str): Reduction option. Its value must be either
-            `'sum'` or `'no'`. Otherwise, `ValueError` is raised.
+            ``'sum'`` or ``'no'``. Otherwise, :class:`ValueError` is raised.
 
     Returns:
-        ~chainer.Variable: A variable representing KL-divergence between
+        ~chainer.Variable:
+            A variable representing KL-divergence between
             given gaussian distribution and the standard gaussian.
-            If `reduce` is `'no'`, the output varialbe holds array
+            If ``reduce`` is ``'no'``, the output varialbe holds array
             whose shape is same as one of (hence both of) input variables.
-            If it is `'sum'`, the output variable holds a scalar value.
+            If it is ``'sum'``, the output variable holds a scalar value.
 
     """
     assert isinstance(mean, variable.Variable)

--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -6,13 +6,13 @@ from chainer.functions.math import sum
 from chainer import variable
 
 
-def gaussian_kl_divergence(mean, ln_var):
+def gaussian_kl_divergence(mean, ln_var, reduce='sum'):
     """Computes the KL-divergence of Gaussian variables from the standard one.
 
     Given two variable ``mean`` representing :math:`\\mu` and ``ln_var``
-    representing :math:`\\log(\\sigma^2)`, this function returns a variable
-    representing the KL-divergence between the given multi-dimensional Gaussian
-    :math:`N(\\mu, S)` and the standard Gaussian :math:`N(0, I)`
+    representing :math:`\\log(\\sigma^2)`, this function calculates
+    the KL-divergence in elementwise manner between the given multi-dimensional
+    Gaussian :math:`N(\\mu, S)` and the standard Gaussian :math:`N(0, I)`
 
     .. math::
 
@@ -21,23 +21,41 @@ def gaussian_kl_divergence(mean, ln_var):
     where :math:`S` is a diagonal matrix such that :math:`S_{ii} = \\sigma_i^2`
     and :math:`I` is an identity matrix.
 
+    The output is a varialbe whose value depends on the value of
+    the option `reduce`. If it is `'no'`, it holds the elementwise
+    loss values. If it is `'sum'`, loss values are summed up.
+
     Args:
         mean (~chainer.Variable): A variable representing mean of given
             gaussian distribution, :math:`\\mu`.
         ln_var (~chainer.Variable): A variable representing logarithm of
             variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
+        recude (str): Reduction option. Its value must be either
+            `'sum'` or `'no'`. Otherwise, `ValueError` is raised.
 
     Returns:
         ~chainer.Variable: A variable representing KL-divergence between
             given gaussian distribution and the standard gaussian.
+            If `reduce` is `'no'`, the output varialbe holds array
+            whose shape is same as one of (hence both of) input variables.
+            If it is `'sum'`, the output variable holds a scalar value.
 
     """
     assert isinstance(mean, variable.Variable)
     assert isinstance(ln_var, variable.Variable)
 
-    J = mean.size
+    if reduce not in ('sum', 'no'):
+        raise ValueError(
+            "only 'sum' and 'no' are valid for 'reduce', but '%s' is "
+            'given' % reduce)
+
     var = exponential.exp(ln_var)
-    return (sum.sum(mean * mean) + sum.sum(var) - sum.sum(ln_var) - J) * 0.5
+    mean_square = mean * mean
+    loss = (mean_square + var - ln_var - 1) * 0.5
+    if reduce == 'sum':
+        return sum.sum(loss)
+    else:
+        return loss
 
 
 def bernoulli_nll(x, y):

--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -6,7 +6,7 @@ from chainer.functions.math import sum
 from chainer import variable
 
 
-def gaussian_kl_divergence(mean, ln_var, reduce='sum'):
+def gaussian_kl_divergence(mean, ln_var):
     """Computes the KL-divergence of Gaussian variables from the standard one.
 
     Given two variable ``mean`` representing :math:`\\mu` and ``ln_var``
@@ -21,42 +21,26 @@ def gaussian_kl_divergence(mean, ln_var, reduce='sum'):
     where :math:`S` is a diagonal matrix such that :math:`S_{ii} = \\sigma_i^2`
     and :math:`I` is an identity matrix.
 
-    The output is a varialbe whose value depends on the value of
-    the option ``reduce``. If it is ``'no'``, it holds the elementwise
-    loss values. If it is ``'sum'``, loss values are summed up.
-
     Args:
         mean (~chainer.Variable): A variable representing mean of given
             gaussian distribution, :math:`\\mu`.
         ln_var (~chainer.Variable): A variable representing logarithm of
             variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
-        recude (str): Reduction option. Its value must be either
-            ``'sum'`` or ``'no'``. Otherwise, :class:`ValueError` is raised.
 
     Returns:
         ~chainer.Variable:
             A variable representing KL-divergence between
             given gaussian distribution and the standard gaussian.
-            If ``reduce`` is ``'no'``, the output varialbe holds array
-            whose shape is same as one of (hence both of) input variables.
-            If it is ``'sum'``, the output variable holds a scalar value.
+            It holds an array whose shape is same as one of
+            (hence both of) input variables.
 
     """
     assert isinstance(mean, variable.Variable)
     assert isinstance(ln_var, variable.Variable)
 
-    if reduce not in ('sum', 'no'):
-        raise ValueError(
-            "only 'sum' and 'no' are valid for 'reduce', but '%s' is "
-            'given' % reduce)
-
     var = exponential.exp(ln_var)
     mean_square = mean * mean
-    loss = (mean_square + var - ln_var - 1) * 0.5
-    if reduce == 'sum':
-        return sum.sum(loss)
-    else:
-        return loss
+    return (mean_square + var - ln_var - 1) * 0.5
 
 
 def bernoulli_nll(x, y):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -10,6 +10,10 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(
+    {'reduce': 'no'},
+    {'reduce': 'sum'}
+)
 class TestGaussianKLDivergence(unittest.TestCase):
 
     def setUp(self):
@@ -18,15 +22,19 @@ class TestGaussianKLDivergence(unittest.TestCase):
 
         # Refer to Appendix B in the original paper
         # Auto-Encoding Variational Bayes (https://arxiv.org/abs/1312.6114)
-        J = self.mean.size
-        self.expect = -(J + numpy.sum(self.ln_var) -
-                        numpy.sum(self.mean * self.mean) -
-                        numpy.sum(numpy.exp(self.ln_var))) * 0.5
+        loss = -(1 + self.ln_var -
+                 self.mean * self.mean -
+                 numpy.exp(self.ln_var)) * 0.5
+        if self.reduce == 'sum':
+            self.expect = numpy.sum(loss)
+        elif self.reduce == 'no':
+            self.expect = loss
 
     def check_gaussian_kl_divergence(self, mean, ln_var):
         m = chainer.Variable(mean)
         v = chainer.Variable(ln_var)
-        actual = cuda.to_cpu(vae.gaussian_kl_divergence(m, v).data)
+        actual = vae.gaussian_kl_divergence(m, v, self.reduce)
+        actual = cuda.to_cpu(actual.data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)
@@ -38,6 +46,26 @@ class TestGaussianKLDivergence(unittest.TestCase):
     def test_gaussian_kl_divergence_gpu(self):
         self.check_gaussian_kl_divergence(cuda.to_gpu(self.mean),
                                           cuda.to_gpu(self.ln_var))
+
+
+class TestGaussianNLLInvalidReductionOption(unittest.TestCase):
+
+    def setUp(self):
+        self.mean = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
+        self.ln_var = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
+
+    def check_invalid_option(self, xp):
+        m = chainer.Variable(xp.asarray(self.mean))
+        v = chainer.Variable(xp.asarray(self.ln_var))
+        with self.assertRaises(ValueError):
+            vae.gaussian_kl_divergence(m, v, 'invalid_option')
+
+    def test_invalid_option_cpu(self):
+        self.check_invalid_option(numpy)
+
+    @attr.gpu
+    def test_invalid_option_gpu(self):
+        self.check_invalid_option(cuda.cupy)
 
 
 class TestBernoulliNLL(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -4,16 +4,13 @@ import numpy
 
 import chainer
 from chainer import cuda
+from chainer import functions as F
 from chainer.functions import vae
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
 
 
-@testing.parameterize(
-    {'reduce': 'no'},
-    {'reduce': 'sum'}
-)
 class TestGaussianKLDivergence(unittest.TestCase):
 
     def setUp(self):
@@ -22,18 +19,14 @@ class TestGaussianKLDivergence(unittest.TestCase):
 
         # Refer to Appendix B in the original paper
         # Auto-Encoding Variational Bayes (https://arxiv.org/abs/1312.6114)
-        loss = -(1 + self.ln_var -
-                 self.mean * self.mean -
-                 numpy.exp(self.ln_var)) * 0.5
-        if self.reduce == 'sum':
-            self.expect = numpy.sum(loss)
-        elif self.reduce == 'no':
-            self.expect = loss
+        self.expect = -(1 + self.ln_var -
+                        self.mean * self.mean -
+                        numpy.exp(self.ln_var)) * 0.5
 
     def check_gaussian_kl_divergence(self, mean, ln_var):
         m = chainer.Variable(mean)
         v = chainer.Variable(ln_var)
-        actual = cuda.to_cpu(F.gaussian_kl_divergence(m, v, self.reduce).data)
+        actual = cuda.to_cpu(F.gaussian_kl_divergence(m, v).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)
@@ -45,26 +38,6 @@ class TestGaussianKLDivergence(unittest.TestCase):
     def test_gaussian_kl_divergence_gpu(self):
         self.check_gaussian_kl_divergence(cuda.to_gpu(self.mean),
                                           cuda.to_gpu(self.ln_var))
-
-
-class TestGaussianNLLInvalidReductionOption(unittest.TestCase):
-
-    def setUp(self):
-        self.mean = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
-        self.ln_var = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
-
-    def check_invalid_option(self, xp):
-        m = chainer.Variable(xp.asarray(self.mean))
-        v = chainer.Variable(xp.asarray(self.ln_var))
-        with self.assertRaises(ValueError):
-            F.gaussian_kl_divergence(m, v, 'invalid_option')
-
-    def test_invalid_option_cpu(self):
-        self.check_invalid_option(numpy)
-
-    @attr.gpu
-    def test_invalid_option_gpu(self):
-        self.check_invalid_option(cuda.cupy)
 
 
 class TestBernoulliNLL(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -58,7 +58,7 @@ class TestGaussianNLLInvalidReductionOption(unittest.TestCase):
         m = chainer.Variable(xp.asarray(self.mean))
         v = chainer.Variable(xp.asarray(self.ln_var))
         with self.assertRaises(ValueError):
-            vae.gaussian_kl_divergence(m, v, 'invalid_option')
+            F.gaussian_kl_divergence(m, v, 'invalid_option')
 
     def test_invalid_option_cpu(self):
         self.check_invalid_option(numpy)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -33,8 +33,7 @@ class TestGaussianKLDivergence(unittest.TestCase):
     def check_gaussian_kl_divergence(self, mean, ln_var):
         m = chainer.Variable(mean)
         v = chainer.Variable(ln_var)
-        actual = vae.gaussian_kl_divergence(m, v, self.reduce)
-        actual = cuda.to_cpu(actual.data)
+        actual = cuda.to_cpu(F.gaussian_kl_divergence(m, v, self.reduce).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)


### PR DESCRIPTION
This PR removed `reduce` option from `F.gaussian_kl_divergence`.
Related to #2558 