### PR TITLE
Remove reduce option from F.huber_loss

### DIFF
--- a/chainer/functions/loss/huber_loss.py
+++ b/chainer/functions/loss/huber_loss.py
@@ -7,8 +7,14 @@ from chainer.utils import type_check
 
 class HuberLoss(function.Function):
 
-    def __init__(self, delta):
+    def __init__(self, delta, reduce='sum_along_second_axis'):
         self.delta = delta
+
+        if reduce not in ('sum_along_second_axis', 'no'):
+            raise ValueError(
+                "only 'sum_along_second_axis' and 'no' are valid "
+                "for 'reduce', but '%s' is given" % reduce)
+        self.reduce = reduce
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -26,17 +32,24 @@ class HuberLoss(function.Function):
         mask = y > (self.delta ** 2)
         y -= mask * xp.square(abs(self.diff) - self.delta)
         y *= 0.5
-        return y.sum(axis=1),
+        if self.reduce == 'sum_along_second_axis':
+            return y.sum(axis=1),
+        else:
+            return y,
 
     def backward(self, inputs, gy):
         xp = cuda.get_array_module(*inputs)
         mask = xp.abs(self.diff) <= self.delta
-        gx = gy[0].reshape(gy[0].shape + (1,) * (self.diff.ndim - 1)) * \
-            xp.where(mask, self.diff, self.delta * xp.sign(self.diff))
+
+        gx = xp.where(mask, self.diff, self.delta * xp.sign(self.diff))
+        gy_ = gy[0]
+        if self.reduce == 'sum_along_second_axis':
+            gy_ = gy_.reshape(gy[0].shape + (1,) * (self.diff.ndim - 1))
+        gx = gy_ * gx
         return gx, -gx
 
 
-def huber_loss(x, t, delta):
+def huber_loss(x, t, delta, reduce='sum_along_second_axis'):
     """Loss function which is less sensitive to outliers in data than MSE.
 
         .. math::
@@ -50,6 +63,11 @@ def huber_loss(x, t, delta):
             \\delta (|a| - \\frac{1}{2} \\delta) & {\\rm otherwise,}
             \\end{array} \\right.
 
+        The output is a varialbe whose value depends on the value of
+        the option ``reduce``. If it is ``'no'``, it holds the elementwise
+        loss values. If it is ``'sum_along_second_axis'``, loss values are
+        summed up along the second axis (i.e. ``axis=1``).
+
     Args:
         x (~chainer.Variable): Input variable.
             The shape of ``x`` should be (:math:`N`, :math:`K`).
@@ -57,13 +75,21 @@ def huber_loss(x, t, delta):
             The shape of ``t`` should be (:math:`N`, :math:`K`).
         delta (float): Constant variable for huber loss function
             as used in definition.
+        recude (str): Reduction option. Its value must be either
+            ``'sum_along_second_axis'`` or ``'no'``. Otherwise,
+            :class:`ValueError` is raised.
 
     Returns:
-        ~chainer.Variable: A variable object holding a scalar array of the
+        ~chainer.Variable:
+            A variable object holding a scalar array of the
             huber loss :math:`L_{\\delta}`.
+            If ``reduce`` is ``'no'``, the output varialbe holds array
+            whose shape is same as one of (hence both of) input variables.
+            If it is ``'sum_along_second_axis'``, the shape of the array
+            is same as the input variables, except the second axis is removed.
 
     See:
         `Huber loss - Wikipedia <https://en.wikipedia.org/wiki/Huber_loss>`_.
 
     """
-    return HuberLoss(delta=delta)(x, t)
+    return HuberLoss(delta=delta, reduce=reduce)(x, t)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
@@ -11,6 +11,10 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+@testing.parameterize(
+    {'reduce': 'no'},
+    {'reduce': 'sum_along_second_axis'}
+)
 class TestHuberLoss(unittest.TestCase):
 
     def setUp(self):
@@ -18,21 +22,26 @@ class TestHuberLoss(unittest.TestCase):
         self.x = (numpy.random.random(self.shape) - 0.5) * 20
         self.x = self.x.astype(numpy.float32)
         self.t = numpy.random.random(self.shape).astype(numpy.float32)
-        self.gy = numpy.random.random(self.shape[0]).astype(numpy.float32)
+        if self.reduce == 'sum_along_second_axis':
+            gy_shape = self.shape[0]
+        else:
+            gy_shape = self.shape
+        self.gy = numpy.random.random(gy_shape).astype(numpy.float32)
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
-        loss = functions.huber_loss(x, t, delta=1)
+        loss = functions.huber_loss(x, t, delta=1, reduce=self.reduce)
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = cuda.to_cpu(loss.data)
 
         diff_data = cuda.to_cpu(x_data) - cuda.to_cpu(t_data)
-        expected_result = numpy.zeros(self.shape)
+        loss_expect = numpy.zeros(self.shape)
         mask = numpy.abs(diff_data) < 1
