### PR TITLE
Make b c-contiguous in backward for deconvolution

### DIFF
--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -248,6 +248,8 @@ class Deconvolution2DFunction(function.Function):
             x = cuda.cupy.ascontiguousarray(x)
             W = cuda.cupy.ascontiguousarray(W)
             gy = cuda.cupy.ascontiguousarray(gy)
+            if b is not None:
+                b = cuda.cupy.ascontiguousarray(b)
 
             handle = cudnn.get_handle()
             gy_desc = cudnn.create_tensor_descriptor(gy)

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -228,6 +228,8 @@ class DeconvolutionND(function.Function):
         x = cuda.cupy.ascontiguousarray(x)
         W = cuda.cupy.ascontiguousarray(W)
         gy = cuda.cupy.ascontiguousarray(gy)
+        if b is not None:
+            b = cuda.cupy.ascontiguousarray(b)
 
         # Make empty arrays for results.
         gx = cuda.cupy.empty_like(x)


### PR DESCRIPTION
Currently `b` is not converted into c-contiguous in the `backward` functions of deconvolution (although it is made c-contiguous in the `forward` functions), because `b` is used as `gb = cuda.cupy.empty_like(b)` and `cuda.cupy.empty_like` always returns a c-contiguous array.

However, this behavior of `cuda.cupy.empty_like` is implementation specific that is different from how `numpy.empty_like` behaves. For a fortran array `x`, `numpy.empty_like(x)` returns a fortran array if the `order` argument is not given, as documented in https://docs.scipy.org/doc/numpy/reference/generated/numpy.empty_like.html:

> numpy.empty_like(a, dtype=None, order='K', subok=True)
> ...
> order : {‘C’, ‘F’, ‘A’, or ‘K’}, optional
> Overrides the memory layout of the result. ‘C’ means C-order, ‘F’ means F-order, ‘A’ means ‘F’ if a is Fortran contiguous, ‘C’ otherwise. ‘K’ means match the layout of a as closely as possible.

Given this, I believe converting `b` into c-contiguous here is a good thing to make the code more robust, especially against future extensions of cupy.

