### PR TITLE
Treat numpy scalars correctly in cupy.ndarray.fill	

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -368,7 +368,7 @@ cdef class ndarray:
 
         """
         if isinstance(value, numpy.ndarray):
-            if value.size != 1:
+            if value.shape != ():
                 raise ValueError(
                     'non-scalar numpy.ndarray cannot be used for fill')
             value = value.item()

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -367,6 +367,12 @@ cdef class ndarray:
         .. seealso:: :meth:`numpy.ndarray.fill`
 
         """
+        if isinstance(value, numpy.ndarray):
+            if value.size != 1:
+                raise ValueError(
+                    'non-scalar numpy.ndarray cannot be used for fill')
+            value = value.item()
+
         if value == 0 and self._c_contiguous:
             self.data.memset_async(0, self.nbytes, stream.Stream(True))
         else:

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -44,6 +44,13 @@ class TestArrayCopyAndView(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_fill_with_numpy_ndarray(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        a.fill(numpy.ones((), dtype=dtype))
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_transposed_fill(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = a.transpose(2, 0, 1)

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -44,10 +44,16 @@ class TestArrayCopyAndView(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_fill_with_numpy_ndarray(self, xp, dtype):
+    def test_fill_with_numpy_scalar_ndarray(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         a.fill(numpy.ones((), dtype=dtype))
         return a
+
+    @testing.for_all_dtypes()
+    def test_fill_with_numpy_nonscalar_ndarray(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        with self.assertRaises(ValueError):
+            a.fill(numpy.ones((1,), dtype=dtype))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
This PR allows to fill `cupy.ndarray` with a numpy scalar: 

```python
x = cupy.ndarray((2, 3, 4))
x.fill(numpy.array([42]))
```
```python
x = cupy.ndarray((2, 3, 4))
x[...] = numpy.array([42])
```

Additionally, the error message is improved when a non-scalar `numpy.ndarray` is passed to `cupy.ndarray.fill`.