-        expected_result[mask] = 0.5 * diff_data[mask] ** 2
-        expected_result[~mask] = numpy.abs(diff_data[~mask]) - 0.5
-        loss_expect = numpy.sum(expected_result, axis=1)
+        loss_expect[mask] = 0.5 * diff_data[mask] ** 2
+        loss_expect[~mask] = numpy.abs(diff_data[~mask]) - 0.5
+        if self.reduce == 'sum_along_second_axis':
+            loss_expect = numpy.sum(loss_expect, axis=1)
         testing.assert_allclose(loss_value, loss_expect)
 
     @condition.retry(3)
@@ -46,7 +55,7 @@ class TestHuberLoss(unittest.TestCase):
 
     def check_backward(self, x_data, t_data, y_grad):
         gradient_check.check_backward(
-            functions.HuberLoss(delta=1),
+            functions.HuberLoss(delta=1, reduce=self.reduce),
             (x_data, t_data), y_grad, eps=1e-2, atol=1e-3)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
@@ -69,4 +69,24 @@ class TestHuberLoss(unittest.TestCase):
                             cuda.to_gpu(self.gy))
 
 
+class TestHuberLossInvalidReductionOption(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (4, 10)).astype(numpy.float32)
+        self.t = numpy.random.uniform(-1, 1, (4, 10)).astype(numpy.float32)
+
+    def check_invalid_option(self, xp):
+        x = xp.asarray(self.x)
+        t = xp.asarray(self.t)
+        with self.assertRaises(ValueError):
+            functions.huber_loss(x, t, 1, 'invalid_option')
+
+    def test_invalid_option_cpu(self):
+        self.check_invalid_option(numpy)
+
+    @attr.gpu
+    def test_invalid_option_gpu(self):
+        self.check_invalid_option(cuda.cupy)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
@@ -11,10 +11,6 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
-@testing.parameterize(
-    {'reduce': 'no'},
-    {'reduce': 'sum_along_second_axis'}
-)
 class TestHuberLoss(unittest.TestCase):
 
     def setUp(self):
@@ -22,16 +18,12 @@ class TestHuberLoss(unittest.TestCase):
         self.x = (numpy.random.random(self.shape) - 0.5) * 20
         self.x = self.x.astype(numpy.float32)
         self.t = numpy.random.random(self.shape).astype(numpy.float32)
-        if self.reduce == 'sum_along_second_axis':
-            gy_shape = self.shape[0]
-        else:
-            gy_shape = self.shape
-        self.gy = numpy.random.random(gy_shape).astype(numpy.float32)
+        self.gy = numpy.random.random(self.shape).astype(numpy.float32)
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
-        loss = functions.huber_loss(x, t, delta=1, reduce=self.reduce)
+        loss = functions.huber_loss(x, t, delta=1)
         self.assertEqual(loss.data.dtype, numpy.float32)
         loss_value = cuda.to_cpu(loss.data)
 
@@ -40,8 +32,6 @@ class TestHuberLoss(unittest.TestCase):
         mask = numpy.abs(diff_data) < 1
         loss_expect[mask] = 0.5 * diff_data[mask] ** 2
         loss_expect[~mask] = numpy.abs(diff_data[~mask]) - 0.5
-        if self.reduce == 'sum_along_second_axis':
-            loss_expect = numpy.sum(loss_expect, axis=1)
         testing.assert_allclose(loss_value, loss_expect)
 
     @condition.retry(3)
@@ -55,7 +45,7 @@ class TestHuberLoss(unittest.TestCase):
 
     def check_backward(self, x_data, t_data, y_grad):
         gradient_check.check_backward(
-            functions.HuberLoss(delta=1, reduce=self.reduce),
+            functions.HuberLoss(delta=1),
             (x_data, t_data), y_grad, eps=1e-2, atol=1e-3)
 
     @condition.retry(3)
@@ -67,26 +57,6 @@ class TestHuberLoss(unittest.TestCase):
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t),
                             cuda.to_gpu(self.gy))
-
-
-class TestHuberLossInvalidReductionOption(unittest.TestCase):
-
-    def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (4, 10)).astype(numpy.float32)
-        self.t = numpy.random.uniform(-1, 1, (4, 10)).astype(numpy.float32)
-
-    def check_invalid_option(self, xp):
-        x = xp.asarray(self.x)
-        t = xp.asarray(self.t)
-        with self.assertRaises(ValueError):
-            functions.huber_loss(x, t, 1, 'invalid_option')
-
-    def test_invalid_option_cpu(self):
-        self.check_invalid_option(numpy)
-
-    @attr.gpu
-    def test_invalid_option_gpu(self):
-        self.check_invalid_option(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR removes reduce option from `F.huber_loss` and `F.HuberLoss`. Different from v1, they output sample wise loss values in v2. Related to #2558 #2560