### PR TITLE
Remove reduce option from F.bernoulli_nll

### DIFF
--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -40,7 +40,7 @@ def gaussian_kl_divergence(mean, ln_var):
     return (sum.sum(mean * mean) + sum.sum(var) - sum.sum(ln_var) - J) * 0.5
 
 
-def bernoulli_nll(x, y):
+def bernoulli_nll(x, y, reduce='sum'):
     """Computes the negative log-likelihood of a Bernoulli distribution.
 
     This function calculates the negative log-likelihood of a Bernoulli
@@ -53,6 +53,11 @@ def bernoulli_nll(x, y):
     where :math:`p = \\sigma(y)`, :math:`\\sigma(\\cdot)` is a sigmoid
     function, and :math:`B(x; p)` is a Bernoulli distribution.
 
+
+    The output is a varialbe whose value depends on the value of
+    the option `reduce`. If it is `'no'`, it holds the elementwise
+    loss values. If it is `'sum'`, loss values are summed up.
+
     .. note::
 
        As this function uses a sigmoid function, you can pass a result of
@@ -63,15 +68,29 @@ def bernoulli_nll(x, y):
         x (~chainer.Variable): Input variable.
         y (~chainer.Variable): A variable representing the parameter of
             Bernoulli distribution.
+        recude (str): Reduction option. Its value must be either
+            `'sum'` or `'no'`. Otherwise, `ValueError` is raised.
 
     Returns:
         ~chainer.Variable: A variable representing negative log-likelihood.
+            If `reduce` is `'no'`, the output varialbe holds array
+            whose shape is same as one of (hence both of) input variables.
+            If it is `'sum'`, the output variable holds a scalar value.
 
     """
     assert isinstance(x, variable.Variable)
     assert isinstance(y, variable.Variable)
 
-    return sum.sum(softplus.softplus(y)) - sum.sum(x * y)
+    if reduce not in ('sum', 'no'):
+        raise ValueError(
+            "only 'sum' and 'no' are valid for 'reduce', but '%s' is "
+            'given' % reduce)
+
+    loss = softplus.softplus(y) - x * y
+    if reduce == 'sum':
+        return sum.sum(loss)
+    else:
+        return loss
 
 
 def gaussian_nll(x, mean, ln_var):

--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -55,8 +55,8 @@ def bernoulli_nll(x, y, reduce='sum'):
 
 
     The output is a varialbe whose value depends on the value of
-    the option `reduce`. If it is `'no'`, it holds the elementwise
-    loss values. If it is `'sum'`, loss values are summed up.
+    the option ``reduce``. If it is ``'no'``, it holds the elementwise
+    loss values. If it is ``'sum'``, loss values are summed up.
 
     .. note::
 
@@ -69,13 +69,14 @@ def bernoulli_nll(x, y, reduce='sum'):
         y (~chainer.Variable): A variable representing the parameter of
             Bernoulli distribution.
         recude (str): Reduction option. Its value must be either
-            `'sum'` or `'no'`. Otherwise, `ValueError` is raised.
+            ``'sum'`` or ``'no'``. Otherwise, :class:`ValueError` is raised.
 
     Returns:
-        ~chainer.Variable: A variable representing negative log-likelihood.
-            If `reduce` is `'no'`, the output varialbe holds array
+        ~chainer.Variable:
+            A variable representing the negative log-likelihood.
+            If ``reduce`` is ``'no'``, the output varialbe holds array
             whose shape is same as one of (hence both of) input variables.
-            If it is `'sum'`, the output variable holds a scalar value.
+            If it is ``'sum'``, the output variable holds a scalar value.
 
     """
     assert isinstance(x, variable.Variable)

--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -40,7 +40,7 @@ def gaussian_kl_divergence(mean, ln_var):
     return (sum.sum(mean * mean) + sum.sum(var) - sum.sum(ln_var) - J) * 0.5
 
 
-def bernoulli_nll(x, y, reduce='sum'):
+def bernoulli_nll(x, y):
     """Computes the negative log-likelihood of a Bernoulli distribution.
 
     This function calculates the negative log-likelihood of a Bernoulli
@@ -53,11 +53,6 @@ def bernoulli_nll(x, y, reduce='sum'):
     where :math:`p = \\sigma(y)`, :math:`\\sigma(\\cdot)` is a sigmoid
     function, and :math:`B(x; p)` is a Bernoulli distribution.
 
-
-    The output is a varialbe whose value depends on the value of
-    the option ``reduce``. If it is ``'no'``, it holds the elementwise
-    loss values. If it is ``'sum'``, loss values are summed up.
-
     .. note::
 
        As this function uses a sigmoid function, you can pass a result of
