### PR TITLE
contrastive without reduction

### DIFF
--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -45,7 +45,7 @@ class Contrastive(function.Function):
         self.dist = xp.sqrt(self.dist_sq)
         self.mdist = self.margin - self.dist
         dist = xp.maximum(self.mdist, 0)
-        loss = (y * self.dist_sq + (1 - y) * dist * dist) / 2.0
+        loss = (y * self.dist_sq + (1 - y) * dist * dist) * .5
         if self.reduce == 'mean':
             loss = xp.sum(loss) / x0.shape[0]
         return xp.array(loss, dtype=xp.float32),

--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -9,10 +9,16 @@ class Contrastive(function.Function):
 
     """Contrastive loss function."""
 
-    def __init__(self, margin):
+    def __init__(self, margin, reduce='mean'):
         if margin <= 0:
             raise ValueError("margin should be positive value.")
         self.margin = margin
+
+        if reduce not in ('mean', 'no'):
+            raise ValueError(
+                "only 'mean' and 'no' are valid for 'reduce', but '%s' is "
+                'given' % reduce)
+        self.reduce = reduce
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 3)
@@ -39,9 +45,9 @@ class Contrastive(function.Function):
         self.dist = xp.sqrt(self.dist_sq)
         self.mdist = self.margin - self.dist
         dist = xp.maximum(self.mdist, 0)
-        loss = y * self.dist_sq + (1 - y) * dist * dist
-        loss = xp.sum(loss) / 2.0 / x0.shape[0]
-
+        loss = (y * self.dist_sq + (1 - y) * dist * dist) / 2.0
+        if self.reduce == 'mean':
+            loss = xp.sum(loss) / x0.shape[0]
         return xp.array(loss, dtype=xp.float32),
 
     def backward(self, inputs, gy):
@@ -50,7 +56,10 @@ class Contrastive(function.Function):
 
         x_dim = x0.shape[1]
         y = xp.repeat(y[:, None], x_dim, axis=1)
-        alpha = gy[0] / y.shape[0]
+        if self.reduce == 'mean':
+            alpha = gy[0] / y.shape[0]
+        else:
+            alpha = gy[0][:, None]
         dist = xp.repeat(self.dist[:, None], x_dim, axis=1)
         # avoid division by zero
         dist = xp.maximum(dist, 1e-8)
@@ -65,24 +74,30 @@ class Contrastive(function.Function):
         return gx0, -gx0, None
 
 
-def contrastive(x0, x1, y, margin=1):
+def contrastive(x0, x1, y, margin=1, reduce='mean'):
     """Computes contrastive loss.
 
-    It takes a pair of variables and a label as inputs. The label is 1 when
-    those two input variables are similar, or 0 when they are dissimilar. Let
-    :math:`N` and :math:`K` denote mini-batch size and the dimension of input
-    variables, respectively. The shape of both input variables should be
-    ``(N, K)``.
+    It takes a pair of samples and a label as inputs.
+    The label is :math:`1` when those samples are similar,
+    or :math:`0` when they are dissimilar.
+
+    Let :math:`N` and :math:`K` denote mini-batch size and the dimension
+    of input variables, respectively. The shape of both input variables
+    ``x0`` and ``x1`` should be ``(N, K)``.
+    The loss value of the :math:`n`-th sample pair :math:`L_n` is
 
     .. math::
-        L = \\frac{1}{2N} \\left( \\sum_{n=1}^N y_n d_n^2
-            + (1 - y_n) \\max ({\\rm margin} - d_n, 0)^2 \\right)
+        L_n = \\frac{1}{2} \\left( y_n d_n^2
+        + (1 - y_n) \\max ({\\rm margin} - d_n, 0)^2 \\right)
 
-    where :math:`d_n = \\| {\\bf x_0}_n - {\\bf x_1}_n \\|_2`. :math:`N`
-    denotes the mini-batch size. Input variables, x0 and x1, have :math:`N`
-    vectors, and each vector is K-dimensional. Therefore, :math:`{\\bf x_0}_n`
-    and :math:`{\\bf x_1}_n` are :math:`n`-th K-dimensional vectors of x0 and
-    x1.
+    where :math:`d_n = \\| {\\bf x_0}_n - {\\bf x_1}_n \\|_2`,
+    :math:`{\\bf x_0}_n` and :math:`{\\bf x_1}_n` are :math:`n`-th
+    K-dimensional vectors of ``x0`` and ``x1``.
+
+    The output is a variable whose value depends on the value of
+    the option ``reduce``. If it is ``'no'``, it holds the elementwise
+    loss values. If it is ``'mean'``, this function takes a mean of
+    loss values.
 
     Args:
         x0 (~chainer.Variable): The first input variable. The shape should be
@@ -94,10 +109,16 @@ def contrastive(x0, x1, y, margin=1):
             should be ``(N,)``, where N denotes the mini-batch size.
         margin (float): A parameter for contrastive loss. It should be positive
             value.
+        recude (str): Reduction option. Its value must be either
+            ``'mean'`` or ``'no'``. Otherwise, :class:`ValueError` is raised.
 
     Returns:
-        ~chainer.Variable: A variable holding a scalar that is the loss value
-            calculated by the above equation.
+        ~chainer.Variable:
+            A variable holding the loss value(s) calculated by the
+            above equation.
+            If ``reduce`` is ``'no'``, the output variable holds array
+            whose shape is same as one of (hence both of) input variables.
+            If it is ``'mean'``, the output variable holds a scalar value.
 
     .. note::
         This cost can be used to train siamese networks. See `Learning a
@@ -106,4 +127,4 @@ def contrastive(x0, x1, y, margin=1):
         for details.
 
     """
