### PR TITLE
Remove wscale option from MLPConvolution2D

### DIFF
--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -44,8 +44,7 @@ class MLPConvolution2D(link.ChainList):
     """
 
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
-                 activation=relu.relu, wscale=1,
-                 conv_init=None, bias_init=None):
+                 activation=relu.relu, conv_init=None, bias_init=None):
         assert len(out_channels) > 0
         convs = [convolution_2d.Convolution2D(
             in_channels, out_channels[0], ksize, stride, pad,

--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -1,11 +1,14 @@
 from chainer.functions.activation import relu
 from chainer import link
 from chainer.links.connection import convolution_2d
+from chainer.utils import argument
 
 
 class MLPConvolution2D(link.ChainList):
 
-    """Two-dimensional MLP convolution layer of Network in Network.
+    """__init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0, activation=relu.relu, conv_init=None, bias_init=None)
+
+    Two-dimensional MLP convolution layer of Network in Network.
 
     This is an "mlpconv" layer from the Network in Network paper. This layer
     is a two-dimensional convolution layer followed by 1x1 convolution layers
@@ -33,19 +36,39 @@ class MLPConvolution2D(link.ChainList):
         activation (function): Activation function for internal hidden units.
             Note that this function is not applied to the output of this link.
         conv_init: An initializer of weight matrices
-            passed to the convolution layers.
+            passed to the convolution layers. This option must be specified as
+            a keyword argument.
         bias_init: An initializer of bias vectors
-            passed to the convolution layers.
+            passed to the convolution layers. This option must be specified as
+            a keyword argument.
+
+    .. note:
+        From v2, `conv_init` and `bias_init` arguments must be specified as
+        keyword arguments only. We impose this restriction to forbid
+        users to assume the API for v1 and specify `wscale` option, 
+        that had been between `activation` and `conv_init` arguments in v1.
 
     See: `Network in Network <https://arxiv.org/abs/1312.4400v3>`_.
 
     Attributes:
         activation (function): Activation function.
 
-    """
+    """  # NOQA
 
     def __init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0,
-                 activation=relu.relu, conv_init=None, bias_init=None):
+                 activation=relu.relu, *args, **kwargs):
+
+        # If `args` is not empty, users assume the API for v1 and
+        # specifie `wscale` as a positonal argument, which we want
+        # to detect and forbid with an explicit error message.
+        msg = ('wscale is not supported anymore. '
+               'Use conv_init and bias_init argument to change '
+               'the scale of initial parameters.')
+        if args:
+            raise TypeError(msg)
+        argument.check_unexpected_kwargs(kwargs, wscale=msg)
+        conv_init, bias_init = argument.parse_kwargs(
+            kwargs, ('conv_init', None), ('bias_init', None))
 
         if ksize is None:
             out_channels, ksize, in_channels = in_channels, out_channels, None

--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -59,7 +59,7 @@ class MLPConvolution2D(link.ChainList):
                  activation=relu.relu, *args, **kwargs):
 
         # If `args` is not empty, users assume the API for v1 and
-        # specifie `wscale` as a positonal argument, which we want
+        # specify `wscale` as a positonal argument, which we want
         # to detect and forbid with an explicit error message.
         msg = ('wscale is not supported anymore. '
                'Use conv_init and bias_init argument to change '


### PR DESCRIPTION
I found `wscale` option in `L.MLPConvolution2D` is not used any longer. Related to #2163 