### PR TITLE
Add observe_value and observe_lr to extension.rst

### DIFF
--- a/docs/source/reference/extensions.rst
+++ b/docs/source/reference/extensions.rst
@@ -29,6 +29,14 @@ LogReport
 .. autoclass:: LogReport
    :members:
 
+observe_lr
+----------
+.. autofunction:: observe_lr
+
+observe_value
+-------------
+.. autofunction:: observe_value
+
 snapshot
 --------
 .. autofunction:: snapshot


### PR DESCRIPTION
Somehow both `observe_value` and `observe_lr` are missing from the documentation. Those are useful, so should be added.