### PR TITLE
Remove reduce option from F.black_out

### DIFF
--- a/chainer/functions/loss/black_out.py
+++ b/chainer/functions/loss/black_out.py
@@ -28,8 +28,8 @@ def black_out(x, t, W, samples, reduce='mean'):
        \\sum_{s \\in samples} \\exp(W_s^\\top x)}.
 
     The output is a variable whose value depends on the value of
-    the option ``reduce``. If it is ``'samplewise'``, it holds the
-    samplewise loss values. If it is ``'mean'``, this function takes
+    the option ``reduce``. If it is ``'no'``, it holds the
+    no loss values. If it is ``'mean'``, this function takes
     a mean of loss values.
 
     Args:
@@ -45,13 +45,13 @@ def black_out(x, t, W, samples, reduce='mean'):
             Its shape should be :math:`(N, S)` where :math:`S` is
             the number of negative samples.
         recude (str): Reduction option. Its value must be either
-        ``'samplewise'`` or ``'mean'``. Otherwise,
+        ``'no'`` or ``'mean'``. Otherwise,
         :class:`ValueError` is raised.
 
     Returns:
         ~chainer.Variable:
             A variable object holding loss value(s).
-            If ``reduce`` is ``'samplewise'``, the output variable holds an
+            If ``reduce`` is ``'no'``, the output variable holds an
             array whose shape is :math:`(N,)` .
             If it is ``'mean'``, it holds a scalar.
 

--- a/chainer/functions/loss/black_out.py
+++ b/chainer/functions/loss/black_out.py
@@ -3,6 +3,7 @@ from chainer.functions.array import concat
 from chainer.functions.array import expand_dims
 from chainer.functions.array import reshape
 from chainer.functions.connection import embed_id
+from chainer.functions.math import average
 from chainer.functions.math import exponential
 from chainer.functions.math import logsumexp
 from chainer.functions.math import matmul
@@ -79,6 +80,5 @@ def black_out(x, t, W, samples, reduce='mean'):
     py = reshape.reshape(pos_y, (batch_size,))
     loss = -(py - logz + _sum.sum(ny, axis=1))
     if reduce == 'mean':
-        return _sum.sum(loss) / batch_size
-    else:
-        return loss
+        loss = average.average(loss)
+    return loss

--- a/chainer/functions/loss/black_out.py
+++ b/chainer/functions/loss/black_out.py
@@ -3,14 +3,13 @@ from chainer.functions.array import concat
 from chainer.functions.array import expand_dims
 from chainer.functions.array import reshape
 from chainer.functions.connection import embed_id
-from chainer.functions.math import average
 from chainer.functions.math import exponential
 from chainer.functions.math import logsumexp
 from chainer.functions.math import matmul
 from chainer.functions.math import sum as _sum
 
 
