### PR TITLE
Remove TOC from examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,10 +3,6 @@ Chainer Examples
 
 This page contains a list of example codes written with Chainer.
 
-- [Natural Language Processing](#natual-language-processing)
-- [Image Classification](#image-classification)
-- [Generative Models](#generative-models)
-
 ### <a name="natual-language-processing"></a> Natural Language Processing
 
 * [Recurrent Net Language Model](https://github.com/pfnet/chainer/tree/master/examples/ptb)


### PR DESCRIPTION
Table of contents in this short list is rather confusing.
Maybe we can get it back when the list grows longer.