### PR TITLE
Remove obsolete document in DilatedConvolution2D

### DIFF
--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -58,8 +58,6 @@ class DilatedConvolution2D(link.Link):
         else:
             self.initialW = initialW
 
-        # For backward compatibility, the scale of weights is proportional to
-        # the square root of wscale.
         self.add_param('W', initializer=initializers._get_initializer(
             initialW))
         if in_channels is not None:


### PR DESCRIPTION
I remove an obsolete document about `wscale`, which is removed by #2163.