@@ -68,30 +63,18 @@ def bernoulli_nll(x, y, reduce='sum'):
         x (~chainer.Variable): Input variable.
         y (~chainer.Variable): A variable representing the parameter of
             Bernoulli distribution.
-        recude (str): Reduction option. Its value must be either
-            ``'sum'`` or ``'no'``. Otherwise, :class:`ValueError` is raised.
 
     Returns:
         ~chainer.Variable:
             A variable representing the negative log-likelihood.
-            If ``reduce`` is ``'no'``, the output varialbe holds array
-            whose shape is same as one of (hence both of) input variables.
-            If it is ``'sum'``, the output variable holds a scalar value.
+            It holds an array whose shape is same as one of
+            (hence both of) input variables.
 
     """
     assert isinstance(x, variable.Variable)
     assert isinstance(y, variable.Variable)
 
-    if reduce not in ('sum', 'no'):
-        raise ValueError(
-            "only 'sum' and 'no' are valid for 'reduce', but '%s' is "
-            'given' % reduce)
-
-    loss = softplus.softplus(y) - x * y
-    if reduce == 'sum':
-        return sum.sum(loss)
-    else:
-        return loss
+    return softplus.softplus(y) - x * y
 
 
 def gaussian_nll(x, mean, ln_var):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -85,7 +85,7 @@ class TestBernoulliNLLInvalidReductionOption(unittest.TestCase):
         x = chainer.Variable(xp.asarray(self.x))
         y = chainer.Variable(xp.asarray(self.y))
         with self.assertRaises(ValueError):
-            vae.bernoulli_nll(x, y, 'invalid_option')
+            F.bernoulli_nll(x, y, 'invalid_option')
 
     def test_invalid_option_cpu(self):
         self.check_invalid_option(numpy)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -40,6 +40,10 @@ class TestGaussianKLDivergence(unittest.TestCase):
                                           cuda.to_gpu(self.ln_var))
 
 
+@testing.parameterize(
+    {'reduce': 'no'},
+    {'reduce': 'sum'}
+)
 class TestBernoulliNLL(unittest.TestCase):
 
     def setUp(self):
@@ -49,13 +53,15 @@ class TestBernoulliNLL(unittest.TestCase):
         # Refer to Appendix C.1 in the original paper
         # Auto-Encoding Variational Bayes (https://arxiv.org/abs/1312.6114)
         p = 1 / (1 + numpy.exp(-self.y))
-        self.expect = - (numpy.sum(self.x * numpy.log(p)) +
-                         numpy.sum((1 - self.x) * numpy.log(1 - p)))
+        self.expect = -(self.x * numpy.log(p) +
+                        (1 - self.x) * numpy.log(1 - p))
+        if self.reduce == 'sum':
+            self.expect = numpy.sum(self.expect)
 
     def check_bernoulli_nll(self, x_data, y_data):
         x = chainer.Variable(x_data)
         y = chainer.Variable(y_data)
-        actual = cuda.to_cpu(vae.bernoulli_nll(x, y).data)
+        actual = cuda.to_cpu(vae.bernoulli_nll(x, y, self.reduce).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)
@@ -67,6 +73,26 @@ class TestBernoulliNLL(unittest.TestCase):
     def test_bernoulli_nll_gpu(self):
         self.check_bernoulli_nll(cuda.to_gpu(self.x),
                                  cuda.to_gpu(self.y))
+
+
+class TestBernoulliNLLInvalidReductionOption(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
+        self.y = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
+
+    def check_invalid_option(self, xp):
+        x = chainer.Variable(xp.asarray(self.x))
+        y = chainer.Variable(xp.asarray(self.y))
+        with self.assertRaises(ValueError):
+            vae.bernoulli_nll(x, y, 'invalid_option')
+
+    def test_invalid_option_cpu(self):
+        self.check_invalid_option(numpy)
+
+    @attr.gpu
+    def test_invalid_option_gpu(self):
+        self.check_invalid_option(cuda.cupy)
 
 
 class TestGaussianNLL(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_vae.py
@@ -61,7 +61,7 @@ class TestBernoulliNLL(unittest.TestCase):
     def check_bernoulli_nll(self, x_data, y_data):
         x = chainer.Variable(x_data)
         y = chainer.Variable(y_data)
-        actual = cuda.to_cpu(vae.bernoulli_nll(x, y, self.reduce).data)
+        actual = cuda.to_cpu(F.bernoulli_nll(x, y, self.reduce).data)
         testing.assert_allclose(self.expect, actual)
 
     @condition.retry(3)


### PR DESCRIPTION
This PR removed reduce option from `F.bernoulli_nll`.
Related to #2558