### PR TITLE
Add L.StatelessGRU and change the implementation of L.GRU

### DIFF
--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -14,6 +14,7 @@ from chainer.links.connection.dilated_convolution_2d import DilatedConvolution2D
 from chainer.links.connection.embed_id import EmbedID  # NOQA
 from chainer.links.connection.gru import GRU  # NOQA
 from chainer.links.connection.gru import StatefulGRU  # NOQA
+from chainer.links.connection.gru import StatelessGRU  # NOQA
 from chainer.links.connection.highway import Highway  # NOQA
 from chainer.links.connection.inception import Inception  # NOQA
 from chainer.links.connection.inceptionbn import InceptionBN  # NOQA

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -213,9 +213,9 @@ class GRU(StatefulGRU):
         msg = ("Invalid argument. The length of GRU.__call__ must be 1. "
                "But %d is given. " % n_args)
 
-        if n_args == 0:
+        if n_args == 0 or n_args >= 3:
             raise ValueError(msg)
-        elif n_args >= 2:
+        elif n_args == 2:
             msg += ("In Chainer v2, chainer.links.GRU is changed "
                     "from stateless to stateful. "
                     "One possiblity is you assume GRU to be stateless. "

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -28,7 +28,7 @@ class GRUBase(link.Chain):
         )
 
 
