### PR TITLE
Revert "Fix docstring"

### DIFF
--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -176,7 +176,9 @@ class GoogLeNet(link.Chain):
         npz.save_npz(path_npz, chainermodel, compression=False)
 
     def __call__(self, x, layers=['prob'], **kwargs):
-        """Computes all the feature maps specified by ``layers``.
+        """__call__(self, x, layers=['prob'])
+
+        Computes all the feature maps specified by ``layers``.
 
         .. warning::
 


### PR DESCRIPTION
This is my mistake, I incorrectly "fix"ed the docstring at commit 24a2884eed1307f874470a53d8d5bc4f33a26079, without understanding the intent.

This PR reverts the commit.