-    return Contrastive(margin)(x0, x1, y)
+    return Contrastive(margin, reduce)(x0, x1, y)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -28,7 +28,7 @@ class TestContrastive(unittest.TestCase):
         self.t = numpy.random.randint(
             0, 2, (self.batchsize,)).astype(numpy.int32)
         if self.reduce == 'mean':
-            self.gy = None
+            self.gy = numpy.float32(numpy.random.uniform(-1, 1))
         else:
             self.gy = numpy.random.uniform(
                 -1, 1, (self.batchsize,)).astype(numpy.float32)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -15,7 +15,8 @@ from chainer.testing import condition
 
 @testing.parameterize(
     *testing.product({
-        'batchsize': [5, 10], 'input_dim': [2, 3], 'margin': [1, 2]
+        'batchsize': [5, 10], 'input_dim': [2, 3], 'margin': [1, 2],
+        'reduce': ['mean', 'no']
     })
 )
 class TestContrastive(unittest.TestCase):
@@ -26,34 +27,45 @@ class TestContrastive(unittest.TestCase):
         self.x1 = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
         self.t = numpy.random.randint(
             0, 2, (self.batchsize,)).astype(numpy.int32)
+        if self.reduce == 'mean':
+            self.gy = None
+        else:
+            self.gy = numpy.random.uniform(
+                -1, 1, (self.batchsize,)).astype(numpy.float32)
 
     def check_forward(self, x0_data, x1_data, t_data):
         x0_val = chainer.Variable(x0_data)
         x1_val = chainer.Variable(x1_data)
         t_val = chainer.Variable(t_data)
-        loss = functions.contrastive(x0_val, x1_val, t_val, self.margin)
-        self.assertEqual(loss.data.shape, ())
+        loss = functions.contrastive(
+            x0_val, x1_val, t_val, self.margin, self.reduce)
         self.assertEqual(loss.data.dtype, numpy.float32)
-        loss_value = float(cuda.to_cpu(loss.data))
+        if self.reduce == 'mean':
+            self.assertEqual(loss.data.shape, ())
+        else:
+            self.assertEqual(loss.data.shape, (self.batchsize,))
+        loss_value = cuda.to_cpu(loss.data)
 
         # Compute expected value
-        loss_expect = 0
+        loss_expect = numpy.empty((self.batchsize,), numpy.float32)
         for i in six.moves.range(self.x0.shape[0]):
             x0d, x1d, td = self.x0[i], self.x1[i], self.t[i]
             d = numpy.sum((x0d - x1d) ** 2)
             if td == 1:  # similar pair
-                loss_expect += d
+                loss_expect[i] = d
             elif td == 0:  # dissimilar pair
-                loss_expect += max(self.margin - math.sqrt(d), 0) ** 2
-        loss_expect /= 2.0 * self.t.shape[0]
-        self.assertAlmostEqual(loss_expect, loss_value, places=5)
+                loss_expect[i] = max(self.margin - math.sqrt(d), 0) ** 2
+            loss_expect[i] /= 2.
+        if self.reduce == 'mean':
+            loss_expect = numpy.sum(loss_expect) / self.t.shape[0]
+        numpy.testing.assert_allclose(loss_expect, loss_value, rtol=1e-5)
 
     def test_negative_margin(self):
         self.margin = -1
         self.assertRaises(ValueError, self.check_forward,
                           self.x0, self.x1, self.t)
         self.assertRaises(ValueError, self.check_backward,
-                          self.x0, self.x1, self.t)
+                          self.x0, self.x1, self.t, self.gy)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -65,30 +77,30 @@ class TestContrastive(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1),
                            cuda.to_gpu(self.t))
 
-    def check_backward(self, x0_data, x1_data, t_data):
+    def check_backward(self, x0_data, x1_data, t_data, gy_data):
         gradient_check.check_backward(
-            functions.Contrastive(self.margin),
-            (x0_data, x1_data, t_data), None, rtol=1e-4, atol=1e-4)
+            functions.Contrastive(self.margin, self.reduce),
+            (x0_data, x1_data, t_data), gy_data, rtol=1e-4, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x0, self.x1, self.t)
+        self.check_backward(self.x0, self.x1, self.t, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1),
-                            cuda.to_gpu(self.t))
+                            cuda.to_gpu(self.t), cuda.to_gpu(self.gy))
 
     @condition.retry(3)
     def test_backward_zero_dist_cpu(self):
