### PR TITLE
Add reduce option to triplet loss

### DIFF
--- a/chainer/functions/loss/triplet.py
+++ b/chainer/functions/loss/triplet.py
@@ -9,10 +9,16 @@ class Triplet(function.Function):
 
     """Triplet loss function."""
 
-    def __init__(self, margin):
+    def __init__(self, margin, reduce='mean'):
         if margin <= 0:
             raise ValueError('margin should be positive value.')
         self.margin = margin
+
+        if reduce not in ('mean', 'no'):
+            raise ValueError(
+                "only 'mean' and 'no' are valid for 'reduce', but '%s' is "
+                'given' % reduce)
+        self.reduce = reduce
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 3)
@@ -30,14 +36,16 @@ class Triplet(function.Function):
         xp = cuda.get_array_module(*inputs)
 
         anchor, positive, negative = inputs
-        N = anchor.shape[0]
 
         dist = xp.sum(
             (anchor - positive) ** 2 - (anchor - negative) ** 2,
             axis=1) + self.margin
         self.dist_hinge = xp.maximum(dist, 0)
-        loss = xp.sum(self.dist_hinge) / N
-
+        if self.reduce == 'mean':
+            N = anchor.shape[0]
+            loss = xp.sum(self.dist_hinge) / N
+        else:
+            loss = self.dist_hinge
         return xp.array(loss, dtype=numpy.float32),
 
     def backward(self, inputs, gy):
@@ -50,7 +58,12 @@ class Triplet(function.Function):
         tmp = xp.repeat(self.dist_hinge[:, None], x_dim, axis=1)
         mask = xp.array(tmp > 0, dtype=numpy.float32)
 
-        tmp = 2 * gy[0] * mask / N
+        if self.reduce == 'mean':
+            g = gy[0] / N
+        else:
+            g = gy[0][:, None]
+
+        tmp = 2 * g * mask
         gx0 = (tmp * (negative - positive)).astype(numpy.float32)
         gx1 = (tmp * (positive - anchor)).astype(numpy.float32)
         gx2 = (tmp * (anchor - negative)).astype(numpy.float32)
@@ -58,7 +71,7 @@ class Triplet(function.Function):
         return gx0, gx1, gx2
 
 
-def triplet(anchor, positive, negative, margin=0.2):
+def triplet(anchor, positive, negative, margin=0.2, reduce='mean'):
     """Computes triplet loss.
 
     It takes a triplet of variables as inputs, :math:`a`, :math:`p` and
@@ -74,6 +87,11 @@ def triplet(anchor, positive, negative, margin=0.2):
 
     where :math:`d(x_i, y_i) = \\| {\\bf x}_i - {\\bf y}_i \\|_2^2`.
 
+    The output is a variable whose value depends on the value of
+    the option ``reduce``. If it is ``'no'``, it holds the elementwise
+    loss values. If it is ``'mean'``, this function takes a mean of
+    loss values.
+
     Args:
         anchor (~chainer.Variable): The anchor example variable. The shape
             should be :math:`(N, K)`, where :math:`N` denotes the minibatch
@@ -84,14 +102,20 @@ def triplet(anchor, positive, negative, margin=0.2):
             should be the same as anchor.
         margin (float): A parameter for triplet loss. It should be a positive
             value.
+        recude (str): Reduction option. Its value must be either
+            ``'mean'`` or ``'no'``. Otherwise, :class:`ValueError` is raised.
 
     Returns:
-        ~chainer.Variable: A variable holding a scalar that is the loss value
+        ~chainer.Variable:
+            A variable holding a scalar that is the loss value
             calculated by the above equation.
+            If ``reduce`` is ``'no'``, the output variable holds array
+            whose shape is same as one of (hence both of) input variables.
+            If it is ``'mean'``, the output variable holds a scalar value.
 
     .. note::
         This cost can be used to train triplet networks. See `Learning \
         Fine-grained Image Similarity with Deep Ranking \
         <https://arxiv.org/abs/1404.4661>`_ for details.
     """
-    return Triplet(margin)(anchor, positive, negative)
+    return Triplet(margin, reduce)(anchor, positive, negative)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
@@ -14,7 +14,8 @@ from chainer.testing import condition
 
 @testing.parameterize(
     *testing.product({
-        'batchsize': [5, 10], 'input_dim': [2, 3], 'margin': [0.1, 0.5]
+        'batchsize': [5, 10], 'input_dim': [2, 3],
+        'margin': [0.1, 0.5], 'reduce': ['mean', 'no']
     })
 )
 class TestTriplet(unittest.TestCase):
