### PR TITLE
Add reduce option to F.cross_covariance

### DIFF
--- a/chainer/functions/loss/cross_covariance.py
+++ b/chainer/functions/loss/cross_covariance.py
@@ -82,7 +82,7 @@ def cross_covariance(y, z, reduce='half_frobenius_norm'):
             corresponds to the batches.
         z (Variable): Variable holding a matrix where the first dimension
             corresponds to the batches.
-        recude (str): Reduction option. Its value must be either
+        reduce (str): Reduction option. Its value must be either
             ``'half_frobenius_norm'`` or ``'no'``.
             Otherwise, :class:`ValueError` is raised.
 

--- a/chainer/functions/loss/cross_covariance.py
+++ b/chainer/functions/loss/cross_covariance.py
@@ -10,14 +10,14 @@ class CrossCovariance(function.Function):
 
     """Cross-covariance loss."""
 
-    def __init__(self, reduce='half_frobenius_norm'):
+    def __init__(self, reduce='half_squared_sum'):
         self.y_centered = None
         self.z_centered = None
         self.covariance = None
 
-        if reduce not in ('half_frobenius_norm', 'no'):
+        if reduce not in ('half_squared_sum', 'no'):
             raise ValueError(
-                "only 'half_frobenius_norm' and 'no' are valid "
+                "only 'half_squared_sum' and 'no' are valid "
                 "for 'reduce', but '%s' is given" % reduce)
         self.reduce = reduce
 
@@ -43,7 +43,7 @@ class CrossCovariance(function.Function):
         self.covariance = self.y_centered.T.dot(self.z_centered)
         self.covariance /= len(y)
 
-        if self.reduce == 'half_frobenius_norm':
+        if self.reduce == 'half_squared_sum':
             cost = xp.vdot(self.covariance, self.covariance)
             cost *= y.dtype.type(0.5)
             return utils.force_array(cost),
@@ -55,7 +55,7 @@ class CrossCovariance(function.Function):
         gcost, = grad_outputs
         gcost_div_n = gcost / gcost.dtype.type(len(y))
 
-        if self.reduce == 'half_frobenius_norm':
+        if self.reduce == 'half_squared_sum':
             gy = self.z_centered.dot(self.covariance.T)
             gz = self.y_centered.dot(self.covariance)
             gy *= gcost_div_n
@@ -66,14 +66,14 @@ class CrossCovariance(function.Function):
         return gy, gz
 
 
-def cross_covariance(y, z, reduce='half_frobenius_norm'):
+def cross_covariance(y, z, reduce='half_squared_sum'):
     """Computes the sum-squared cross-covariance penalty between ``y`` and ``z``
 
     The output is a variable whose value depends on the value of
     the option ``reduce``. If it is ``'no'``, it holds the covariant
     matrix that has as many rows (resp. columns) as the dimension of
     ``y`` (resp.z).
-    If it is ``'half_frobenius_norm'``, it holds the half of the
+    If it is ``'half_squared_sum'``, it holds the half of the
     Frobenius norm (i.e. L2 norm of a matrix flattened to a vector)
     of the covarianct matrix.
 
@@ -83,7 +83,7 @@ def cross_covariance(y, z, reduce='half_frobenius_norm'):
         z (Variable): Variable holding a matrix where the first dimension
             corresponds to the batches.
         reduce (str): Reduction option. Its value must be either
-            ``'half_frobenius_norm'`` or ``'no'``.
+            ``'half_squared_sum'`` or ``'no'``.
             Otherwise, :class:`ValueError` is raised.
 
     Returns:
@@ -93,7 +93,7 @@ def cross_covariance(y, z, reduce='half_frobenius_norm'):
             2-dimensional array matrix of shape ``(M, N)`` where
             ``M`` (resp. ``N``) is the number of columns of ``y``
             (resp. ``z``).
-            If it is ``'half_frobenius_norm'``, the output variable
+            If it is ``'half_squared_sum'``, the output variable
             holds a scalar value.
 
     .. note::

--- a/chainer/functions/loss/cross_covariance.py
+++ b/chainer/functions/loss/cross_covariance.py
@@ -10,10 +10,16 @@ class CrossCovariance(function.Function):
 
     """Cross-covariance loss."""
 
-    def __init__(self):
+    def __init__(self, reduce='half_frobenius_norm'):
         self.y_centered = None
         self.z_centered = None
         self.covariance = None
+
+        if reduce not in ('half_frobenius_norm', 'no'):
+            raise ValueError(
+                "only 'half_frobenius_norm' and 'no' are valid "
+                "for 'reduce', but '%s' is given" % reduce)
+        self.reduce = reduce
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -36,32 +42,59 @@ class CrossCovariance(function.Function):
         self.z_centered = z - z.mean(axis=0, keepdims=True)
         self.covariance = self.y_centered.T.dot(self.z_centered)
         self.covariance /= len(y)
-        cost = xp.vdot(self.covariance, self.covariance) * y.dtype.type(0.5)
-        return utils.force_array(cost),
+
+        if self.reduce == 'half_frobenius_norm':
+            cost = xp.vdot(self.covariance, self.covariance)
+            cost *= y.dtype.type(0.5)
+            return utils.force_array(cost),
+        else:
+            return self.covariance,
 
     def backward(self, inputs, grad_outputs):
         y, z = inputs
         gcost, = grad_outputs
         gcost_div_n = gcost / gcost.dtype.type(len(y))
 
-        gy = self.z_centered.dot(self.covariance.T)
-        gz = self.y_centered.dot(self.covariance)
-        gy *= gcost_div_n
-        gz *= gcost_div_n
+        if self.reduce == 'half_frobenius_norm':
+            gy = self.z_centered.dot(self.covariance.T)
+            gz = self.y_centered.dot(self.covariance)
+            gy *= gcost_div_n
+            gz *= gcost_div_n
+        else:
+            gy = self.z_centered.dot(gcost_div_n.T)
+            gz = self.y_centered.dot(gcost_div_n)
         return gy, gz
 
 
-def cross_covariance(y, z):
+def cross_covariance(y, z, reduce='half_frobenius_norm'):
     """Computes the sum-squared cross-covariance penalty between ``y`` and ``z``