-        self.check_backward(self.x0, self.x0, self.t)
+        self.check_backward(self.x0, self.x0, self.t, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_zero_dist_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x0),
-                            cuda.to_gpu(self.t))
+                            cuda.to_gpu(self.t), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -103,4 +103,27 @@ class TestContrastive(unittest.TestCase):
                             cuda.to_gpu(self.t), cuda.to_gpu(self.gy))
 
 
+class TestContrastiveInvalidReductionOption(unittest.TestCase):
+
+    def setUp(self):
+        self.x0 = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
+        self.x1 = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
+        self.t = numpy.random.randint(0, 2, (5,)).astype(numpy.int32)
+
+    def check_invalid_option(self, xp):
+        x0 = xp.asarray(self.x0)
+        x1 = xp.asarray(self.x1)
+        t = xp.asarray(self.t)
+
+        with self.assertRaises(ValueError):
+            functions.contrastive(x0, x1, t, 1, 'invalid_option')
+
+    def test_invalid_option_cpu(self):
+        self.check_invalid_option(numpy)
+
+    @attr.gpu
+    def test_invalid_option_gpu(self):
+        self.check_invalid_option(cuda.cupy)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -28,7 +28,7 @@ class TestContrastive(unittest.TestCase):
         self.t = numpy.random.randint(
             0, 2, (self.batchsize,)).astype(numpy.int32)
         if self.reduce == 'mean':
-            self.gy = numpy.float32(numpy.random.uniform(-1, 1))
+            self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)
         else:
             self.gy = numpy.random.uniform(
                 -1, 1, (self.batchsize,)).astype(numpy.float32)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -15,8 +15,7 @@ from chainer.testing import condition
 
 @testing.parameterize(
     *testing.product({
-        'batchsize': [5, 10], 'input_dim': [2, 3], 'margin': [1, 2],
-        'reduce': ['mean', 'no']
+        'batchsize': [5, 10], 'input_dim': [2, 3], 'margin': [1, 2]
     })
 )
 class TestContrastive(unittest.TestCase):
@@ -27,23 +26,17 @@ class TestContrastive(unittest.TestCase):
         self.x1 = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
         self.t = numpy.random.randint(
             0, 2, (self.batchsize,)).astype(numpy.int32)
-        if self.reduce == 'mean':
-            self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)
-        else:
-            self.gy = numpy.random.uniform(
-                -1, 1, (self.batchsize,)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, (self.batchsize,)).astype(numpy.float32)
 
     def check_forward(self, x0_data, x1_data, t_data):
         x0_val = chainer.Variable(x0_data)
         x1_val = chainer.Variable(x1_data)
         t_val = chainer.Variable(t_data)
         loss = functions.contrastive(
-            x0_val, x1_val, t_val, self.margin, self.reduce)
+            x0_val, x1_val, t_val, self.margin)
         self.assertEqual(loss.data.dtype, numpy.float32)
-        if self.reduce == 'mean':
-            self.assertEqual(loss.data.shape, ())
-        else:
-            self.assertEqual(loss.data.shape, (self.batchsize,))
+        self.assertEqual(loss.data.shape, (self.batchsize,))
         loss_value = cuda.to_cpu(loss.data)
 
         # Compute expected value
@@ -56,8 +49,6 @@ class TestContrastive(unittest.TestCase):
             elif td == 0:  # dissimilar pair
                 loss_expect[i] = max(self.margin - math.sqrt(d), 0) ** 2
             loss_expect[i] /= 2.
-        if self.reduce == 'mean':
-            loss_expect = numpy.sum(loss_expect) / self.t.shape[0]
         numpy.testing.assert_allclose(loss_expect, loss_value, rtol=1e-5)
 
     def test_negative_margin(self):
@@ -79,7 +70,7 @@ class TestContrastive(unittest.TestCase):
 
     def check_backward(self, x0_data, x1_data, t_data, gy_data):
         gradient_check.check_backward(
-            functions.Contrastive(self.margin, self.reduce),
+            functions.Contrastive(self.margin),
             (x0_data, x1_data, t_data), gy_data, rtol=1e-4, atol=1e-4)
 
     @condition.retry(3)
@@ -101,29 +92,6 @@ class TestContrastive(unittest.TestCase):
     def test_backward_zero_dist_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x0),
                             cuda.to_gpu(self.t), cuda.to_gpu(self.gy))
-
-
-class TestContrastiveInvalidReductionOption(unittest.TestCase):
-
-    def setUp(self):
-        self.x0 = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
-        self.x1 = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
-        self.t = numpy.random.randint(0, 2, (5,)).astype(numpy.int32)
-
-    def check_invalid_option(self, xp):
-        x0 = xp.asarray(self.x0)
-        x1 = xp.asarray(self.x1)
-        t = xp.asarray(self.t)
-
-        with self.assertRaises(ValueError):
-            functions.contrastive(x0, x1, t, 1, 'invalid_option')
-
-    def test_invalid_option_cpu(self):
-        self.check_invalid_option(numpy)
-
-    @attr.gpu
-    def test_invalid_option_gpu(self):
-        self.check_invalid_option(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR removes `reduce` option from `F.Contrastive` and `F.contrastive`. Different from v1, they output sample wise loss values in v2. Related to #2558 #2603 