### PR TITLE
Check input device in Copy.backward

### DIFF
--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -17,7 +17,7 @@ class Copy(function.Function):
 
     def forward_cpu(self, x):
         self.retain_inputs(())
-        self._in_device = cuda.get_device(x[0])
+        self._in_device = cuda.get_device_from_array(x[0])
         if self.out_device == -1:
             return x[0].copy(),
         else:
@@ -25,7 +25,7 @@ class Copy(function.Function):
 
     def forward_gpu(self, x):
         self.retain_inputs(())
-        self._in_device = cuda.get_device(x[0])
+        self._in_device = cuda.get_device_from_array(x[0])
         if self.out_device == -1:
             return cuda.to_cpu(x[0]),
         else:

--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -17,6 +17,7 @@ class Copy(function.Function):
 
     def forward_cpu(self, x):
         self.retain_inputs(())
+        self._in_device = cuda.get_device(x[0])
         if self.out_device == -1:
             return x[0].copy(),
         else:
@@ -33,7 +34,7 @@ class Copy(function.Function):
     def backward(self, inputs, grad_outputs):
         # In this function, `grad_outputs` contains cuda arrays even when
         # `inputs` only contains numpy arrays.
-        if isinstance(inputs[0], cuda.ndarray):
+        if self._in_device.id != -1:
             return self.backward_gpu(inputs, grad_outputs)
         else:
             return self.backward_cpu(inputs, grad_outputs)

--- a/tests/chainer_tests/functions_tests/array_tests/test_copy.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_copy.py
@@ -46,7 +46,7 @@ class Copy(unittest.TestCase):
         y.backward()
 
         x_grad = x.grad
-        self.assertEqual(cuda.get_device(x_grad).id, src_id)
+        self.assertEqual(cuda.get_device_from_array(x_grad).id, src_id)
         numpy.testing.assert_array_equal(
             cuda.to_cpu(x_grad), self.gy)
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_copy.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_copy.py
@@ -46,6 +46,7 @@ class Copy(unittest.TestCase):
         y.backward()
 
         x_grad = x.grad
+        self.assertEqual(cuda.get_device(x_grad).id, src_id)
         numpy.testing.assert_array_equal(
             cuda.to_cpu(x_grad), self.gy)
 


### PR DESCRIPTION
`Copy.backward` needs to check type of input array.