+
+    The output is a variable whose value depends on the value of
+    the option ``reduce``. If it is ``'no'``, it holds the covariant
+    matrix that has as many rows (resp. columns) as the dimension of
+    ``y`` (resp.z).
+    If it is ``'half_frobenius_norm'``, it holds the half of the
+    Frobenius norm (i.e. L2 norm of a matrix flattened to a vector)
+    of the covarianct matrix.
 
     Args:
         y (Variable): Variable holding a matrix where the first dimension
             corresponds to the batches.
         z (Variable): Variable holding a matrix where the first dimension
             corresponds to the batches.
+        recude (str): Reduction option. Its value must be either
+            ``'half_frobenius_norm'`` or ``'no'``.
+            Otherwise, :class:`ValueError` is raised.
 
     Returns:
-        Variable: A variable holding a scalar of the cross covariance loss.
+        Variable:
+            A variable holding the cross covariance loss.
+            If ``reduce`` is ``'no'``, the output variable holds
+            2-dimensional array matrix of shape ``(M, N)`` where
+            ``M`` (resp. ``N``) is the number of columns of ``y``
+            (resp. ``z``).
+            If it is ``'half_frobenius_norm'``, the output variable
+            holds a scalar value.
 
     .. note::
 
@@ -69,4 +102,4 @@ def cross_covariance(y, z):
        See https://arxiv.org/abs/1412.6583v3 for details.
 
     """
-    return CrossCovariance()(y, z)
+    return CrossCovariance(reduce)(y, z)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
@@ -50,8 +50,6 @@ class TestCrossCovariance(unittest.TestCase):
         z = chainer.Variable(z_data)
         loss = functions.cross_covariance(y, z, self.reduce)
 
-        row = y_data.shape[1]
-        col = z_data.shape[1]
         self.assertEqual(loss.shape, self.gloss.shape)
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = cuda.to_cpu(loss.data)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
@@ -30,7 +30,7 @@ def _cross_covariance(y, z):
 
 
 @testing.parameterize(
-    {'reduce': 'half_frobenius_norm'},
+    {'reduce': 'half_squared_sum'},
     {'reduce': 'no'}
 )
 class TestCrossCovariance(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestCrossCovariance(unittest.TestCase):
     def setUp(self):
         self.y = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
         self.z = numpy.random.uniform(-1, 1, (4, 2)).astype(numpy.float32)
-        if self.reduce == 'half_frobenius_norm':
+        if self.reduce == 'half_squared_sum':
             gloss_shape = ()
         else:
             gloss_shape = (3, 2)
@@ -56,7 +56,7 @@ class TestCrossCovariance(unittest.TestCase):
 
         # Compute expected value
         loss_expect = _cross_covariance(y_data, z_data)
-        if self.reduce == 'half_frobenius_norm':
+        if self.reduce == 'half_squared_sum':
             loss_expect = numpy.sum(loss_expect ** 2) * 0.5
         numpy.testing.assert_allclose(
             loss_expect, loss_value, rtol=1e-4, atol=1e-4)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
@@ -52,11 +52,7 @@ class TestCrossCovariance(unittest.TestCase):
 
         row = y_data.shape[1]
         col = z_data.shape[1]
-        if self.reduce == 'half_frobenius_norm':
-            self.assertEqual(loss.data.shape, ())
-        else:
-            self.assertEqual(loss.data.shape, (row, col))
-
+        self.assertEqual(loss.shape, self.gloss.shape)
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = cuda.to_cpu(loss.data)
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_cross_covariance.py
@@ -12,38 +12,60 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+def _cross_covariance(y, z):
+    row = y.shape[1]
+    col = z.shape[1]
+    y, z = cuda.to_cpu(y), cuda.to_cpu(z)
+    y_mean = y.mean(axis=0)
+    z_mean = z.mean(axis=0)
+    N = y.shape[0]
+    loss_expect = numpy.zeros((row, col), dtype=numpy.float32)
+    for i in six.moves.xrange(row):
+        for j in six.moves.xrange(col):
+            for n in six.moves.xrange(N):
+                loss_expect[i, j] += (y[n, i] - y_mean[i]) * (
+                    z[n, j] - z_mean[j])
+    loss_expect /= N
+    return loss_expect
+
+
+@testing.parameterize(
+    {'reduce': 'half_frobenius_norm'},
+    {'reduce': 'no'}
+)
 class TestCrossCovariance(unittest.TestCase):
 
     def setUp(self):
         self.y = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
         self.z = numpy.random.uniform(-1, 1, (4, 2)).astype(numpy.float32)
+        if self.reduce == 'half_frobenius_norm':
+            gloss_shape = ()
+        else:
+            gloss_shape = (3, 2)
+        self.gloss = numpy.random.uniform(
+            -1, 1, gloss_shape).astype(numpy.float32)
 
     def check_forward(self, y_data, z_data):
         y = chainer.Variable(y_data)
         z = chainer.Variable(z_data)
-        loss = functions.cross_covariance(y, z)
-        self.assertEqual(loss.data.shape, ())
+        loss = functions.cross_covariance(y, z, self.reduce)
+
+        row = y_data.shape[1]
+        col = z_data.shape[1]
+        if self.reduce == 'half_frobenius_norm':
+            self.assertEqual(loss.data.shape, ())
+        else:
+            self.assertEqual(loss.data.shape, (row, col))
+
         self.assertEqual(loss.data.dtype, numpy.float32)
-        loss_value = float(loss.data)
+        loss_value = cuda.to_cpu(loss.data)
 
         # Compute expected value
-        y_data, z_data = cuda.to_cpu(y_data), cuda.to_cpu(z_data)
-        y_mean = y_data.mean(axis=0)
-        z_mean = z_data.mean(axis=0)
-        N = y_data.shape[0]
-
-        loss_expect = 0
-        for i in six.moves.xrange(y_data.shape[1]):
-            for j in six.moves.xrange(z_data.shape[1]):
-                ij_loss = 0.
-                for n in six.moves.xrange(N):
-                    ij_loss += (y_data[n, i] - y_mean[i]) * (
-                        z_data[n, j] - z_mean[j])
-                ij_loss /= N
-                loss_expect += ij_loss ** 2
-        loss_expect *= 0.5
-
-        self.assertAlmostEqual(loss_expect, loss_value, places=5)
+        loss_expect = _cross_covariance(y_data, z_data)
+        if self.reduce == 'half_frobenius_norm':
+            loss_expect = numpy.sum(loss_expect ** 2) * 0.5
+        numpy.testing.assert_allclose(
+            loss_expect, loss_value, rtol=1e-4, atol=1e-4)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -54,33 +76,58 @@ class TestCrossCovariance(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.y), cuda.to_gpu(self.z))
 
-    def check_backward(self, y_data, z_data):
+    def check_backward(self, y_data, z_data, gloss_data):
         gradient_check.check_backward(
-            functions.CrossCovariance(), (y_data, z_data), None, eps=0.02)
+            functions.CrossCovariance(self.reduce), (y_data, z_data),
+            gloss_data, eps=0.02, rtol=1e-4, atol=1e-4)
 
-    def check_type(self, y_data, z_data):
+    def check_type(self, y_data, z_data, gloss_data):
         y = chainer.Variable(y_data)
         z = chainer.Variable(z_data)
-        loss = functions.cross_covariance(y, z)
+        loss = functions.cross_covariance(y, z, self.reduce)
+        loss.grad = gloss_data
         loss.backward()
         self.assertEqual(y_data.dtype, y.grad.dtype)
         self.assertEqual(z_data.dtype, z.grad.dtype)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.y, self.z)
+        self.check_backward(self.y, self.z, self.gloss)
 
     def test_backward_type_cpu(self):
-        self.check_type(self.y, self.z)
+        self.check_type(self.y, self.z, self.gloss)
 
     @attr.gpu
     def test_backward_type_gpu(self):
-        self.check_type(cuda.to_gpu(self.y), cuda.to_gpu(self.z))
+        self.check_type(cuda.to_gpu(self.y), cuda.to_gpu(self.z),
+                        cuda.to_gpu(self.gloss))
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.y), cuda.to_gpu(self.z))
+        self.check_backward(cuda.to_gpu(self.y), cuda.to_gpu(self.z),
+                            cuda.to_gpu(self.gloss))
+
+
+class TestCrossCovarianceInvalidReductionOption(unittest.TestCase):
+
+    def setUp(self):
+        self.y = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
+        self.z = numpy.random.uniform(-1, 1, (4, 2)).astype(numpy.float32)
+
+    def check_invalid_option(self, xp):
+        y = xp.asarray(self.y)
+        z = xp.asarray(self.z)
+
+        with self.assertRaises(ValueError):
+            functions.cross_covariance(y, z, 'invalid_option')
+
+    def test_invalid_option_cpu(self):
+        self.check_invalid_option(numpy)
+
+    @attr.gpu
+    def test_invalid_option_gpu(self):
+        self.check_invalid_option(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds `reduce` option to `F.CrossCovariance` and `F.cross_covariance`. Related to #2558 