### PR TITLE
remove redundant parentheses in link.py

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -30,7 +30,7 @@ def _is_shape(value):
 def _ensure_shape_dtype(value):
     # Return value paired with dtype FP32 if it is a shape.
     if _is_shape(value):
-        return (value, 'f')
+        return value, 'f'
     # Otherwise, returns it with assuming a shape-dtype pair.
     else:
         return value


### PR DESCRIPTION
This PR remove redundant parentheses in link.py