### PR TITLE
Chainer should depend on protobuf >= 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     'filelock',
     'nose',
     'numpy>=1.9.0',
-    'protobuf',
+    'protobuf>=2.6.0',
     'six>=1.9.0',
 ]
 


### PR DESCRIPTION
apt `python-protobuf` is 2.5.0 on ubuntu trusty, and I found someone who encountered this problem.

```
% pip show protobuf
Name: protobuf
Version: 2.5.0
Summary: Protocol Buffers
Home-page: http://code.google.com/p/protobuf/
Author: protobuf@googlegroups.com
Author-email: protobuf@googlegroups.com
License: New BSD License
Location: /usr/lib/python2.7/dist-packages
Requires:

% python -c 'import chainer.links.caffe.protobuf2.caffe_pb2'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "chainer/links/caffe/__init__.py", line 1, in <module>
    from chainer.links.caffe import caffe_function
  File "chainer/links/caffe/caffe_function.py", line 37, in <module>
    from chainer.links.caffe.protobuf2 import caffe_pb2 as caffe_pb
  File "chainer/links/caffe/protobuf2/caffe_pb2.py", line 10, in <module>
    from google.protobuf import symbol_database as _symbol_database
ImportError: cannot import name symbol_database

% sudo pip install 'protobuf==2.6.0'
The directory '/home/wkentaro/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/home/wkentaro/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting protobuf==2.6.0
/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#snimissingwarning.
  SNIMissingWarning
/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
  Downloading protobuf-2.6.0.tar.gz (187kB)
    100% |████████████████████████████████| 194kB 3.4MB/s
Requirement already satisfied: setuptools in /usr/local/lib/python2.7/dist-packages (from protobuf==2.6.0)
Requirement already satisfied: appdirs>=1.4.0 in /usr/local/lib/python2.7/dist-packages (from setuptools->protobuf==2.6.0)
Requirement already satisfied: packaging>=16.8 in /usr/local/lib/python2.7/dist-packages (from setuptools->protobuf==2.6.0)
Requirement already satisfied: six>=1.6.0 in /usr/local/lib/python2.7/dist-packages (from setuptools->protobuf==2.6.0)
Requirement already satisfied: pyparsing in /usr/local/lib/python2.7/dist-packages (from packaging>=16.8->setuptools->protobuf==2.6.0)
Installing collected packages: protobuf
  Found existing installation: protobuf 2.5.0
    Uninstalling protobuf-2.5.0:
      Successfully uninstalled protobuf-2.5.0
  Running setup.py install for protobuf ... done
Successfully installed protobuf-2.6.0

% pip show protobuf
Name: protobuf
Version: 2.6.0
Summary: Protocol Buffers
Home-page: http://code.google.com/p/protobuf/
Author: protobuf@googlegroups.com
Author-email: protobuf@googlegroups.com
License: New BSD License
Location: /usr/local/lib/python2.7/dist-packages
Requires: setuptools
wkentaro at hoop in /tmp/chainer tm 16:24 on use_protobuf_ge_2.6.0
% python -c 'import chainer.links.caffe.protobuf2.caffe_pb2'
```