-class GRU(GRUBase):
+class StatelessGRU(GRUBase):
 
     """Stateless Gated Recurrent Unit function (GRU).
 
@@ -177,3 +177,49 @@ class StatefulGRU(GRUBase):
             h_new = z * h_bar
         self.h = h_new
         return self.h
+
+
+class GRU(StatefulGRU):
+    """Stateful Gated Recurrent Unit function (GRU)
+
+    This is an alias of "~chainer.links.StatefulGRU".
+    Its documented API is identical to the function.
+
+    .. warning::
+
+       In Chainer v1, :class:`~chainer.links.GRU` was *stateless*,
+       as opposed to the current implementation.
+       To align with the naming convension of LSTM links, we have changed
+       the naming convension from Chainer v2 so that the shorthand name
+       points the stateful links.
+       You can use :class:`~chainer.links.StatelessGRU` for stateless version,
+       whose implementation is identical to ``chainer.linksGRU`` in v1.
+
+       See issue `#2537 <https://github.com/pfnet/chainer/issues/2537>_`
+       for detail.
+
+    .. seealso:: :class:`~chainer.links.GRU`
+
+    """
+
+    def __call__(self, *args):
+        """__call__(self, x)
+
+        Does forward propagation.
+
+        """
+
+        n_args = len(args)
+        msg = ("Invalid argument. The length of GRU.__call__ must be 1. "
+               "But %d is given. " % n_args)
+
+        if n_args == 0:
+            raise ValueError(msg)
+        elif n_args >= 2:
+            msg += ("In Chainer v2, chainer.links.GRU is changed "
+                    "from stateless to stateful. "
+                    "One possiblity is you assume GRU to be stateless. "
+                    "Use chainer.links.StatelessGRU instead.")
+            raise ValueError(msg)
+
+        return super(GRU, self).__call__(args[0])

--- a/tests/chainer_tests/links_tests/connection_tests/test_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_gru.py
@@ -27,25 +27,28 @@ def _gru(func, h, x):
 
 
 @testing.parameterize(
+    {'gru': links.StatelessGRU, 'state': 'random',
+     'in_size': 3, 'out_size': 5},
+    {'gru': links.StatelessGRU, 'state': 'random', 'out_size': 5},
     {'gru': links.GRU, 'state': 'random', 'in_size': 3, 'out_size': 5},
-    {'gru': links.GRU, 'state': 'random', 'out_size': 5},
+    {'gru': links.GRU, 'state': 'zero', 'in_size': 3, 'out_size': 5},
     {'gru': links.StatefulGRU, 'state': 'random', 'in_size': 3, 'out_size': 5},
     {'gru': links.StatefulGRU, 'state': 'zero', 'in_size': 3, 'out_size': 5},
 )
 class TestGRU(unittest.TestCase):
 
     def setUp(self):
-        if self.gru == links.GRU:
+        if self.gru == links.StatelessGRU:
             if hasattr(self, 'in_size'):
                 self.link = self.gru(self.in_size, self.out_size)
             else:
                 self.link = self.gru(None, self.out_size)
                 self.in_size = self.out_size
-        elif self.gru == links.StatefulGRU:
+        elif self.gru == links.StatefulGRU or self.gru == links.GRU:
             self.link = self.gru(self.in_size, self.out_size)
         else:
-            self.fail('Unsupported link(only GRU and StatefulGRU '
-                      'are supported):{}'.format(self.gru))
+            self.fail('Unsupported link(only GRU, StatelessGRU and '
+                      'StatefulGRU are supported):{}'.format(self.gru))
 
         self.x = numpy.random.uniform(
             -1, 1, (3, self.in_size)).astype(numpy.float32)
@@ -60,7 +63,7 @@ class TestGRU(unittest.TestCase):
             -1, 1, (3, self.out_size)).astype(numpy.float32)
 
     def _forward(self, link, h, x):
-        if isinstance(link, links.GRU):
+        if isinstance(link, links.StatelessGRU):
             return link(h, x)
         else:
             if self.state != 'zero':
@@ -99,7 +102,7 @@ class TestGRU(unittest.TestCase):
         gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
         testing.assert_allclose(gx, x.grad, atol=1e-3)
 
-        if isinstance(self.link, links.GRU):
+        if isinstance(self.link, links.StatelessGRU):
             gh, = gradient_check.numerical_grad(f, (h.data,), (y.grad,))
             testing.assert_allclose(gh, h.grad, atol=1e-3)
 
@@ -117,13 +120,14 @@ class TestGRU(unittest.TestCase):
 @testing.parameterize(
     *testing.product({
         'link_array_module': ['to_cpu', 'to_gpu'],
-        'state_array_module': ['to_cpu', 'to_gpu']
+        'state_array_module': ['to_cpu', 'to_gpu'],
+        'gru': [links.GRU, links.StatefulGRU]
     }))
 class TestGRUState(unittest.TestCase):
 
     def setUp(self):
         in_size, out_size = 10, 8
-        self.link = links.StatefulGRU(in_size, out_size)
+        self.link = self.gru(in_size, out_size)
         self.h = chainer.Variable(
             numpy.random.uniform(-1, 1, (3, out_size)).astype(numpy.float32))
 
@@ -153,6 +157,10 @@ class TestGRUState(unittest.TestCase):
         self.check_reset_state()
 
 
+@testing.parameterize(
+    {'gru': links.GRU},
+    {'gru': links.StatefulGRU}
+)
 class TestGRUToCPUToGPU(unittest.TestCase):
 
     def setUp(self):
@@ -196,5 +204,27 @@ class TestGRUToCPUToGPU(unittest.TestCase):
         self.h.to_gpu()
         self.check_to_cpu_to_gpu(self.h)
 
+
+class InvalidCallOfGRU(unittest.TestCase):
+
+    def setUp(self):
+        self.gru = links.GRU(10, 10)
+
+    def test_no_argument(self):
+        with self.assertRaises(ValueError):
+            self.gru()
+
+    def test_too_many_argument_1(self):
+        x = numpy.random.uniform(-1, 1, (5, 10))
+        h = numpy.random.uniform(-1, 1, (5, 10))
+        with self.assertRaises(ValueError):
+            self.gru(x, h)
+
+    def test_too_many_argument_2(self):
+        x = numpy.random.uniform(-1, 1, (5, 10))
+        h = numpy.random.uniform(-1, 1, (5, 10))
+        z = numpy.random.uniform(-1, 1, (5, 10))
+        with self.assertRaises(ValueError):
+            self.gru(x, h, z)
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds `L.StatelessGRU` and change `L.GRU` from stateless to stateful as proposed in #2537.

As the semantics of `L.GRU` is changed, this change breaks users' code. To notify users the change, we determine which API (v1/v2) users assume by the number of argument passed to `__call__` and invalidate the former one.

TODO: Add this change to the upgrade guide #2741.