### PR TITLE
Add contribution guidelines under .github

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,265 @@
+Chainer Contribution Guide
+==========================
+
+This is a guide for all contributions to Chainer.
+The development of Chainer is running on `the official repository at GitHub <https://github.com/pfnet/chainer>`_.
+Anyone that wants to register an issue or to send a pull request should read through this document.
+
+Classification of Contributions
+-------------------------------
+
+There are several ways to contribute to Chainer community:
+
+1. Registering an issue
+2. Sending a pull request (PR)
+3. Sending a question to `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_
+4. Open-sourcing an external example
+5. Writing a post about Chainer
+
+This document mainly focuses on 1 and 2, though other contributions are also appreciated.
+
+Release and Milestone
+---------------------
+
+We are using `GitHub Flow <http://scottchacon.com/2011/08/31/github-flow.html>`_ as our basic working process.
+In particular, we are using the master branch for our development, and releases are made as tags.
+
+Releases are classified into three groups: major, minor, and revision.
+This classification is based on following criteria:
+
+- **Major update** contains disruptive changes that break the backward compatibility.
+- **Minor update** contains additions and extensions to the APIs keeping the supported backward compatibility.
+- **Revision update** contains improvements on the API implementations without changing any API specification.
+
+The release classification is reflected into the version number x.y.z, where x, y, and z corresponds to major, minor, and revision updates, respectively.
+
+We set a milestone for an upcoming release.
+The milestone is of name 'vX.Y.Z', where the version number represents a revision release at the outset.
+If at least one *feature* PR is merged in the period, we rename the milestone to represent a minor release (see the next section for the PR types).
+
+See also :doc:`compatibility`.
+
+Issues and PRs
+--------------
+
+Issues and PRs are classified into following categories:
+
+* **Bug**: bug reports (issues) and bug fixes (PRs)
+* **Enhancement**: implementation improvements without breaking the interface
+* **Feature**: feature requests (issues) and their implementations (PRs)
+* **NoCompat**: disrupts backward compatibility
+* **Test**: test fixes and updates
+* **Document**: document fixes and improvements
+* **Example**: fixes and improvements on the examples
+* **Install**: fixes installation script
+* **Contribution-Welcome**: issues that we request for contribution (only issues are categorized to this)
+* **Other**: other issues and PRs
+
+Issues and PRs are labeled by these categories.
+This classification is often reflected into its corresponding release category: Feature issues/PRs are contained into minor/major releases and NoCompat issues/PRs are contained into major releases, while other issues/PRs can be contained into any releases including revision ones.
+
+On registering an issue, write precise explanations on what you want Chainer to be.
+Bug reports must include necessary and sufficient conditions to reproduce the bugs.
+Feature requests must include **what** you want to do (and **why** you want to do, if needed).
+You can contain your thoughts on **how** to realize it into the feature requests, though **what** part is most important for discussions.
+
+.. warning::
+
+   If you have a question on usages of Chainer, it is highly recommended to send a post to `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_ instead of the issue tracker.
+   The issue tracker is not a place to share knowledge on practices.
+   We may redirect question issues to Chainer User Group.
+
+If you can write code to fix an issue, send a PR to the master branch.
+Before writing your code for PRs, read through the :ref:`coding-guide`.
+The description of any PR must contain a precise explanation of **what** and **how** you want to do; it is the first documentation of your code for developers, a very important part of your PR.
+
+Once you send a PR, it is automatically tested on `Travis CI <https://travis-ci.org/pfnet/chainer/>`_ for Linux and Mac OS X, and on `AppVeyor <https://ci.appveyor.com/project/pfnet/chainer>`_ for Windows.
+Your PR need to pass at least the test for Linux on Travis CI.
+After the automatic test passes, some of the core developers will start reviewing your code.
+Note that this automatic PR test only includes CPU tests.
+
+.. note::
+
+   We are also running continuous integration with GPU tests for the master branch.
+   Since this service is running on our internal server, we do not use it for automatic PR tests to keep the server secure.
+
+
+Even if your code is not complete, you can send a pull request as a *work-in-progress PR* by putting the ``[WIP]`` prefix to the PR title.
+If you write a precise explanation about the PR, core developers and other contributors can join the discussion about how to proceed the PR.
+
+.. _coding-guide:
+
+Coding Guidelines
+-----------------
+
+We use `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ and a part of `OpenStack Style Guidelines <http://docs.openstack.org/developer/hacking/>`_ related to general coding style as our basic style guidelines.
+
+To check your code, use ``autopep8`` and ``flake8`` command installed by ``hacking`` package::
+
+  $ pip install autopep8 hacking
+  $ autopep8 --global-config .pep8 path/to/your/code.py
+  $ flake8 path/to/your/code.py
+
+To check Cython code, use ``.flake8.cython`` configuration file::
+
+  $ flake8 --config=.flake8.cython path/to/your/cython/code.pyx
+
+The ``autopep8`` supports automatically correct Python code to conform to the PEP 8 style guide::
+
+  $ autopep8 --in-place --global-config .pep8 path/to/your/code.py
+
+The ``flake8`` command lets you know the part of your code not obeying our style guidelines.
+Before sending a pull request, be sure to check that your code passes the ``flake8`` checking.
+
+Note that ``flake8`` command is not perfect.
+It does not check some of the style guidelines.
+Here is a (not-complete) list of the rules that ``flake8`` cannot check.
+
+* Relative imports are prohibited. [H304]
+* Importing non-module symbols is prohibited.
+* Import statements must be organized into three parts: standard libraries, third-party libraries, and internal imports. [H306]
+
+In addition, we restrict the usage of *shortcut symbols* in our code base.
+They are symbols imported by packages and sub-packages of ``chainer``.
+For example, ``chainer.Variable`` is a shortcut of ``chainer.variable.Variable``.
+**It is not allowed to use such shortcuts in the ``chainer`` library implementation**.
+Note that you can still use them in ``tests`` and ``examples`` directories.
+Also note that you should use shortcut names of CuPy APIs in Chainer implementation.
+
+Once you send a pull request, your coding style is automatically checked by `Travis-CI <https://travis-ci.org/pfnet/chainer/>`_.
+The reviewing process starts after the check passes.
+
+The CuPy is designed based on NumPy's API design. CuPy's source code and documents contain the original NumPy ones.
+Please note the followings when writing the document.
+
+* In order to identify overlapping parts, it is preferable to add some remarks
+  that this document is just copied or altered from the original one. It is
+  also preferable to briefly explain the specification of the function in a
+  short paragraph, and refer to the corresponding function in NumPy so that
+  users can read the detailed document. However, it is possible to include a
+  complete copy of the document with such a remark if users cannot summarize
+  in such a way.
+* If a function in CuPy only implements a limited amount of features in the
+  original one, users should explicitly describe only what is implemented in
+  the document.
+
+
+Testing Guidelines
+------------------
+
+Testing is one of the most important part of your code.
+You must test your code by unit tests following our testing guidelines.
+Note that we are using the nose package and the mock package for testing, so install nose and mock before writing your code::
+
+  $ pip install nose mock
+
+In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
+
+  $ python setup.py develop
+
+Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
+
+  $ nosetests
+
+It requires CUDA by default.
+In order to run unit tests that do not require CUDA, pass ``--attr='!gpu'`` option to the ``nosetests`` command::
+
+  $ nosetests path/to/your/test.py --attr='!gpu'
+
+Some GPU tests involve multiple GPUs.
+If you want to run GPU tests with insufficient number of GPUs, specify the number of available GPUs by ``--eval-attr='gpu<N'`` where ``N`` is a concrete integer.
+For example, if you have only one GPU, launch ``nosetests`` by the following command to skip multi-GPU tests::
+
+  $ nosetests path/to/gpu/test.py --eval-attr='gpu<2'
+
+Some tests spend too much time.
+If you want to skip such tests, pass ``--attr='!slow'`` option to the ``nosetests`` command::
+
+  $ nosetests path/to/your/test.py --attr='!slow'
+
+Tests are put into the ``tests/chainer_tests``, ``tests/cupy_tests`` and ``tests/install_tests`` directories.
+These have the same structure as that of ``chainer``, ``cupy`` and ``install`` directories, respectively.
+In order to enable test runner to find test scripts correctly, we are using special naming convention for the test subdirectories and the test scripts.
+
+* The name of each subdirectory of ``tests`` must end with the ``_tests`` suffix.
+* The name of each test script must start with the ``test_`` prefix.
+
+Following this naming convention, you can run all the tests by just typing ``nosetests`` at the repository root::
+
+  $ nosetests
+
+Or you can also specify a root directory to search test scripts from::
+
+  $ nosetests tests/chainer_tests  # to just run tests of Chainer
+  $ nosetests tests/cupy_tests     # to just run tests of CuPy
+  $ nosetests tests/install_tests  # to just run tests of installation modules
+
+If you modify the code related to existing unit tests, you must run appropriate commands.
+
+.. note::
+   CuPy tests include type-exhaustive test functions which take long time to execute.
+   If you are running tests on a multi-core machine, you can parallelize the tests by following options::
+
+     $ nosetests --processes=12 --process-timeout=1000 tests/cupy_tests
+
+   The magic numbers can be modified for your usage.
+   Note that some tests require many CUDA compilations, which require a bit long time.
+   Without the ``process-timeout`` option, the timeout is set shorter, causing timeout failures for many test cases.
+
+There are many examples of unit tests under the ``tests`` directory.
+They simply use the ``unittest`` package of the standard library.
+
+Even if your patch includes GPU-related code, your tests should not fail without GPU capability.
+Test functions that require CUDA must be tagged by the ``chainer.testing.attr.gpu`` decorator (or ``cupy.testing.attr.gpu`` for testing CuPy APIs)::
+
+  import unittest
+  from chainer.testing import attr
+
+  class TestMyFunc(unittest.TestCase):
+      ...
+
+      @attr.gpu
+      def test_my_gpu_func(self):
+          ...
+
+The functions tagged by the ``gpu`` decorator are skipped if ``--attr='!gpu'`` is given.
+We also have the ``chainer.testing.attr.cudnn`` decorator to let ``nosetests`` know that the test depends on cuDNN.
+
+The test functions decorated by ``gpu`` must not depend on multiple GPUs.
+In order to write tests for multiple GPUs, use ``chainer.testing.attr.multi_gpu()`` or ``cupy.testing.attr.multi_gpu()`` decorators instead::
+
+  import unittest
+  from chainer.testing import attr
+
+  class TestMyFunc(unittest.TestCase):
+      ...
+
+      @attr.multi_gpu(2)  # specify the number of required GPUs here
+      def test_my_two_gpu_func(self):
+          ...
+
+If your test requires too much time, add ``chainer.testing.attr.slow`` decorator.
+The test functions decorated by ``slow`` are skipped if ``--attr='!slow'`` is given::
+
+  import unittest
+  from chainer.testing import attr
+
+  class TestMyFunc(unittest.TestCase):
+      ...
+
+      @attr.slow
+      def test_my_slow_func(self):
+          ...
+
+.. note::
+   If you want to specify more than two attributes, separate them with a comma such as ``--attr='!gpu,!slow'``.
+   See detail in `the document of nose <https://nose.readthedocs.io/en/latest/plugins/attrib.html#simple-syntax>`_.
+
+Once you send a pull request, your code is automatically tested by `Travis-CI <https://travis-ci.org/pfnet/chainer/>`_ **with --attr='!gpu,!slow' option**.
+Since Travis-CI does not support CUDA, we cannot check your CUDA-related code automatically.
+The reviewing process starts after the test passes.
+Note that reviewers will test your code without the option to check CUDA-related code.
+
+.. note::
+   Some of numerically unstable tests might cause errors irrelevant to your changes.
+   In such a case, we ignore the failures and go on to the review process, so do not worry about it.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,6 @@ Chainer Contribution Guide
 ==========================
 
 This is a guide for all contributions to Chainer.
