### PR TITLE
Make Hyperparameter copyable in Py3.6

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -57,6 +57,8 @@ class Hyperparameter(object):
         self._parent = parent
 
     def __getattr__(self, name):
+        if '_parent' not in self.__dict__:
+            raise AttributeError('_parent is not set up yet')
         return getattr(self._parent, name)
 
     def __repr__(self):
@@ -64,6 +66,11 @@ class Hyperparameter(object):
         keys = sorted(d.keys())
         values_repr = ', '.join('%s=%s' % (k, d[k]) for k in keys)
         return 'Hyperparameter(%s)' % values_repr
+
+    @property
+    def parent(self):
+        """Parent hyperparmaeter object."""
+        return self._parent
 
     def get_dict(self):
         """Converts the hyperparameter into a dictionary.

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 import mock
@@ -42,6 +43,12 @@ class TestHyperparameter(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(repr(self.parent), 'Hyperparameter(x=1, y=2)')
         self.assertEqual(repr(self.child), 'Hyperparameter(x=1, y=3, z=4)')
+
+    def test_deep_copy(self):
+        parent_copy, child_copy = copy.deepcopy([self.parent, self.child])
+        self.assertEqual(self.child.get_dict(), child_copy.get_dict())
+        self.assertEqual(self.parent.get_dict(), parent_copy.get_dict())
+        self.assertIs(child_copy.parent, parent_copy)
 
 
 class TestUpdateRule(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a bug of Hyperparameter on deep copy (or, strictly speaking, on unpickling).