### PR TITLE
Update API Compatibility Policy

### DIFF
--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -28,7 +28,7 @@ See :ref:`contrib` for details of versioning.
 
 The backward compatibility is kept for **revision updates**, which are applied to the latest stable version.
 A **major update** from the latest release candidate basically keeps the backward compatibility, although it is not guaranteed.
-Any **pre-releases** may break the bakward compatibility.
+Any **pre-releases** may break the backward compatibility.
 
 
 Breaking the Compatibility
@@ -52,7 +52,7 @@ The following list shows an example of what we can do to reduce the cost (*Note:
 .. note::
 
    Since Chainer v2, we have stopped adopting any solid processes to break backward compatibilities (e.g. a solid schedule for deprecating and removing a feature) in order to keep the development fast enough to support the cutting-edge research.
-   **It does not mean we stop taking care of mantenability of user codes.**
+   **It does not mean we stop taking care of maintenability of user codes.**
    We are still paying much attention to not breaking user codes.
 
 

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -1,3 +1,5 @@
+.. _compatibility:
+
 API Compatibility Policy
 ========================
 

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -26,7 +26,7 @@ Versioning and Backward Compatibility
 The versioning of Chainer follows the `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_ and a part of `Semantic versioning <http://semver.org/>`_.
 See :ref:`contrib` for details of versioning.
 
-The backward compatibility is kept for **revision updates**, which are applied to the latest stable version.
+The backward compatibility is kept for **revision updates**, which are applied to the stable version.
 A **major update** from the latest release candidate basically keeps the backward compatibility, although it is not guaranteed.
 Any **pre-releases** may break the backward compatibility.
 

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -3,8 +3,8 @@
 API Compatibility Policy
 ========================
 
-This document expresses the design policy on compatibilities of Chainer APIs.
-Development team should obey this policy on deciding to add, extend, and change APIs and their behaviors.
+This document explains the design policy on compatibilities of Chainer APIs.
+Development team should follow this policy on deciding to add, extend, and change APIs and their behaviors.
 
 This document is written for both users and developers.
 Users can decide the level of dependencies on Chainer’s implementations in their codes based on this document.
@@ -15,59 +15,45 @@ Note that this document may contain ambiguities on the level of supported compat
 Targeted Versions
 -----------------
 
-This policy is applied to Chainer of versions v1.5.1 and higher.
+**This policy is applied to Chainer v2.0.0 and higher.**
 Note that this policy is not applied to Chainer of lower versions.
+For older versions of Chainer, see `the old version of API Compatiblity Policy <http://docs.chainer.org/en/v1.24.0/compatibility.html>`_.
 
 
-Versioning and Backward Compatibilities
----------------------------------------
+Versioning and Backward Compatibility
+-------------------------------------
 
-The updates of Chainer are classified into three levels: major, minor, and revision.
-These types have distinct levels of backward compatibilities.
+The versioning of Chainer follows the `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_ and a part of `Semantic versioning <http://semver.org/>`_.
+See :ref:`contrib` for details of versioning.
 
-- **Major update** contains disruptive changes that break the backward compatibility.
-- **Minor update** contains addition and extension to the APIs keeping the supported backward compatibility.
-- **Revision update** contains improvements on the API implementations without changing any API specifications.
-
-Note that we do not support full backward compatibility, which is almost infeasible for Python-based APIs, since there is no way to completely hide the implementation details.
+The backward compatibility is kept for **revision updates**, which are applied to the latest stable version.
+A **major update** from the latest release candidate basically keeps the backward compatibility, although it is not guaranteed.
+Any **pre-releases** may break the bakward compatibility.
 
 
-Processes to Break Backward Compatibilities
--------------------------------------------
+Breaking the Compatibility
+--------------------------
 
-Deprecation, Dropping, and Its Preparation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We sometimes need to break the backward compatibility to improve the framework design and to support new kinds of machine learning methods.
+Such a change is only made into pre-releases (alpha, beta, and release candidate) and sometimes into the major update.
 
-Any APIs may be *deprecated* at some minor updates.
-In such a case, the deprecation note is added to the API documentation, and the API implementation is changed to fire deprecation warning (if possible).
-There should be another way to reimplement the same things previously written with the deprecated APIs.
+A change that breaks the compatibility affects user codes.
+We try to lower the cost of adapting your code to the newer version.
+The following list shows an example of what we can do to reduce the cost (*Note: this is not a promise; what kind of actions we can take depends on the situation*).
 
-Any APIs may be marked as *to be dropped in the future*.
-In such a case, the dropping is stated in the documentation with the major version number on which the API is planned to be dropped, and the API implementation is changed to fire the future warning (if possible).
+- When an argument is removed from an existing API, passing the argument to the updated API will emit an error with a special error message.
+  The error message tells you how to fix your code.
+- When a function or a class is removed, we make the current stable version emit a deprecation warning.
+  **Note that the deprecation warning is not printed by default in Python.**
+  You have to manually turn on the deprecation warning by ``warnings.simplefilter('always', DeprecationWarning)``.
+- When a definition of a link is changed, we try to enable it to deserialize a model dumped with an older version of Chainer.
+  In most cases, we cannot guarantee that a model serialized with a newer version of Chainer is loadable by an older version of Chainer.
 
-The actual dropping should be done through the following steps:
+.. note::
 
-- Make the API deprecated.
-  At this point, users should not need the deprecated API in their new application codes.
-- After that, mark the API as *to be dropped in the future*.
-  It must be done in the minor update different from that of the deprecation.
-- At the major version announced in the above update, drop the API.
-
-Consequently, it takes at least two minor versions to drop any APIs after the first deprecation.
-
-API Changes and Its Preparation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Any APIs may be marked as *to be changed in the future* for changes without backward compatibility.
-In such a case, the change is stated in the documentation with the version number on which the API is planned to be changed, and the API implementation is changed to fire the future warning on the certain usages.
-
-The actual change should be done in the following steps:
-
-- Announce that the API will be changed in the future.
-  At this point, the actual version of change need not be accurate.
-- After the announcement, mark the API as *to be changed in the future* with version number of planned changes.
-  At this point, users should not use the marked API in their new application codes.
-- At the major update announced in the above update, change the API.
+   Since Chainer v2, we have stopped adopting any solid processes to break backward compatibilities (e.g. a solid schedule for deprecating and removing a feature) in order to keep the development fast enough to support the cutting-edge research.
+   **It does not mean we stop taking care of mantenability of user codes.**
+   We are still paying much attention to not breaking user codes.
 
 
 .. module:: chainer.utils
@@ -78,27 +64,25 @@ Experimental APIs
 Thanks to many contributors, we have introduced many new features to Chainer.
 
 However, we have sometimes released new features only to later notice that their APIs are not appropriate.
-The objective of experimental APIs is to avoid such issues by allowing the developer to mark any newly added API as experimental.
+In particular, we sometimes know that the API is likely to be modified in the near future because we do not have enough knowledge about how well the current design fits to the real usages.
+**The objective of experimental APIs is to declare that the APIs are likely to be updated in the near future so that users can decide if they can(not) use them.**
 
 Any newly added API can be marked as *experimental*.
 Any API that is not experimental is called *stable* in this document.
 
 .. note::
-    Undocumented behaviors are not considered as APIs. So they are not experimental nor stable.
-    The treatment of undocumented behaviors are described in :ref:`undocumented_behavior` section.
 
-Chainer can change the interfaces and documents of experimental APIs at **any** version up.
-This change is not considered as a break of backward compatibility.
-Chainer can promote an experimental API to become stable at any **minor** or **major** version up.
-Once experimental APIs become stable, they cannot revert to experimental again.
+    Undocumented behaviors are not considered as APIs, so they can be changed at any time (even in a revision update).
+    The treatment of undocumented behaviors are described in :ref:`undocumented_behavior` section.
 
 When users use experimental APIs for the first time, warnings are raised once for each experimental API,
 unless users explicitly disable the emission of the warnings in advance.
 
-See the document of :meth:`chainer.utils.experimental` how developers mark APIs as experimental
+See the document of :meth:`chainer.utils.experimental` to know how developers mark APIs as experimental
 and how users enable or disable the warnings practically.
 
 .. note::
+
    It is up to developers if APIs should be annotated as experimental or not.
    We recommend to make the APIs experimental if they implement large modules or
    make a decision from several design choices.
@@ -107,7 +91,7 @@ and how users enable or disable the warnings practically.
 Supported Backward Compatibility
 --------------------------------
 
-This section defines backward compatibilities that minor updates must maintain.
+This section defines backward compatibilities that revision updates must maintain.
 
 Documented Interface
 ~~~~~~~~~~~~~~~~~~~~
@@ -115,10 +99,16 @@ Documented Interface
 Chainer has the official API documentation.
 Many applications can be written based on the documented features.
 We support backward compatibilities of documented features.
-In other words, codes only based on the documented features run correctly with minor/revision-updated versions.
+In other words, codes only based on the documented features run correctly with revision-updated versions.
 
 Developers are encouraged to use apparent names for objects of implementation details.
 For example, attributes outside of the documented APIs should have one or more underscores at the prefix of their names.
+
+.. note::
+
+   Although it is not stated as a rule, we also try to keep the compatibility for any interface that looks like a stable feature.
+   For example, if the name of a symbol (function, class, method, attribute, etc.) is not prefixed by an underscore and the API is not experimental,
+   the API should be kept over revision updates even if it is not documented.
 
 .. _undocumented_behavior:
 
@@ -126,78 +116,70 @@ Undocumented behaviors
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Behaviors of Chainer implementation not stated in the documentation are undefined.
-Undocumented behaviors are not guaranteed to be stable between different minor/revision versions.
+Undocumented behaviors are not guaranteed to be stable between different revision versions.
 
-Minor update may contain changes to undocumented behaviors.
-For example, suppose an API X is added at the minor update.
-In the previous version, attempts to use X cause AttributeError.
-This behavior is not stated in the documentation, so this is undefined.
-Thus, adding the API X in minor version is permissible.
-
-Revision update may also contain changes to undefined behaviors.
-Typical example is a bug fix.
+Even revision updates may contain changes to undefined behaviors.
+One of the typical examples is a bug fix.
 Another example is an improvement on implementation, which may change the internal object structures not shown in the documentation.
 As a consequence, **even revision updates do not support compatibility of pickling, unless the full layout of pickled objects is clearly documented.**
 
 Documentation Error
 ~~~~~~~~~~~~~~~~~~~
 
-Compatibility is basically determined based on the documentation, though it sometimes contains errors.
+Compatibility is basically determined based on the documentation, although it sometimes contains errors.
 It may make the APIs confusing to assume the documentation always stronger than the implementations.
 We therefore may fix the documentation errors in any updates that may break the compatibility in regard to the documentation.
 
 .. note::
-   Developers MUST NOT fix the documentation and implementation of the same functionality at the same time in revision updates as "bug fix".
-   Such a change completely breaks the backward compatibility.
-   If you want to fix the bugs in both sides, first fix the documentation to fit it into the implementation, and start the API changing procedure described above.
+
+   Developers should not fix the documentation and implementation of the same functionality at the same time in revision updates as a "bug fix"
+   unless the bug is so critical that no users are expected to be using the old version correctly.
 
 Object Attributes and Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Object attributes and properties are sometimes replaced by each other at minor updates.
+Object attributes and properties are sometimes replaced by each other.
 It does not break the user codes, except the codes depend on how the attributes and properties are implemented.
 
 Functions and Methods
 ~~~~~~~~~~~~~~~~~~~~~
 
-Methods may be replaced by callable attributes keeping the compatibility of parameters and return values in minor updates.
+Methods may be replaced by callable attributes keeping the compatibility of parameters and return values.
 It does not break the user codes, except the codes depend on how the methods and callable attributes are implemented.
 
 Exceptions and Warnings
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The specifications of raising exceptions are considered as a part of standard backward compatibilities.
-No exception is raised in the future versions with correct usages that the documentation allows, unless the API changing process is completed.
+No exception is raised in the future revision versions with correct usages that the documentation allows.
 
-On the other hand, warnings may be added at any minor updates for any APIs.
-It means minor updates do not keep backward compatibility of warnings.
+On the other hand, warnings may be added at any revision updates for any APIs.
+It means revision updates do not keep backward compatibility of warnings.
 
 Model Format Compatibility
 --------------------------
 
-Objects serialized by official serializers that Chainer provides are correctly loaded with the higher (future) versions.
+Links and chains serialized by official serializers that Chainer provides are correctly loaded with the future versions.
 They might not be correctly loaded with Chainer of the lower versions.
 
 .. note::
-   Current serialization APIs do not support versioning (at least in v1.6.1).
+
+   Current serialization APIs do not support versioning.
    It prevents us from introducing changes in the layout of objects that support serialization.
-   We are discussing about introducing versioning in serialization APIs.
+   We are discussing versioning in serialization APIs.
 
 Installation Compatibility
 --------------------------
 
 The installation process is another concern of compatibilities.
-We support environmental compatibilities in the following ways.
 
-- Any changes of dependent libraries that force modifications on the existing environments must be done in major updates.
-  Such changes include following cases:
+Any changes on the set of dependent libraries that force modifications on the existing environments should be done in pre-releases and major updates.
+Such changes include following cases:
 
-  - dropping supported versions of dependent libraries (e.g. dropping cuDNN v2)
-  - adding new mandatory dependencies (e.g. adding h5py to setup_requires)
-
-- Supporting optional packages/libraries may be done in minor updates (e.g. supporting h5py in optional features).
+- dropping supported versions of dependent libraries (e.g. dropping cuDNN v2)
+- adding new mandatory dependencies (e.g. adding h5py to setup_requires)
 
 .. note::
-   The installation compatibility does not guarantee that all the features of Chainer correctly run on supported environments.
-   It may contain bugs that only occurs in certain environments.
-   Such bugs should be fixed in some updates.
+
+   We sometimes have to narrow the supported versions due to bugs in the specific versions of libraries.
+   In such a case, we may drop the support of those versions even in revision updates unless a workaround is found for the issue.

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -1,9 +1,14 @@
-Chainer Contribution Guide
-==========================
+Contribution Guide
+==================
 
 This is a guide for all contributions to Chainer.
 The development of Chainer is running on `the official repository at GitHub <https://github.com/pfnet/chainer>`_.
 Anyone that wants to register an issue or to send a pull request should read through this document.
+
+.. note::
+
+   Many points of this document are updated at v2.
+   We strongly recommend all contributors of v1 to read through the document again.
 
 Classification of Contributions
 -------------------------------
@@ -12,37 +17,113 @@ There are several ways to contribute to Chainer community:
 
 1. Registering an issue
 2. Sending a pull request (PR)
-3. Sending a question to `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_
+3. Sending a question/reply to `StackOverflow <https://stackoverflow.com/>`_ (with ``chainer`` tag) or `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_
 4. Open-sourcing an external example
 5. Writing a post about Chainer
 
 This document mainly focuses on 1 and 2, though other contributions are also appreciated.
 
-Release and Milestone
----------------------
 
-We are using `GitHub Flow <http://scottchacon.com/2011/08/31/github-flow.html>`_ as our basic working process.
-In particular, we are using the master branch for our development, and releases are made as tags.
+Development Cycle
+-----------------
 
-Releases are classified into three groups: major, minor, and revision.
-This classification is based on following criteria:
+This section explains the development process of Chainer.
+Before contributing to Chainer, it is strongly recommended to understand the development cycle.
 
-- **Major update** contains disruptive changes that break the backward compatibility.
-- **Minor update** contains additions and extensions to the APIs keeping the supported backward compatibility.
-- **Revision update** contains improvements on the API implementations without changing any API specification.
+Versioning
+~~~~~~~~~~
 
-The release classification is reflected into the version number x.y.z, where x, y, and z corresponds to major, minor, and revision updates, respectively.
+The versioning of Chainer follows `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_ and a part of `Semantic versioning <http://semver.org/>`_.
+The version number consists of three or four parts: ``X.Y.Zw`` where ``X`` denotes the **major version**, ``Y`` denotes the **minor version**, ``Z`` denotes the **revision number**, and the optional ``w`` denotes the prelease suffix.
+While the major, minor, and revision numbers follow the rule of semantic versioning, the pre-release suffix follows PEP 440 so that the version string is much friendly with Python eco-system.
 
-We set a milestone for an upcoming release.
-The milestone is of name 'vX.Y.Z', where the version number represents a revision release at the outset.
-If at least one *feature* PR is merged in the period, we rename the milestone to represent a minor release (see the next section for the PR types).
+**Note that a major update basically does not contain compatibility-breaking changes from the last release candidate (RC).**
+This is not a strict rule, though; if there is a critical API bug that we have to fix for the major version, we may add breaking changes to the major version up.
 
-See also :doc:`compatibility`.
+As for the backward compatibility, see :ref:`compatibility`.
 
-Issues and PRs
---------------
 
-Issues and PRs are classified into following categories:
+.. _contrib-release-cycle:
+
+Release Cycle
+~~~~~~~~~~~~~
+
+Starting from v2.0.0, we are developing two tracks of versions at the same time.
+The first one is the track of **stable versions**, which is a series of revision updates for the latest major version.
+The second one is the track of **development versions**, which is a series of pre-releases for the upcoming major version.
+
+Consider that ``X.0.0`` is the latest major version and ``Y.0.0``, ``Z.0.0`` are the succeeding major versions.
+Then, the timeline of the updates is depicted by the following table.
+
+========== =========== =========== ============
+   Date       ver X       ver Y       ver Z
+========== =========== =========== ============
+  0 weeks    X.0.0rc1    --         --
+  4 weeks    X.0.0       Y.0.0a1    --
+  8 weeks    X.0.1       Y.0.0b1    --
+ 12 weeks    X.0.2       Y.0.0rc1   --
+ 16 weeks    --          Y.0.0      Z.0.0a1
+========== =========== =========== ============
+
+The dates shown in the left-most column are relative to the release of ``X.0.0rc1``.
+In particular, each revision release is made four weeks after the previous one of the same major version, and the pre-release of the upcoming major version is made at the same time.
+
+Note that the development of ``X.0.x`` stops at ``X.0.2``.
+During the parallel development of ``Y.0.0`` and ``Z.0.0a1``, the version ``Y`` is treated as an **almost-stable version** and ``Z`` is treated as a development version.
+
+If there is a critical bug found in ``X.0.2`` after stopping the development of version ``X``, we may release a hot-fix for this version at any time.
+
+.. note::
+
+   The release cycle of ``2.0.x`` and ``3.0.0x`` are slightly different from this table because we do not have ``3.0.0a1`` at the timing of the release of ``2.0.0``.
+   In this case, the releases of ``3.0.0x`` are shifted four weeks behind the usual timeline, that is, ``3.0.0a1`` will be released at the same time with ``2.0.1``.
+
+As you can see in the above table, we basically do not have any minor releases from v2.
+All changes that add and/or modify APIs should be made by the pre-release updates.
+
+We create a milestone for each upcoming release at GitHub.
+The GitHub milestone is basically used for collecting the issues and PRs resolved in the release.
+
+.. _contrib-git-branches:
+
+Git Branches
+~~~~~~~~~~~~
+
+There are two main branches: ``master`` and ``dev``.
+
+The ``master`` branch is used to develop stable versions.
+It means that **major updates and revision updates are developed at the** ``master`` **branch**.
+
+The ``dev`` branch is used to develop pre-release versions.
+It means that **alpha, beta, and RC updates are developed at the** ``dev`` **branch**.
+
+After we release the RC of the next major version, we create a *maintenance branch* for the current stable version.
+The maintenance branch is named as ``vX`` (e.g. the maintenance branch for v2 is ``v2``).
+
+**Notes for contributors:**
+When you send a pull request, you have to choose an appropriate branch.
+You basically only have to consider the ``master`` and ``dev`` branches.
+The following simple rule is enough to know the appropriate branch to send a pull request:
+
+- If the change does not add nor modify APIs and it can be applied to the stable version, choose the ``master`` branch.
+- Otherwise, choose the ``dev`` branch.
+
+For example, a change to fix a bug of the stable version should basically be sent to the ``master`` branch.
+A change to fix a bug caused by newly-introduced APIs in the development version should be sent to the ``dev`` branch.
+A change to introduce a new function/class, add a new argument to an existing function, and/or modify the existing arguments of a function should be sent to the ``dev`` branch.
+
+*Note: a change that can be applied to both branches should be sent to the* ``master`` *branch.*
+*Each release of the stable version is also merged to the development version so that the change is also reflected to the next major version.*
+
+Issues and Pull Requests
+------------------------
+
+In this section, we explain how to file issues and send pull requests (PRs).
+
+Issue/PR Labels
+~~~~~~~~~~~~~~~
+
+Issues and PRs are labeled by the following tags:
 
 * **Bug**: bug reports (issues) and bug fixes (PRs)
 * **Enhancement**: implementation improvements without breaking the interface
@@ -55,54 +136,71 @@ Issues and PRs are classified into following categories:
 * **Contribution-Welcome**: issues that we request for contribution (only issues are categorized to this)
 * **Other**: other issues and PRs
 
-Issues and PRs are labeled by these categories.
-This classification is often reflected into its corresponding release category: Feature issues/PRs are contained into minor/major releases and NoCompat issues/PRs are contained into major releases, while other issues/PRs can be contained into any releases including revision ones.
+Multiple tags might be labeled to one issue/PR.
+**Note that revision releases cannot include PRs in Feature and NoCompat categories.**
 
-On registering an issue, write precise explanations on what you want Chainer to be.
+How to File an Issue
+~~~~~~~~~~~~~~~~~~~~
+
+On registering an issue, write precise explanations on how you want Chainer to be.
 Bug reports must include necessary and sufficient conditions to reproduce the bugs.
-Feature requests must include **what** you want to do (and **why** you want to do, if needed).
+Feature requests must include **what** you want to do (and **why** you want to do, if needed) with Chainer.
 You can contain your thoughts on **how** to realize it into the feature requests, though **what** part is most important for discussions.
 
 .. warning::
 
-   If you have a question on usages of Chainer, it is highly recommended to send a post to `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_ instead of the issue tracker.
+   If you have a question on usages of Chainer, it is highly recommended to send a post to `StackOverflow <https://stackoverflow.com/>`_ or `Chainer User Group <https://groups.google.com/forum/#!forum/chainer>`_ instead of the issue tracker.
    The issue tracker is not a place to share knowledge on practices.
-   We may redirect question issues to Chainer User Group.
+   We may suggest these places and immediately close how-to question issues.
 
-If you can write code to fix an issue, send a PR to the master branch.
-Before writing your code for PRs, read through the :ref:`coding-guide`.
-The description of any PR must contain a precise explanation of **what** and **how** you want to do; it is the first documentation of your code for developers, a very important part of your PR.
+How to Send a Pull Request
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you can write code to fix an issue, we encourage to send a PR.
+
+First of all, before starting to write any code, do not forget to confirm the following points.
+
+- Read through the :ref:`coding-guide` and :ref:`testing-guide`.
+- Check the appropriate branch that you should send the PR following :ref:`contrib-git-branches`.
+
+In particular, **check the branch before writing any code.**
+The current source tree of the chosen branch is the starting point of your change.
+
+After writing your code **(including unit tests and hopefully documentations!)**, send a PR on GitHub.
+You have to write a precise explanation of **what** and **how** you fix;
+it is the first documentation of your code that developers read, which is a very important part of your PR.
 
 Once you send a PR, it is automatically tested on `Travis CI <https://travis-ci.org/pfnet/chainer/>`_ for Linux and Mac OS X, and on `AppVeyor <https://ci.appveyor.com/project/pfnet/chainer>`_ for Windows.
-Your PR need to pass at least the test for Linux on Travis CI.
+Your PR needs to pass at least the test for Linux on Travis CI.
 After the automatic test passes, some of the core developers will start reviewing your code.
 Note that this automatic PR test only includes CPU tests.
 
 .. note::
 
-   We are also running continuous integration with GPU tests for the master branch.
-   Since this service is running on our internal server, we do not use it for automatic PR tests to keep the server secure.
+   We are also running continuous integration with GPU tests for the ``master`` and ``dev`` branches.
+   Since this service is currently running on our internal server, we do not use it for automatic PR tests to keep the server secure.
 
+If you are planning to add a new feature or modify existing APIs, **it is recommended to open an issue and discuss the design first.**
+The design discussion needs lower cost for the core developers than code review.
+Following the consequences of the discussions, you can send a PR that is smoothly reviewed in a shorter time.
 
 Even if your code is not complete, you can send a pull request as a *work-in-progress PR* by putting the ``[WIP]`` prefix to the PR title.
 If you write a precise explanation about the PR, core developers and other contributors can join the discussion about how to proceed the PR.
+WIP PR is also useful to have discussions based on a concrete code.
+
 
 .. _coding-guide:
 
 Coding Guidelines
 -----------------
 
-We use `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ and a part of `OpenStack Style Guidelines <http://docs.openstack.org/developer/hacking/>`_ related to general coding style as our basic style guidelines.
+We use `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ and a part of `OpenStack Style Guidelines <http://docs.openstack.org/developer/hacking/>`_ related to general coding style as our basic style guidelines.
 
 To check your code, use ``autopep8`` and ``flake8`` command installed by ``hacking`` package::
 
   $ pip install autopep8 hacking
   $ autopep8 --global-config .pep8 path/to/your/code.py
   $ flake8 path/to/your/code.py
-
-To check Cython code, use ``.flake8.cython`` configuration file::
-
-  $ flake8 --config=.flake8.cython path/to/your/cython/code.pyx
 
 The ``autopep8`` supports automatically correct Python code to conform to the PEP 8 style guide::
 
@@ -122,13 +220,15 @@ Here is a (not-complete) list of the rules that ``flake8`` cannot check.
 In addition, we restrict the usage of *shortcut symbols* in our code base.
 They are symbols imported by packages and sub-packages of ``chainer``.
 For example, ``chainer.Variable`` is a shortcut of ``chainer.variable.Variable``.
-**It is not allowed to use such shortcuts in the ``chainer`` library implementation**.
+**It is not allowed to use such shortcuts in the ``chainer`` library implementation.**
 Note that you can still use them in ``tests`` and ``examples`` directories.
 Also note that you should use shortcut names of CuPy APIs in Chainer implementation.
 
 Once you send a pull request, your coding style is automatically checked by `Travis-CI <https://travis-ci.org/pfnet/chainer/>`_.
 The reviewing process starts after the check passes.
 
+
+.. _testing-guide:
 
 Testing Guidelines
 ------------------
@@ -139,13 +239,20 @@ Note that we are using the nose package and the mock package for testing, so ins
 
   $ pip install nose mock
 
-In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
+How to Run Tests
+~~~~~~~~~~~~~~~~
 
-  $ python setup.py develop
-
-Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
+You can run unit tests simply by running ``nosetests`` command at the repository root::
 
   $ nosetests
+
+or specify the test script that you want to run::
+
+  $ nosetests path/to/your/test.py
+
+You can also run all unit tests under a specified directory::
+
+  $ nosetests tests/chainer_tests/<directory name>
 
 It requires CUDA by default.
 In order to run unit tests that do not require CUDA, pass ``--attr='!gpu'`` option to the ``nosetests`` command::
@@ -163,24 +270,25 @@ If you want to skip such tests, pass ``--attr='!slow'`` option to the ``nosetest
 
   $ nosetests path/to/your/test.py --attr='!slow'
 
+If you modify the code related to existing unit tests, you must run appropriate commands and confirm that the tests pass.
+
+Test File and Directory Naming Conventions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Tests are put into the ``tests/chainer_tests`` directory.
 In order to enable test runner to find test scripts correctly, we are using special naming convention for the test subdirectories and the test scripts.
 
 * The name of each subdirectory of ``tests`` must end with the ``_tests`` suffix.
 * The name of each test script must start with the ``test_`` prefix.
 
-Following this naming convention, you can run all the tests by just typing ``nosetests`` at the repository root::
+When we write a test for a module, we use the appropriate path and file name for the test script whose correspondence to the tested module is clear.
+For example, if you want to write a test for a module ``chainer.x.y.z``, the test script must be located at ``tests/chainer_tests/x_tests/y_tests/test_z.py``.
 
-  $ nosetests
+How to Write Tests
+~~~~~~~~~~~~~~~~~~
 
-Or you can also specify a root directory to search test scripts from::
-
-  $ nosetests tests/chainer_tests  # to just run tests of Chainer
-
-If you modify the code related to existing unit tests, you must run appropriate commands.
-
-There are many examples of unit tests under the ``tests`` directory.
-They simply use the ``unittest`` package of the standard library.
+There are many examples of unit tests under the ``tests`` directory, so reading some of them is a good and recommended way to learn how to write tests for Chainer.
+They simply use the ``unittest`` package of the standard library, while some tests are using utilities from :mod:`chainer.testing`.
 
 Even if your patch includes GPU-related code, your tests should not fail without GPU capability.
 Test functions that require CUDA must be tagged by ``chainer.testing.attr.gpu`` decorator::
@@ -235,4 +343,4 @@ Note that reviewers will test your code without the option to check CUDA-related
 
 .. note::
    Some of numerically unstable tests might cause errors irrelevant to your changes.
-   In such a case, we ignore the failures and go on to the review process, so do not worry about it.
+   In such a case, we ignore the failures and go on to the review process, so do not worry about it!

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -1,3 +1,5 @@
+.. _contrib:
+
 Contribution Guide
 ==================
 


### PR DESCRIPTION
This change updates API Compatibility Policy for v2. Since it includes a link to some sections of the updated contribution guide, this PR depends on #2773. Please merge #2773 before this one.