-The development of Chainer is running on `the official repository at GitHub <https://github.com/pfnet/chainer>`_.
 Anyone that wants to register an issue or to send a pull request should read through this document.
 
 Classification of Contributions
@@ -12,7 +11,7 @@ There are several ways to contribute to Chainer community:
 
 1. Registering an issue
 2. Sending a pull request (PR)
-3. Sending a question to `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_
+3. Sending a question to [Chainer User Group](https://groups.google.com/forum/#!forum/chainer)
 4. Open-sourcing an external example
 5. Writing a post about Chainer
 
@@ -21,7 +20,7 @@ This document mainly focuses on 1 and 2, though other contributions are also app
 Release and Milestone
 ---------------------
 
-We are using `GitHub Flow <http://scottchacon.com/2011/08/31/github-flow.html>`_ as our basic working process.
+We are using [GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html) as our basic working process.
 In particular, we are using the master branch for our development, and releases are made as tags.
 
 Releases are classified into three groups: major, minor, and revision.
@@ -37,7 +36,7 @@ We set a milestone for an upcoming release.
 The milestone is of name 'vX.Y.Z', where the version number represents a revision release at the outset.
 If at least one *feature* PR is merged in the period, we rename the milestone to represent a minor release (see the next section for the PR types).
 
-See also :doc:`compatibility`.
+See also [API Compatibility Policy](http://docs.chainer.org/en/stable/compatibility.html).
 
 Issues and PRs
 --------------
@@ -63,50 +62,54 @@ Bug reports must include necessary and sufficient conditions to reproduce the bu
 Feature requests must include **what** you want to do (and **why** you want to do, if needed).
 You can contain your thoughts on **how** to realize it into the feature requests, though **what** part is most important for discussions.
 
-.. warning::
+**Warning**:
 
-   If you have a question on usages of Chainer, it is highly recommended to send a post to `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_ instead of the issue tracker.
-   The issue tracker is not a place to share knowledge on practices.
-   We may redirect question issues to Chainer User Group.
+> If you have a question on usages of Chainer, it is highly recommended to send a post to [Chainer User Group](https://groups.google.com/forum/#!forum/chainer) instead of the issue tracker.
+> The issue tracker is not a place to share knowledge on practices.
+> We may redirect question issues to Chainer User Group.
 
 If you can write code to fix an issue, send a PR to the master branch.
 Before writing your code for PRs, read through the :ref:`coding-guide`.
 The description of any PR must contain a precise explanation of **what** and **how** you want to do; it is the first documentation of your code for developers, a very important part of your PR.
 
-Once you send a PR, it is automatically tested on `Travis CI <https://travis-ci.org/pfnet/chainer/>`_ for Linux and Mac OS X, and on `AppVeyor <https://ci.appveyor.com/project/pfnet/chainer>`_ for Windows.
+Once you send a PR, it is automatically tested on [Travis CI](https://travis-ci.org/pfnet/chainer/) for Linux and Mac OS X, and on [AppVeyor](https://ci.appveyor.com/project/pfnet/chainer) for Windows.
 Your PR need to pass at least the test for Linux on Travis CI.
 After the automatic test passes, some of the core developers will start reviewing your code.
 Note that this automatic PR test only includes CPU tests.
 
-.. note::
+**Note**:
 
-   We are also running continuous integration with GPU tests for the master branch.
-   Since this service is running on our internal server, we do not use it for automatic PR tests to keep the server secure.
+> We are also running continuous integration with GPU tests for the master branch.
+> Since this service is running on our internal server, we do not use it for automatic PR tests to keep the server secure.
 
 
 Even if your code is not complete, you can send a pull request as a *work-in-progress PR* by putting the ``[WIP]`` prefix to the PR title.
 If you write a precise explanation about the PR, core developers and other contributors can join the discussion about how to proceed the PR.
 
-.. _coding-guide:
-
 Coding Guidelines
 -----------------
 
-We use `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ and a part of `OpenStack Style Guidelines <http://docs.openstack.org/developer/hacking/>`_ related to general coding style as our basic style guidelines.
+We use [PEP8](https://www.python.org/dev/peps/pep-0008/) and a part of [OpenStack Style Guidelines](http://docs.openstack.org/developer/hacking/) related to general coding style as our basic style guidelines.
 
-To check your code, use ``autopep8`` and ``flake8`` command installed by ``hacking`` package::
+To check your code, use ``autopep8`` and ``flake8`` command installed by ``hacking`` package:
 
-  $ pip install autopep8 hacking
-  $ autopep8 --global-config .pep8 path/to/your/code.py
-  $ flake8 path/to/your/code.py
+```shell
+$ pip install autopep8 hacking
+$ autopep8 --global-config .pep8 path/to/your/code.py
+$ flake8 path/to/your/code.py
+```
 
-To check Cython code, use ``.flake8.cython`` configuration file::
+To check Cython code, use ``.flake8.cython`` configuration file:
 
-  $ flake8 --config=.flake8.cython path/to/your/cython/code.pyx
+```shell
+$ flake8 --config=.flake8.cython path/to/your/cython/code.pyx
+```
 
-The ``autopep8`` supports automatically correct Python code to conform to the PEP 8 style guide::
+The ``autopep8`` supports automatically correct Python code to conform to the PEP 8 style guide:
 
-  $ autopep8 --in-place --global-config .pep8 path/to/your/code.py
+```shell
+$ autopep8 --in-place --global-config .pep8 path/to/your/code.py
+```
 
 The ``flake8`` command lets you know the part of your code not obeying our style guidelines.
 Before sending a pull request, be sure to check that your code passes the ``flake8`` checking.
@@ -126,7 +129,7 @@ For example, ``chainer.Variable`` is a shortcut of ``chainer.variable.Variable``
 Note that you can still use them in ``tests`` and ``examples`` directories.
 Also note that you should use shortcut names of CuPy APIs in Chainer implementation.
 
-Once you send a pull request, your coding style is automatically checked by `Travis-CI <https://travis-ci.org/pfnet/chainer/>`_.
+Once you send a pull request, your coding style is automatically checked by [Travis-CI](https://travis-ci.org/pfnet/chainer/).
 The reviewing process starts after the check passes.
 
 The CuPy is designed based on NumPy's API design. CuPy's source code and documents contain the original NumPy ones.
@@ -149,33 +152,45 @@ Testing Guidelines
 
 Testing is one of the most important part of your code.
 You must test your code by unit tests following our testing guidelines.
-Note that we are using the nose package and the mock package for testing, so install nose and mock before writing your code::
+Note that we are using the nose package and the mock package for testing, so install nose and mock before writing your code:
 
-  $ pip install nose mock
+```shell
+$ pip install nose mock
+```
 
-In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
+In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command:
 
-  $ python setup.py develop
+```shell
+$ python setup.py develop
+```
 
-Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
+Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root:
 
-  $ nosetests
+```shell
+$ nosetests
+```
 
 It requires CUDA by default.
-In order to run unit tests that do not require CUDA, pass ``--attr='!gpu'`` option to the ``nosetests`` command::
+In order to run unit tests that do not require CUDA, pass ``--attr='!gpu'`` option to the ``nosetests`` command:
 
-  $ nosetests path/to/your/test.py --attr='!gpu'
+```shell
+$ nosetests path/to/your/test.py --attr='!gpu'
+```
 
 Some GPU tests involve multiple GPUs.
 If you want to run GPU tests with insufficient number of GPUs, specify the number of available GPUs by ``--eval-attr='gpu<N'`` where ``N`` is a concrete integer.
-For example, if you have only one GPU, launch ``nosetests`` by the following command to skip multi-GPU tests::
+For example, if you have only one GPU, launch ``nosetests`` by the following command to skip multi-GPU tests:
 
-  $ nosetests path/to/gpu/test.py --eval-attr='gpu<2'
+```shell
+$ nosetests path/to/gpu/test.py --eval-attr='gpu<2'
+```
 
 Some tests spend too much time.
-If you want to skip such tests, pass ``--attr='!slow'`` option to the ``nosetests`` command::
+If you want to skip such tests, pass ``--attr='!slow'`` option to the ``nosetests`` command:
 
-  $ nosetests path/to/your/test.py --attr='!slow'
+```shell
+$ nosetests path/to/your/test.py --attr='!slow'
+```
 
 Tests are put into the ``tests/chainer_tests``, ``tests/cupy_tests`` and ``tests/install_tests`` directories.
 These have the same structure as that of ``chainer``, ``cupy`` and ``install`` directories, respectively.
@@ -184,82 +199,98 @@ In order to enable test runner to find test scripts correctly, we are using spec
 * The name of each subdirectory of ``tests`` must end with the ``_tests`` suffix.
 * The name of each test script must start with the ``test_`` prefix.
 
-Following this naming convention, you can run all the tests by just typing ``nosetests`` at the repository root::
+Following this naming convention, you can run all the tests by just typing ``nosetests`` at the repository root:
 
-  $ nosetests
 
-Or you can also specify a root directory to search test scripts from::
+```shell
+$ nosetests
+```
 
-  $ nosetests tests/chainer_tests  # to just run tests of Chainer
-  $ nosetests tests/cupy_tests     # to just run tests of CuPy
-  $ nosetests tests/install_tests  # to just run tests of installation modules
+Or you can also specify a root directory to search test scripts from:
+
+```shell
+$ nosetests tests/chainer_tests  # to just run tests of Chainer
+$ nosetests tests/cupy_tests     # to just run tests of CuPy
+$ nosetests tests/install_tests  # to just run tests of installation modules
+```
 
 If you modify the code related to existing unit tests, you must run appropriate commands.
 
-.. note::
-   CuPy tests include type-exhaustive test functions which take long time to execute.
-   If you are running tests on a multi-core machine, you can parallelize the tests by following options::
+**Note**:
 
-     $ nosetests --processes=12 --process-timeout=1000 tests/cupy_tests
-
-   The magic numbers can be modified for your usage.
-   Note that some tests require many CUDA compilations, which require a bit long time.
-   Without the ``process-timeout`` option, the timeout is set shorter, causing timeout failures for many test cases.
+> CuPy tests include type-exhaustive test functions which take long time to execute.
+> If you are running tests on a multi-core machine, you can parallelize the tests by following options:
+>
+> ```shell
+> $ nosetests --processes=12 --process-timeout=1000 tests/cupy_tests
+> ```
+>
+> The magic numbers can be modified for your usage.
+> Note that some tests require many CUDA compilations, which require a bit long time.
+> Without the ``process-timeout`` option, the timeout is set shorter, causing timeout failures for many test cases.
 
 There are many examples of unit tests under the ``tests`` directory.
 They simply use the ``unittest`` package of the standard library.
 
 Even if your patch includes GPU-related code, your tests should not fail without GPU capability.
-Test functions that require CUDA must be tagged by the ``chainer.testing.attr.gpu`` decorator (or ``cupy.testing.attr.gpu`` for testing CuPy APIs)::
+Test functions that require CUDA must be tagged by the ``chainer.testing.attr.gpu`` decorator (or ``cupy.testing.attr.gpu`` for testing CuPy APIs):
 
-  import unittest
-  from chainer.testing import attr
+```python
+import unittest
+from chainer.testing import attr
 
-  class TestMyFunc(unittest.TestCase):
-      ...
+class TestMyFunc(unittest.TestCase):
+    ...
 
-      @attr.gpu
-      def test_my_gpu_func(self):
-          ...
+    @attr.gpu
+    def test_my_gpu_func(self):
+        ...
+```
 
 The functions tagged by the ``gpu`` decorator are skipped if ``--attr='!gpu'`` is given.
 We also have the ``chainer.testing.attr.cudnn`` decorator to let ``nosetests`` know that the test depends on cuDNN.
 
 The test functions decorated by ``gpu`` must not depend on multiple GPUs.
-In order to write tests for multiple GPUs, use ``chainer.testing.attr.multi_gpu()`` or ``cupy.testing.attr.multi_gpu()`` decorators instead::
+In order to write tests for multiple GPUs, use ``chainer.testing.attr.multi_gpu()`` or ``cupy.testing.attr.multi_gpu()`` decorators instead:
 
-  import unittest
-  from chainer.testing import attr
+```python
+import unittest
+from chainer.testing import attr
 
-  class TestMyFunc(unittest.TestCase):
-      ...
+class TestMyFunc(unittest.TestCase):
+    ...
 
-      @attr.multi_gpu(2)  # specify the number of required GPUs here
-      def test_my_two_gpu_func(self):
-          ...
+    @attr.multi_gpu(2)  # specify the number of required GPUs here
+    def test_my_two_gpu_func(self):
+        ...
+```
 
 If your test requires too much time, add ``chainer.testing.attr.slow`` decorator.
-The test functions decorated by ``slow`` are skipped if ``--attr='!slow'`` is given::
+The test functions decorated by ``slow`` are skipped if ``--attr='!slow'`` is given:
 
-  import unittest
-  from chainer.testing import attr
+```python
+import unittest
+from chainer.testing import attr
 
-  class TestMyFunc(unittest.TestCase):
-      ...
+class TestMyFunc(unittest.TestCase):
+    ...
 
-      @attr.slow
-      def test_my_slow_func(self):
-          ...
+    @attr.slow
+    def test_my_slow_func(self):
+        ...
+```
 
-.. note::
-   If you want to specify more than two attributes, separate them with a comma such as ``--attr='!gpu,!slow'``.
-   See detail in `the document of nose <https://nose.readthedocs.io/en/latest/plugins/attrib.html#simple-syntax>`_.
+**Note**:
 
-Once you send a pull request, your code is automatically tested by `Travis-CI <https://travis-ci.org/pfnet/chainer/>`_ **with --attr='!gpu,!slow' option**.
+> If you want to specify more than two attributes, separate them with a comma such as ``--attr='!gpu,!slow'``.
+> See detail in [the document of nose](https://nose.readthedocs.io/en/latest/plugins/attrib.html#simple-syntax).
+
+Once you send a pull request, your code is automatically tested by [Travis-CI](https://travis-ci.org/pfnet/chainer/) **with ``--attr='!gpu,!slow'`` option**.
 Since Travis-CI does not support CUDA, we cannot check your CUDA-related code automatically.
 The reviewing process starts after the test passes.
 Note that reviewers will test your code without the option to check CUDA-related code.
 
-.. note::
-   Some of numerically unstable tests might cause errors irrelevant to your changes.
-   In such a case, we ignore the failures and go on to the review process, so do not worry about it.
+**Note**:
+
+> Some of numerically unstable tests might cause errors irrelevant to your changes.
+> In such a case, we ignore the failures and go on to the review process, so do not worry about it.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+Please read this before submitting an issue.
+
+
+If your issue is a **request for support in using Chainer**,
+please post it on [Stack Overflow](https://stackoverflow.com/questions/tagged/chainer).
+
+If it is a **bug report**, **feature request** or **suggestion**,
+please take a look at [our contribution guide](https://github.com/pfnet/chainer/blob/master/.github/CONTRIBUTING.md#issues-and-prs).
+
+Specifically, if it is a bug report, these information are very helpful:
+
+* Conditions
+  - Chainer version
+  - CuPy version
+  - OS/Platform
+  - CUDA/cuDNN version
+  - etc.
+* Code to reproduce
+* Error messages, stack traces, or logs
+
+Thank you for your cooperation!
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Thank you for creating a pull request!
+
+Please double-check the following.
+
+- Read [our contribution guide](https://github.com/pfnet/chainer/blob/master/.github/CONTRIBUTING.md#issues-and-prs).
+  - Does you code conform to our coding guidelines?
+  - Did you write sufficient test code?
+  - Did you write sufficient documentation?
+- Also take a look at [our backward compatibility policy](http://docs.chainer.org/en/stable/compatibility.html).
+- We accept pull requests to ``dev`` branch, not ``master``. Check the base branch.

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -86,11 +86,11 @@ def softmax(x, axis=1):
     """Softmax function.
 
     This function computes its softmax along an axis. Let
-    :math:`x = (x_1, x_2, \\dots, x_d)^{\\top}` be the d dimensional index
-    array and :math:`f(x)` be the d dimensional input array. For each index
+    :math:`x = (x_1, x_2, \\dots, x_D)^{\\top}` be the D dimensional index
+    array and :math:`f(x)` be the D dimensional input array. For each index
     :math:`x` of the input array :math:`f(x)`, it computes the probability
     :math:`p(x)` defined as
-    :math:`p(x) = {\\exp(f(x)) \\over \\sum_{x_2} \\exp(f(x))}`.
+    :math:`p(x) = {\\exp(f(x)) \\over \\sum_{d} \\exp(f(x_d))}`.
 
     Args:
         x (~chainer.Variable): Input variable.

--- a/docs/source/tutorial/convnet.rst
+++ b/docs/source/tutorial/convnet.rst
@@ -15,7 +15,7 @@ After reading this section, you will be able to:
 A convolutional network (ConvNet) is mainly comprised of convolutional layers.
 This type of network is commonly used for various visual recognition tasks,
 e.g., classifying hand-written digits or natural images into given object
-classes, detectiong objects from an image, and labeling all pixels of an image
+classes, detecting objects from an image, and labeling all pixels of an image
 with the object classes (semantic segmenation), and so on.
 
 In such tasks, a typical ConvNet takes a set of images whose shape is

--- a/docs/source/tutorial/convnet.rst
+++ b/docs/source/tutorial/convnet.rst
@@ -196,7 +196,7 @@ wrapping the model object (:class:`~chainer.Chain` or
 model defined above and register it through the constructor of its superclass
 or :meth:`~chainer.Chain.add_link`. :class:`~chainer.Chain` is actually
 inherited from :class:`~chainer.Link`, so that :class:`~chainer.Chain` itself
-can also be registedred as a trainable :class:`~chainer.Link` to another
+can also be registered as a trainable :class:`~chainer.Link` to another
 :class:`~chainer.Chain`. Actually, :class:`~chainer.links.Classifier` class to
 wrap the model and add the loss computation to the model already exists.
 Actually, there is already a :class:`~chainer.links.Classifier` class that can

--- a/docs/source/tutorial/convnet.rst
+++ b/docs/source/tutorial/convnet.rst
@@ -16,7 +16,7 @@ A convolutional network (ConvNet) is mainly comprised of convolutional layers.
 This type of network is commonly used for various visual recognition tasks,
 e.g., classifying hand-written digits or natural images into given object
 classes, detecting objects from an image, and labeling all pixels of an image
-with the object classes (semantic segmenation), and so on.
+with the object classes (semantic segmentation), and so on.
 
 In such tasks, a typical ConvNet takes a set of images whose shape is
 :math:`(N, C, H, W)`, where


### PR DESCRIPTION
This PR is for #2750.

* [CONTRIBUTING.md](https://github.com/pfnet/chainer/blob/dot-github/.github/CONTRIBUTING.md)
* [ISSUE_TEMPLATE.md](https://github.com/pfnet/chainer/blob/dot-github/.github/ISSUE_TEMPLATE.md)
* [PULL_REQUEST_TEMPLATE.md](https://github.com/pfnet/chainer/blob/dot-github/.github/PULL_REQUEST_TEMPLATE.md)

`CONTRIBUTING.md` is simply copied from `docs/source/contribution.rst` and markups has been fixed for markdown.

See also: https://github.com/blog/1184-contributing-guidelines

Also added `ISSUE_TEMPLATE.md` and `PULL_REQUEST_TEMPLATE.md`.