@@ -24,34 +25,44 @@ class TestTriplet(unittest.TestCase):
         self.a = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
         self.p = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
         self.n = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
+        if self.reduce == 'mean':
+            gy_shape = ()
+        else:
+            gy_shape = (self.batchsize,)
+        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(numpy.float32)
 
     def check_forward(self, a_data, p_data, n_data):
         a_val = chainer.Variable(a_data)
         p_val = chainer.Variable(p_data)
         n_val = chainer.Variable(n_data)
-        loss = functions.triplet(a_val, p_val, n_val, self.margin)
-        self.assertEqual(loss.data.shape, ())
+        loss = functions.triplet(a_val, p_val, n_val, self.margin, self.reduce)
+        if self.reduce == 'mean':
+            self.assertEqual(loss.data.shape, ())
+        else:
+            self.assertEqual(loss.data.shape, (self.batchsize,))
         self.assertEqual(loss.data.dtype, numpy.float32)
-        loss_value = float(cuda.to_cpu(loss.data))
+        loss_value = cuda.to_cpu(loss.data)
 
         #
         # Compute expected value
         #
-        loss_expect = 0
+        loss_expect = numpy.empty((self.a.shape[0],), dtype=numpy.float32)
         for i in six.moves.range(self.a.shape[0]):
             ad, pd, nd = self.a[i], self.p[i], self.n[i]
             dp = numpy.sum((ad - pd) ** 2)
             dn = numpy.sum((ad - nd) ** 2)
-            loss_expect += max((dp - dn + self.margin), 0)
-        loss_expect /= self.a.shape[0]
-        self.assertAlmostEqual(loss_expect, loss_value, places=5)
+            loss_expect[i] = max((dp - dn + self.margin), 0)
+        if self.reduce == 'mean':
+            loss_expect = loss_expect.mean()
+        numpy.testing.assert_allclose(
+            loss_expect, loss_value, rtol=1e-4, atol=1e-4)
 
     def test_negative_margin(self):
         self.margin = -1
         self.assertRaises(ValueError, self.check_forward,
                           self.a, self.p, self.n)
         self.assertRaises(ValueError, self.check_backward,
-                          self.a, self.p, self.n)
+                          self.a, self.p, self.n, self.gy)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -63,20 +74,43 @@ class TestTriplet(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.a), cuda.to_gpu(self.p),
                            cuda.to_gpu(self.n))
 
-    def check_backward(self, a_data, p_data, n_data):
+    def check_backward(self, a_data, p_data, n_data, gy_data):
         gradient_check.check_backward(
-            functions.Triplet(self.margin),
-            (a_data, p_data, n_data), None, rtol=1e-4, atol=1e-4)
+            functions.Triplet(self.margin, self.reduce),
+            (a_data, p_data, n_data), gy_data, rtol=1e-4, atol=1e-4)
 
     @condition.retry(10)
     def test_backward_cpu(self):
-        self.check_backward(self.a, self.p, self.n)
+        self.check_backward(self.a, self.p, self.n, self.gy)
 
     @attr.gpu
     @condition.retry(10)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.a), cuda.to_gpu(self.p),
-                            cuda.to_gpu(self.n))
+                            cuda.to_gpu(self.n), cuda.to_gpu(self.gy))
+
+
+class TestContrastiveInvalidReductionOption(unittest.TestCase):
+
+    def setUp(self):
+        self.a = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
+        self.p = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
+        self.n = numpy.random.randint(-1, 1, (5, 10)).astype(numpy.float32)
+
+    def check_invalid_option(self, xp):
+        a = xp.asarray(self.a)
+        p = xp.asarray(self.p)
+        n = xp.asarray(self.n)
+
+        with self.assertRaises(ValueError):
+            functions.triplet(a, p, n, reduce='invalid_option')
+
+    def test_invalid_option_cpu(self):
+        self.check_invalid_option(numpy)
+
+    @attr.gpu
+    def test_invalid_option_gpu(self):
+        self.check_invalid_option(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds `reduce` option to `F.triplet` and `F.Triplet`. Related to #2558 