### PR TITLE
Revert to_gpu behaivor of links and variable

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -216,7 +216,10 @@ def get_device(*args):
     """
     warnings.warn('get_device is deprecated. Please use get_device_from_id or'
                   ' get_device_from_array instead.', DeprecationWarning)
+    return _get_device(*args)
 
+
+def _get_device(*args):
     for arg in args:
         if type(arg) in _integer_types:
             check_cuda_available()
@@ -253,11 +256,7 @@ def to_gpu(array, device=None, stream=None):
 
     """
     check_cuda_available()
-    if type(device) in _integer_types:
-        device = get_device_from_id(device)
-    elif device is None:
-        device = DummyDevice
-    with device:
+    with _get_device(device):
         array_dev = get_device_from_array(array)
         if array_dev.id == cupy.cuda.device.get_device_id():
             return array

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -326,7 +326,7 @@ class Link(object):
         if not self._cpu:
             return self
         d = self.__dict__
-        with cuda.get_device_from_id(device):
+        with cuda._get_device(device):
             for name in self._params:
                 d[name].to_gpu()
             for name in self._persistent:
@@ -620,7 +620,7 @@ class Chain(Link):
         return self
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device):
+        with cuda._get_device(device):
             super(Chain, self).to_gpu()
             d = self.__dict__
             for name in self._children:
@@ -774,7 +774,7 @@ class ChainList(Link):
         return self
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device):
+        with cuda._get_device(device):
             super(ChainList, self).to_gpu()
             for link in self._children:
                 link.to_gpu()

--- a/chainer/links/loss/black_out.py
+++ b/chainer/links/loss/black_out.py
@@ -35,7 +35,7 @@ class BlackOut(link.Link):
         self.sampler.to_cpu()
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device):
+        with cuda._get_device(device):
             super(BlackOut, self).to_gpu()
             self.sampler.to_gpu()
 

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -112,7 +112,7 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
         )
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device):
+        with cuda._get_device(device):
             self.paths = cuda.to_gpu(self.paths)
             self.codes = cuda.to_gpu(self.codes)
             self.begins = cuda.to_gpu(self.begins)
@@ -301,7 +301,7 @@ class BinaryHierarchicalSoftmax(link.Link):
         self.W.data[...] = numpy.random.uniform(-1, 1, self.W.shape)
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device):
+        with cuda._get_device(device):
             super(BinaryHierarchicalSoftmax, self).to_gpu(device)
             self._func.to_gpu(device)
 

--- a/chainer/links/loss/negative_sampling.py
+++ b/chainer/links/loss/negative_sampling.py
@@ -43,7 +43,7 @@ class NegativeSampling(link.Link):
         self.sampler.to_cpu()
 
     def to_gpu(self, device=None):
-        with cuda.get_device_from_id(device):
+        with cuda._get_device(device):
             super(NegativeSampling, self).to_gpu()
             self.sampler.to_gpu()
 


### PR DESCRIPTION
To revert `to_gpu` behavior I added `_get_device` method that works as the original `get_device` and fixed Variable and links to use it.