### PR TITLE
Add strict option to load_npz and load_hdf5

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -84,7 +84,7 @@ class HDF5Deserializer(serializer.Deserializer):
         group (h5py.Group): The group that the deserialization starts from.
         strict (bool): If ``True``, the deserializer raises an error when an
             expected value is not found in the given HDF5 file. Otherwise,
-            it ignores the value and skip deserialization.
+            it ignores the value and skips deserialization.
 
     """
 
@@ -124,7 +124,7 @@ class HDF5Deserializer(serializer.Deserializer):
         return value
 
 
-def load_hdf5(filename, obj):
+def load_hdf5(filename, obj, strict=True):
     """Loads an object from the file in HDF5 format.
 
     This is a short-cut function to load from an HDF5 file that contains only
@@ -135,9 +135,12 @@ def load_hdf5(filename, obj):
     Args:
         filename (str): Name of the file to be loaded.
         obj: Object to be deserialized. It must support serialization protocol.
+        strict (bool): If ``True``, the deserializer raises an error when an
+            expected value is not found in the given NPZ file. Otherwise,
+            it ignores the value and skips deserialization.
 
     """
     _check_available()
     with h5py.File(filename, 'r') as f:
-        d = HDF5Deserializer(f)
+        d = HDF5Deserializer(f, strict=strict)
         d.load(obj)

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -84,7 +84,7 @@ class NpzDeserializer(serializer.Deserializer):
         path: The base path that the deserialization starts from.
         strict (bool): If ``True``, the deserializer raises an error when an
             expected value is not found in the given NPZ file. Otherwise,
-            it ignores the value and skip deserialization.
+            it ignores the value and skips deserialization.
 
     """
 
@@ -115,7 +115,7 @@ class NpzDeserializer(serializer.Deserializer):
         return value
 
 
-def load_npz(filename, obj):
+def load_npz(filename, obj, strict=True):
     """Loads an object from the file in NPZ format.
 
     This is a short-cut function to load from an `.npz` file that contains only
@@ -124,8 +124,11 @@ def load_npz(filename, obj):
     Args:
         filename (str): Name of the file to be loaded.
         obj: Object to be deserialized. It must support serialization protocol.
+        strict (bool): If ``True``, the deserializer raises an error when an
+            expected value is not found in the given NPZ file. Otherwise,
+            it ignores the value and skips deserialization.
 
     """
     with numpy.load(filename) as f:
-        d = NpzDeserializer(f)
+        d = NpzDeserializer(f, strict=strict)
         d.load(obj)


### PR DESCRIPTION
I think `load_xxx` also needs `strict` option.