### PR TITLE
Fix init weight of EmbedID

### DIFF
--- a/chainer/links/connection/embed_id.py
+++ b/chainer/links/connection/embed_id.py
@@ -34,7 +34,8 @@ class EmbedID(link.Link):
         super(EmbedID, self).__init__()
         if initialW is None:
             initialW = initializers.Normal(1.0)
-        self.add_param('W', (in_size, out_size), initializer=initialW)
+        self.add_param('W', (in_size, out_size),
+                       initializer=initializers._get_initializer(initialW))
         self.ignore_label = ignore_label
 
     def __call__(self, x):


### PR DESCRIPTION
I fix a bug of #2465
When `EmbedID` is given an initial weight value by `ndarray`, TypeError occured.
```
>>> import chainer.links as L
>>> import numpy as np
>>>
>>> embed = L.EmbedID(10, 3, initialW=np.zeros((10, 3)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/user/git/chainer/chainer/links/connection/embed_id.py", line 37, in __init__
    self.add_param('W', (in_size, out_size), initializer=initialW)
  File "/Users/user/git/chainer/chainer/link.py", line 192, in add_param
    data = initializers.generate_array(initializer, shape, self.xp)
  File "/Users/user/git/chainer/chainer/initializers/__init__.py", line 46, in generate_array
    initializer(array)
TypeError: 'numpy.ndarray' object is not callable
```
Because, `EmbedID` don't use `initializers._get_initializer` in `__init__` method.