### PR TITLE
Check h5py version when serializing None

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -50,7 +50,7 @@ class HDF5Serializer(serializer.Serializer):
         if value is None:
             # use Empty to represent None
             if h5py.version.version_tuple < (2, 7, 0):
-                raise NotImplementedError(
+                raise RuntimeError(
                     'h5py>=2.7.0 is required to serialize None.')
             arr = h5py.Empty('f')
             compression = None

--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -49,6 +49,9 @@ class HDF5Serializer(serializer.Serializer):
             value = cuda.to_cpu(value)
         if value is None:
             # use Empty to represent None
+            if h5py.version.version_tuple < (2, 7, 0):
+                raise NotImplementedError(
+                    'h5py>=2.7.0 is required to serialize None.')
             arr = h5py.Empty('f')
             compression = None
         else:

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -82,6 +82,8 @@ class TestHDF5Serializer(unittest.TestCase):
 
         self.assertIs(ret, 10)
 
+    @unittest.skipUnless(h5py.version.version_tuple >= (2, 7, 0),
+                         'h5py>=2.7.0 is not available')
     def test_serialize_none(self):
         ret = self.serializer('x', None)
         self.assertIs(ret, None)
@@ -104,7 +106,9 @@ class TestHDF5Deserializer(unittest.TestCase):
             f.require_group('x')
             f.create_dataset('y', data=self.data)
             f.create_dataset('z', data=numpy.asarray(10))
-            f.create_dataset('w', data=h5py.Empty('f'))
+            # h5py.Empty is introduced from 2.7.0
+            if h5py.version.version_tuple >= (2, 7, 0):
+                f.create_dataset('w', data=h5py.Empty('f'))
 
         self.hdf5file = h5py.File(path, 'r')
         self.deserializer = hdf5.HDF5Deserializer(self.hdf5file)
@@ -166,10 +170,14 @@ class TestHDF5Deserializer(unittest.TestCase):
         finally:
             os.remove(path)
 
+    @unittest.skipUnless(h5py.version.version_tuple >= (2, 7, 0),
+                         'h5py>=2.7.0 is not available')
     def test_deserialize_none(self):
         ret = self.deserializer('w', None)
         self.assertIs(ret, None)
 
+    @unittest.skipUnless(h5py.version.version_tuple >= (2, 7, 0),
+                         'h5py>=2.7.0 is not available')
     def test_deserialize_none_by_passing_array(self):
         y = numpy.empty((1,))
         ret = self.deserializer('w', y)

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -399,4 +399,28 @@ class TestNoH5py(unittest.TestCase):
             chainer.serializers.HDF5Deserializer(None)
 
 
+@unittest.skipUnless(hdf5._available, 'h5py is not available')
+class Test5pyEmptyNotAvailable(unittest.TestCase):
+
+    def setUp(self):
+        # Set h5py.version.version_tuple to emulate situation that h5py is
+        # so old that it doesn't have h5py.Empty.
+        self.original_version_tuple = h5py.version.version_tuple
+        h5py.version.version_tuple = (2, 6, 0)
+
+        # Prepare serializer
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.temp_file_path = path
+        self.hdf5file = h5py.File(path, 'w')
+        self.serializer = hdf5.HDF5Serializer(self.hdf5file, compression=3)
+
+    def tearDown(self):
+        h5py.version.version_tuple = self.original_version_tuple
+
+    def test_raise1(self):
+        with self.assertRaises(RuntimeError):
+            self.serializer('x', None)
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
`h5py.Empty` is introduced from `h5py==2.7.0`.
