### PR TITLE
hinge without reduction

### DIFF
--- a/chainer/functions/loss/hinge.py
+++ b/chainer/functions/loss/hinge.py
@@ -135,6 +135,10 @@ def hinge(x, t, norm='L1', reduce='mean'):
             2 & {\\rm if~norm} = {\\rm 'L2'.}
             \\end{array} \\right.
 
+        The output is a varialbe whose value depends on the value of
+        the option ``reduce``. If it is ``'no'``, it holds the elementwise
+        loss values. If it is ``'mean'``, it takes the mean of loss values.
+
     Args:
         x (~chainer.Variable): Input variable. The shape of ``x`` should be
             (:math:`N`, :math:`K`).
@@ -142,12 +146,19 @@ def hinge(x, t, norm='L1', reduce='mean'):
             :math:`{\\bf l}` with values
             :math:`l_n \in \{0, 1, 2, \dots, K-1\}`. The shape of ``t`` should
             be (:math:`N`,).
-        norm (string): Specifies norm type. Only either 'L1' or 'L2' is
+        norm (string): Specifies norm type. Only either ``'L1'`` or ``'L2'`` is
             acceptable.
+        recude (str): Reduction option. Its value must be either
+            ``'mean'`` or ``'no'``. Otherwise, :class:`ValueError` is raised.
+
 
     Returns:
-        ~chainer.Variable: A variable object holding a scalar array of the
+        ~chainer.Variable:
+            A variable object holding a scalar array of the
             hinge loss :math:`L`.
+            If ``reduce`` is ``'no'``, the output varialbe holds array
+            whose shape is same as one of (hence both of) input variables.
+            If it is ``'mean'``, the output variable holds a scalar value.
 
     """
     return Hinge(norm, reduce)(x, t)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -79,4 +79,37 @@ class TestHinge(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
 
+class TestHingeInvalidOption(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (10, 5)).astype(numpy.float32)
+        self.t = numpy.random.randint(0, 5, (10,)).astype(numpy.int32)
+
+    def check_invalid_norm_option(self, xp):
+        x = xp.asarray(self.x)
+        t = xp.asarray(self.t)
+        with self.assertRaises(NotImplementedError):
+            functions.hinge(x, t, 'invalid_norm', 'mean')
+
+    def test_invalid_norm_option_cpu(self):
+        self.check_invalid_norm_option(numpy)
+
+    @attr.gpu
+    def test_invalid_norm_option_gpu(self):
+        self.check_invalid_norm_option(cuda.cupy)
+
+    def check_invalid_reduce_option(self, xp):
+        x = xp.asarray(self.x)
+        t = xp.asarray(self.t)
+        with self.assertRaises(ValueError):
+            functions.hinge(x, t, 'L1', 'invalid_option')
+
+    def test_invalid_reduce_option_cpu(self):
+        self.check_invalid_reduce_option(numpy)
+
+    @attr.gpu
+    def test_invalid_reduce_option_gpu(self):
+        self.check_invalid_reduce_option(cuda.cupy)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -13,10 +13,8 @@ from chainer.testing import condition
 
 
 @testing.parameterize(
-    *testing.product(
-        {'reduce': ['no', 'mean'],
-         'norm': ['L1', 'L2']}
-    )
+    {'norm': 'L1'},
+    {'norm': 'L2'}
 )
 class TestHinge(unittest.TestCase):
 
@@ -25,18 +23,14 @@ class TestHinge(unittest.TestCase):
         # Avoid values around -1.0 for stability
         self.x[numpy.logical_and(-1.01 < self.x, self.x < -0.99)] = 0.5
         self.t = numpy.random.randint(0, 5, (10,)).astype(numpy.int32)
-        if self.reduce == 'no':
-            self.gy = numpy.random.uniform(
-                -1, 1, self.x.shape).astype(numpy.float32)
+        self.gy = numpy.random.uniform(
+            -1, 1, self.x.shape).astype(numpy.float32)
 
     def check_forward(self, x_data, t_data):
         x_val = chainer.Variable(x_data)
         t_val = chainer.Variable(t_data)
-        loss = functions.hinge(x_val, t_val, self.norm, self.reduce)
-        if self.reduce == 'mean':
-            self.assertEqual(loss.data.shape, ())
-        else:
-            self.assertEqual(loss.data.shape, self.x.shape)
+        loss = functions.hinge(x_val, t_val, self.norm)
+        self.assertEqual(loss.data.shape, self.x.shape)
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = cuda.to_cpu(loss.data)
 
@@ -50,9 +44,6 @@ class TestHinge(unittest.TestCase):
             loss_expect = self.x
         elif self.norm == 'L2':
             loss_expect = self.x ** 2
-        if self.reduce == 'mean':
-            loss_expect = numpy.sum(loss_expect) / self.x.shape[0]
-
         testing.assert_allclose(loss_expect, loss_value)
 
     @condition.retry(3)
@@ -64,52 +55,20 @@ class TestHinge(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
-    def check_backward(self, x_data, t_data):
+    def check_backward(self, x_data, t_data, gy_data):
         gradient_check.check_backward(
-            functions.Hinge(self.norm), (x_data, t_data), None,
+            functions.Hinge(self.norm), (x_data, t_data), gy_data,
             eps=0.01, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.t)
+        self.check_backward(self.x, self.t, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
-
-
-class TestHingeInvalidOption(unittest.TestCase):
-
-    def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (10, 5)).astype(numpy.float32)
-        self.t = numpy.random.randint(0, 5, (10,)).astype(numpy.int32)
-
-    def check_invalid_norm_option(self, xp):
-        x = xp.asarray(self.x)
-        t = xp.asarray(self.t)
-        with self.assertRaises(NotImplementedError):
-            functions.hinge(x, t, 'invalid_norm', 'mean')
-
-    def test_invalid_norm_option_cpu(self):
-        self.check_invalid_norm_option(numpy)
-
-    @attr.gpu
-    def test_invalid_norm_option_gpu(self):
-        self.check_invalid_norm_option(cuda.cupy)
-
-    def check_invalid_reduce_option(self, xp):
-        x = xp.asarray(self.x)
-        t = xp.asarray(self.t)
-        with self.assertRaises(ValueError):
-            functions.hinge(x, t, 'L1', 'invalid_option')
-
-    def test_invalid_reduce_option_cpu(self):
-        self.check_invalid_reduce_option(numpy)
-
-    @attr.gpu
-    def test_invalid_reduce_option_gpu(self):
-        self.check_invalid_reduce_option(cuda.cupy)
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t),
+                            cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR removes `reduce` option from `F.hinge` and `F.Hinge`. Different from v1, they output sample wise loss values in v2. Related to #2558 #2577 