-def black_out(x, t, W, samples, reduce='mean'):
+def black_out(x, t, W, samples):
     """BlackOut loss function.
 
     BlackOut loss function is defined as
@@ -28,11 +27,6 @@ def black_out(x, t, W, samples, reduce='mean'):
        p(y) = \\frac{\\exp(W_y^\\top x)}{
        \\sum_{s \\in samples} \\exp(W_s^\\top x)}.
 
-    The output is a variable whose value depends on the value of
-    the option ``reduce``. If it is ``'no'``, it holds the
-    no loss values. If it is ``'mean'``, this function takes
-    a mean of loss values.
-
     Args:
         x (~chainer.Variable): Batch of input vectors.
             Its shape should be :math:`(N, D)`.
@@ -45,16 +39,11 @@ def black_out(x, t, W, samples, reduce='mean'):
         samples (~chainer.Variable): Negative samples.
             Its shape should be :math:`(N, S)` where :math:`S` is
             the number of negative samples.
-        recude (str): Reduction option. Its value must be either
-        ``'no'`` or ``'mean'``. Otherwise,
-        :class:`ValueError` is raised.
 
     Returns:
         ~chainer.Variable:
             A variable object holding loss value(s).
-            If ``reduce`` is ``'no'``, the output variable holds an
-            array whose shape is :math:`(N,)` .
-            If it is ``'mean'``, it holds a scalar.
+            whose shape is :math:`(N,)`.
 
     See: `BlackOut: Speeding up Recurrent Neural Network Language Models With \
          Very Large Vocabularies <https://arxiv.org/abs/1511.06909>`_
@@ -79,6 +68,4 @@ def black_out(x, t, W, samples, reduce='mean'):
     ny = exponential.log(1 - exponential.exp(bneg_y - blogz))
     py = reshape.reshape(pos_y, (batch_size,))
     loss = -(py - logz + _sum.sum(ny, axis=1))
-    if reduce == 'mean':
-        loss = average.average(loss)
     return loss

--- a/tests/chainer_tests/functions_tests/loss_tests/test_black_out.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_black_out.py
@@ -13,7 +13,7 @@ from chainer.testing import condition
 
 @testing.parameterize(
     {'reduce': 'mean'},
-    {'reduce': 'samplewise'}
+    {'reduce': 'no'}
 )
 class TestBlackOut(unittest.TestCase):
 
@@ -34,7 +34,7 @@ class TestBlackOut(unittest.TestCase):
         self.samples = numpy.random.randint(
             self.n_vocab, size=self.batch_size * self.n_samples) \
             .astype(numpy.int32).reshape((self.batch_size, self.n_samples))
-        if self.reduce == 'samplewise':
+        if self.reduce == 'no':
             self.gy = numpy.random.uniform(
                 -1, 1, (self.batch_size,)).astype(numpy.float32)
         else:

--- a/tests/chainer_tests/functions_tests/loss_tests/test_black_out.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_black_out.py
@@ -11,6 +11,10 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(
+    {'reduce': 'mean'},
+    {'reduce': 'samplewise'}
+)
 class TestBlackOut(unittest.TestCase):
 
     batch_size = 5
@@ -30,6 +34,11 @@ class TestBlackOut(unittest.TestCase):
         self.samples = numpy.random.randint(
             self.n_vocab, size=self.batch_size * self.n_samples) \
             .astype(numpy.int32).reshape((self.batch_size, self.n_samples))
+        if self.reduce == 'samplewise':
+            self.gy = numpy.random.uniform(
+                -1, 1, (self.batch_size,)).astype(numpy.float32)
+        else:
+            self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)
 
     def check_forward(self, x_data, t_data, w_data, samples_data):
         x = chainer.Variable(x_data)
@@ -37,7 +46,7 @@ class TestBlackOut(unittest.TestCase):
         w = chainer.Variable(w_data)
         samples = chainer.Variable(samples_data)
 
-        y = functions.black_out(x, t, w, samples)
+        y = functions.black_out(x, t, w, samples, self.reduce)
 
         expect_y = numpy.empty((self.batch_size), dtype=numpy.float32)
         for b in range(self.batch_size):
@@ -54,7 +63,11 @@ class TestBlackOut(unittest.TestCase):
 
             expect_y[b] = l
 
-        loss = -numpy.sum(expect_y) / self.batch_size
+        if self.reduce == 'mean':
+            loss = -numpy.sum(expect_y) / self.batch_size
+        else:
+            loss = -expect_y
+
         testing.assert_allclose(y.data, loss, atol=1.e-4)
 
     @condition.retry(3)
@@ -68,21 +81,24 @@ class TestBlackOut(unittest.TestCase):
             cuda.to_gpu(self.x), cuda.to_gpu(self.t), cuda.to_gpu(self.W),
             cuda.to_gpu(self.samples))
 
-    def check_backward(self, x_data, t_data, w_data, samples_data):
+    def check_backward(self, x_data, t_data, w_data, samples_data, gy_data):
+        def _black_out(x, t, W, samples):
+            return functions.black_out(x, t, W, samples, self.reduce)
+
         gradient_check.check_backward(
-            functions.black_out, (x_data, t_data, w_data, samples_data),
-            None, atol=1.e-3)
+            _black_out, (x_data, t_data, w_data, samples_data),
+            gy_data, atol=1.e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.t, self.W, self.samples)
+        self.check_backward(self.x, self.t, self.W, self.samples, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t), cuda.to_gpu(self.W),
-            cuda.to_gpu(self.samples))
+            cuda.to_gpu(self.samples), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR removes `reduce` option from `F.black_out`. Different from v1, `F.black_out` outputs sample wise loss values in v2. Related to #2558 #2600 